### PR TITLE
Fix TypeError passing datetime.date to scoreboard_generate

### DIFF
--- a/src/linescore.py
+++ b/src/linescore.py
@@ -327,7 +327,7 @@ def main(date_str=None):
 
         # this is for the 15 minute refresh no mater what refresh the data
         if games_scheduled_data.get('games_in_progress') > 0 or game_data:
-            scoreboard_generate(target_date, game_data)
+            scoreboard_generate(str(target_date), game_data)
         
     
     else:


### PR DESCRIPTION
target_date was a datetime.date object but scoreboard_generate expects a string, causing a TypeError in PIL's draw.text().