### PR TITLE
Use full epd.init() instead of init_fast() after deep sleep

### DIFF
--- a/src/display_eink.py
+++ b/src/display_eink.py
@@ -51,7 +51,7 @@ def display_image(image_to_display, output_filename='resulting_image.bmp'):
         epd = epd7in5_V2.EPD()
 
         logging.info("init and Clear")
-        epd.init_fast()
+        epd.init()
         # epd.Clear()
 
         logging.info("Drawing on the Horizontal image...")


### PR DESCRIPTION
init_fast() skips critical hardware setup (power settings, booster, panel config, voltage levels) needed after the display enters deep sleep. Replacing with init() ensures the display fully reinitializes each cycle.