### PR TITLE
Hide team record for post-game states

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -577,7 +577,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data):
                 header = 'R     H     E'
                 draw.text((start_x + 68, start_y + 3), header, font=font14, fill=0)
                 draw.text((start_x + 69, start_y + 3), header, font=font14, fill=0)
-    else:
+    elif game_data['detailed_state'] in ['Scheduled', 'Pre-Game', 'Warmup']:
         # Game hasn't started - show team records
         draw.text((start_x + 89, start_y + 31), f'{game_data.get("away_team_record_wins", "0")} - {game_data.get("away_team_record_losses", "0")}', font=font14, fill=0)
         draw.text((start_x + 89, start_y + 61), f'{game_data.get("home_team_record_wins", "0")} - {game_data.get("home_team_record_losses", "0")}', font=font14, fill=0)


### PR DESCRIPTION
Only show team records (wins-losses) for pre-game states (Scheduled, Pre-Game, Warmup). Any post-game status (Game Over, Final, Completed, Completed Early, etc.) no longer displays the team record in the game box.