### PR TITLE
Add team emoji mapping support with auto-download from Twemoji CDN

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,3 +41,15 @@ night_end: 7     # 7am
 # Falls back to text abbreviation when a logo file is missing
 use_team_logos: true
 
+# Team emoji overrides: display emoji instead of logo for these teams
+team_emojis:
+  BOS: "💩"
+  # NYM: "💰"
+  # SD: "🇺🇸"
+  WSH: "🍉"
+  # LAA: "😂"
+  # WSH: "🐾"
+  # CWS: "🏎️"
+  # PIT: "👨‍🚀"
+  # COL: "🌊"
+

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -10,6 +10,10 @@ from collections import OrderedDict
 
 _logo_cache = {}        # (abbr, team_id) -> grayscale PIL Image or None
 _logo_invert_config = None  # loaded once from pic/logo_render_config.json
+_emoji_cache = {}       # abbr -> grayscale PIL Image or None
+_team_emojis = None     # loaded once from config.yaml
+
+emojidir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'pic', 'emojis')
 
 
 def _get_logo_invert_config():
@@ -22,6 +26,87 @@ def _get_logo_invert_config():
         except Exception:
             _logo_invert_config = {}
     return _logo_invert_config
+
+def _get_team_emojis():
+    """Load team_emojis mapping from config.yaml, cached per process."""
+    global _team_emojis
+    if _team_emojis is None:
+        _team_emojis = load_yaml_file('config.yaml').get('team_emojis', {}) or {}
+    return _team_emojis
+
+
+def _emoji_codepoint(char):
+    """Convert an emoji character to its Twemoji hex filename (e.g. 💩 -> 1f4a9).
+
+    Strips variation selectors (U+FE0F) so compound emojis resolve correctly.
+    """
+    codepoints = [f'{ord(c):x}' for c in char if ord(c) != 0xfe0f]
+    return '-'.join(codepoints)
+
+
+def _try_download_emoji(emoji_char):
+    """Download an emoji PNG from the Twemoji CDN (via jsDelivr). Returns True on success."""
+    try:
+        import urllib.request
+        codepoint = _emoji_codepoint(emoji_char)
+        os.makedirs(emojidir, exist_ok=True)
+        path = os.path.join(emojidir, f'{codepoint}.png')
+        url = f'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/{codepoint}.png'
+        with urllib.request.urlopen(url, timeout=5) as response:
+            with open(path, 'wb') as f:
+                f.write(response.read())
+        print(f'Auto-downloaded emoji: {emoji_char} ({codepoint})')
+        return True
+    except Exception as e:
+        print(f'Could not auto-download emoji {emoji_char}: {e}')
+        return False
+
+
+def _load_emoji_gray(abbr):
+    """If abbr has an emoji mapping, load its PNG and return a grayscale Image, else None."""
+    if abbr in _emoji_cache:
+        return _emoji_cache[abbr]
+
+    emojis = _get_team_emojis()
+    emoji_char = emojis.get(abbr)
+    if not emoji_char:
+        _emoji_cache[abbr] = None
+        return None
+
+    codepoint = _emoji_codepoint(emoji_char)
+    path = os.path.join(emojidir, f'{codepoint}.png')
+    if not os.path.exists(path):
+        _try_download_emoji(emoji_char)
+
+    result = None
+    if os.path.exists(path):
+        try:
+            from PIL import ImageStat
+            img = Image.open(path).convert('RGBA')
+            # Detect predominantly white/bright emojis and invert so they
+            # don't vanish against the white e-ink background.
+            alpha_mask = img.split()[3].point(lambda p: 255 if p > 32 else 0)
+            avg_brightness = ImageStat.Stat(img.convert('L'), mask=alpha_mask).mean[0]
+            if avg_brightness > 180:
+                r, g, b, a = img.split()
+                r = r.point(lambda p: 255 - p)
+                g = g.point(lambda p: 255 - p)
+                b = b.point(lambda p: 255 - p)
+                img = Image.merge('RGBA', (r, g, b, a))
+            bg = Image.new('RGBA', img.size, (255, 255, 255, 255))
+            bg.paste(img, mask=img.split()[3])
+            result = bg.convert('L')
+            # Sharpen edges (eyes, mouth) so they survive aggressive
+            # thumbnail + contrast dithering in _logo_small / _logo_ghost.
+            from PIL import ImageFilter
+            result = ImageOps.autocontrast(result, cutoff=1)
+            result = result.filter(ImageFilter.UnsharpMask(radius=2, percent=250, threshold=0))
+        except Exception:
+            pass
+
+    _emoji_cache[abbr] = result
+    return result
+
 
 standings_dict = {
     1: 'American League East',
@@ -496,6 +581,10 @@ def _load_logo_gray(abbr, team_id):
     every machine renders logos identically. Falls back to brightness detection for
     any team not in the config. Results are cached in _logo_cache per process.
     """
+    emoji_img = _load_emoji_gray(abbr)
+    if emoji_img is not None:
+        return emoji_img
+
     cache_key = (abbr, str(team_id))
     if cache_key in _logo_cache:
         return _logo_cache[cache_key]
@@ -563,6 +652,7 @@ def _logo_small(abbr, team_id, size=28):
     gray = _load_logo_gray(abbr, team_id)
     if gray is None:
         return None
+    gray = gray.copy()
     gray.thumbnail((size, size), Image.LANCZOS)
     # Normalize histogram so inherently dark logos (like BAL/MIL) get lifted
     # to a visible range before dithering, preserving internal detail.
@@ -582,6 +672,7 @@ def _logo_ghost(abbr, team_id, size=110):
     gray = _load_logo_gray(abbr, team_id)
     if gray is None:
         return None
+    gray = gray.copy()
     gray.thumbnail((size, size), Image.LANCZOS)
     # Lift dark pixels moderately so ~30-35% survive as black dots
     gray = gray.point(lambda p: 255 if p > 180 else min(255, int(p * 0.3 + 160)))

--- a/src/test_emoji.py
+++ b/src/test_emoji.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Test emoji mapping functionality end-to-end.
+Run from project root: poetry run python src/test_emoji.py
+"""
+
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+from PIL import Image
+from datetime import date
+import generate_image as gi
+
+passed = 0
+failed = 0
+
+def check(name, condition, detail=""):
+    global passed, failed
+    if condition:
+        passed += 1
+        print(f"  PASS  {name}")
+    else:
+        failed += 1
+        print(f"  FAIL  {name}  {detail}")
+
+# ── Test 1: _emoji_codepoint ────────────────────────────────────
+print("\n[1] _emoji_codepoint")
+check("poop -> 1f4a9", gi._emoji_codepoint("\U0001f4a9") == "1f4a9",
+      f"got {gi._emoji_codepoint(chr(0x1f4a9))!r}")
+check("baseball -> 26be", gi._emoji_codepoint("\u26be") == "26be",
+      f"got {gi._emoji_codepoint(chr(0x26be))!r}")
+check("flag US -> 1f1fa-1f1f8", gi._emoji_codepoint("\U0001f1fa\U0001f1f8") == "1f1fa-1f1f8",
+      f"got {gi._emoji_codepoint(chr(0x1f1fa)+chr(0x1f1f8))!r}")
+
+# ── Test 2: _try_download_emoji ─────────────────────────────────
+print("\n[2] _try_download_emoji (downloads poop emoji)")
+ok = gi._try_download_emoji("\U0001f4a9")
+check("download succeeded", ok)
+dl_path = os.path.join(gi.emojidir, "1f4a9.png")
+check("file exists on disk", os.path.exists(dl_path))
+if os.path.exists(dl_path):
+    check("file is non-empty", os.path.getsize(dl_path) > 100,
+          f"size={os.path.getsize(dl_path)}")
+
+# ── Test 3: _load_emoji_gray with injected mapping ─────────────
+print("\n[3] _load_emoji_gray (inject BOS -> poop)")
+# Clear caches so our injection takes effect
+gi._emoji_cache.clear()
+gi._team_emojis = {"BOS": "\U0001f4a9"}
+
+img = gi._load_emoji_gray("BOS")
+check("returns an Image", img is not None)
+if img is not None:
+    check("mode is grayscale L", img.mode == "L", f"got {img.mode}")
+    check("size is reasonable", img.size[0] > 10 and img.size[1] > 10,
+          f"got {img.size}")
+
+no_img = gi._load_emoji_gray("NYY")
+check("unmapped team returns None", no_img is None)
+
+# ── Test 4: _load_logo_gray returns emoji when mapped ──────────
+print("\n[4] _load_logo_gray returns emoji for mapped team")
+gi._emoji_cache.clear()
+gi._team_emojis = {"BOS": "\U0001f4a9"}
+logo = gi._load_logo_gray("BOS", "111")
+check("_load_logo_gray returns image for mapped team", logo is not None)
+if logo is not None:
+    check("returned image is grayscale", logo.mode == "L")
+
+# ── Test 5: Generate a full scoreboard with emoji mapping ──────
+print("\n[5] Full scoreboard render with BOS mapped to poop emoji")
+gi._emoji_cache.clear()
+gi._team_emojis = {"BOS": "\U0001f4a9", "LAD": "\u26be"}
+
+# Reuse the test_scoreboard matchup approach
+MATCHUPS = [
+    ('NYY', 'BOS', 7, 3),
+    ('TB',  'TOR', 2, 5),
+    ('BAL', 'CWS', 10, 1),
+    ('CLE', 'DET', 3, 6),
+    ('KC',  'MIN', 8, 2),
+    ('HOU', 'TEX', 4, 7),
+    ('LAA', 'ATH', 1, 9),
+    ('SEA', 'NYM', 6, 3),
+    ('PHI', 'ATL', 2, 5),
+    ('MIA', 'WSH', 7, 0),
+    ('CHC', 'MIL', 4, 3),
+    ('STL', 'PIT', 9, 2),
+    ('CIN', 'LAD', 1, 4),
+    ('SF',  'SD',  6, 5),
+    ('COL', 'AZ',  3, 8),
+]
+all_teams = sorted({t for m in MATCHUPS for t in (m[0], m[1])})
+_id = {t: str(i + 1) for i, t in enumerate(all_teams)}
+team_data = {'team_abbreviation': {v: k for k, v in _id.items()}}
+
+WP = ['Smith'] * 15
+LP = ['Jones'] * 15
+
+games = []
+for g, (away, home, asc, hsc) in enumerate(MATCHUPS):
+    games.append({
+        'game_pk': g + 2000,
+        'away_team_id': _id[away],
+        'home_team_id': _id[home],
+        'detailed_state': 'Final',
+        'away_runs': asc, 'home_runs': hsc,
+        'away_hits': asc + 3, 'home_hits': hsc + 2,
+        'away_errors': 0, 'home_errors': 0,
+        'away_team_is_winner': asc > hsc,
+        'home_team_is_winner': hsc > asc,
+        'winner_name': WP[g], 'loser_name': LP[g],
+        'current_inning': 9,
+        'game_start': '7:05 PM',
+        'away_probable': None, 'home_probable': None,
+        'away_team_record_wins': '50', 'away_team_record_losses': '40',
+        'home_team_record_wins': '45', 'home_team_record_losses': '45',
+        'perfect_game': False, 'no_hitter': False,
+        'save_situation': False, 'last_play': None,
+    })
+
+canvas = Image.new('1', (800, 480), 255)
+result_img = gi.draw_out_of_town_score_board(
+    canvas, games, team_data, str(date.today()),
+    changed_game_ids=None, use_logos=True,
+)
+
+out_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+out_path = os.path.join(out_dir, 'test_emoji_scoreboard.png')
+result_img.save(out_path)
+check("scoreboard image saved", os.path.exists(out_path))
+check("image is non-trivial size", os.path.getsize(out_path) > 500,
+      f"size={os.path.getsize(out_path)}")
+print(f"  -> saved to {out_path}")
+
+# ── Summary ─────────────────────────────────────────────────────
+print(f"\n{'='*50}")
+print(f"Results: {passed} passed, {failed} failed out of {passed+failed} checks")
+if failed:
+    sys.exit(1)
+else:
+    print("All checks passed!")


### PR DESCRIPTION
Allow mapping teams to emoji characters in config.yaml (e.g. BOS: "💩") that render on the e-ink display instead of logos. Emojis are auto-downloaded from the Twemoji CDN and cached in pic/emojis/. Priority: emoji > logo > text.

Also fixes a pre-existing bug where thumbnail() mutated cached logo images in-place, causing ghost watermarks to render at wrong sizes on subsequent calls.