### PR TITLE
Fix scoreboard partial refresh for all in-game state changes

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1048,6 +1048,23 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None):
 
     save_off_results(game_state_data, "old_scoreboard_state")
 
+    # Build map of old game data by game_pk for per-game comparison
+    old_by_pk = {}
+    if old_data and isinstance(old_data, list):
+        for g in old_data:
+            pk = str(g.get('game_pk', ''))
+            if pk:
+                old_by_pk[pk] = g
+
+    # Track all games with ANY data change (for partial refresh regions)
+    refreshed_game_ids = set()
+    for game in game_state_data:
+        pk = str(game.get('game_pk', ''))
+        if not pk:
+            continue
+        if old_by_pk.get(pk) != game:
+            refreshed_game_ids.add(pk)
+
     # --- Score change detection ---
     old_scores = load_json_file('score_alerts.json')
     new_scores = {}
@@ -1086,7 +1103,7 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None):
         if i >= 15:  # 5x3 grid max
             break
         pk = str(game.get('game_pk', ''))
-        if pk in changed_game_ids:
+        if pk in refreshed_game_ids:
             col = i % 5
             row = i // 5
             # Align x to 8-pixel boundary


### PR DESCRIPTION
## Summary

- Partial refresh previously only triggered on score (run) changes; outs, strikes, runners, and inning changes all caused a full display refresh
- Adds `refreshed_game_ids` set that tracks games with **any** data change by comparing current game dicts against saved old state
- Partial refresh regions are now computed from `refreshed_game_ids` instead of `changed_game_ids`
- `changed_game_ids` is preserved as-is for the visual score-change highlight in `draw_box()`

## Test plan

- [ ] Run `python scoreboard_generate.py` during a live game
- [ ] Confirm log shows `"Scoreboard: partial refresh (N region(s))"` for outs/runners/inning changes
- [ ] Confirm `"Scoreboard: full refresh"` only appears once per hour (forced) or on first run
- [ ] Confirm score-change visual highlight in `draw_box` still works
- [ ] On Pi: visually verify only the affected game cell(s) update without full-screen flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)