### PR TITLE
Normalize 'Completed Early' game state to 'Final' in scoreboard display

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -710,6 +710,11 @@ def _logo_ghost(abbr, team_id, size=110):
 
 
 def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False):
+    # Normalize early-completion states (e.g. spring training games called after 6 innings)
+    if game_data.get('detailed_state', '').startswith('Completed Early'):
+        game_data = dict(game_data)
+        game_data['detailed_state'] = 'Final'
+
     draw = ImageDraw.Draw(Himage)
     font26 = ImageFont.truetype(os.path.join(picdir, 'Font.ttc'), 26)
     font24 = ImageFont.truetype(os.path.join(picdir, 'Font.ttc'), 24)


### PR DESCRIPTION
Spring training (and other shortened) games end with detailedState 'Completed Early' from the MLB API, which previously fell through to the else branch in draw_box and displayed 'BOT 6' instead of 'Final/6'.