### PR TITLE
Add field view, scorecard view, and pitch location display

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,10 +2,11 @@
 # scoreboard: true = 15 game grid, false = 2 detailed linescores + standings
 scoreboard: true
 
-# Display mode: "scoreboard" | "linescore" | "field" | "scorecard"
+# Display mode: "scoreboard" | "linescore" | "field" | "scorecard" | "pitch"
 # If set, overrides the scoreboard: true/false flag above.
-# "field" = single-game field diagram with hit location + game info
-# "scorecard" = official scorer-style scorecard for both teams
+# "field"     = single-game field diagram with runners, hit location, strike zone overlay
+# "scorecard" = official scorer-style per-batter at-bat grid for both teams
+# "pitch"     = full strike zone with pitch locations for current at-bat
 # display_mode: "scoreboard"
 primary: NYY
 primary_backup: BOS

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,12 @@
 # MLB Display Configuration
 # scoreboard: true = 15 game grid, false = 2 detailed linescores + standings
 scoreboard: true
+
+# Display mode: "scoreboard" | "linescore" | "field" | "scorecard"
+# If set, overrides the scoreboard: true/false flag above.
+# "field" = single-game field diagram with hit location + game info
+# "scorecard" = official scorer-style scorecard for both teams
+# display_mode: "scoreboard"
 primary: NYY
 primary_backup: BOS
 primary_backup_2: NYM

--- a/src/field_view.py
+++ b/src/field_view.py
@@ -1,0 +1,447 @@
+import os
+import math
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+from generate_image import (
+    picdir, _logo_small, _load_logo_gray, draw_diamond, draw_circle,
+)
+
+EPD_WIDTH = 800
+EPD_HEIGHT = 480
+
+# Field geometry constants
+HOME_PLATE = (200, 420)
+FIRST_BASE = (275, 355)
+SECOND_BASE = (200, 290)
+THIRD_BASE = (125, 355)
+MOUND = (200, 348)
+FENCE_RADIUS = 260
+FENCE_CENTER = HOME_PLATE
+
+
+def _load_fonts():
+    font_path = os.path.join(picdir, 'Font.ttc')
+    return {
+        'f24': ImageFont.truetype(font_path, 24),
+        'f18': ImageFont.truetype(font_path, 18),
+        'f14': ImageFont.truetype(font_path, 14),
+        'f11': ImageFont.truetype(font_path, 11),
+    }
+
+
+def _draw_field(draw, data):
+    """Draw the baseball field diagram on the left half (0-399)."""
+    hx, hy = HOME_PLATE
+
+    # Foul lines: extend the home→base direction vector out to fence radius
+    def _foul_end(base):
+        dx, dy = base[0] - hx, base[1] - hy
+        mag = math.sqrt(dx * dx + dy * dy)
+        return hx + FENCE_RADIUS * dx / mag, hy + FENCE_RADIUS * dy / mag
+
+    lf_x, lf_y = _foul_end(THIRD_BASE)
+    rf_x, rf_y = _foul_end(FIRST_BASE)
+
+    # Outfield fence arc
+    arc_bbox = [
+        hx - FENCE_RADIUS, hy - FENCE_RADIUS,
+        hx + FENCE_RADIUS, hy + FENCE_RADIUS,
+    ]
+    # Arc from right field foul line to left field foul line
+    # PIL arc angles: 0=3 o'clock, 90=6 o'clock, etc.
+    # We need the arc from ~225 degrees to ~315 degrees
+    draw.arc(arc_bbox, 225, 315, fill=0, width=2)
+
+    # Foul lines
+    draw.line([HOME_PLATE, (int(lf_x), int(lf_y))], fill=0, width=1)
+    draw.line([HOME_PLATE, (int(rf_x), int(rf_y))], fill=0, width=1)
+
+    # Base paths (infield diamond)
+    draw.line([HOME_PLATE, FIRST_BASE], fill=0, width=1)
+    draw.line([FIRST_BASE, SECOND_BASE], fill=0, width=1)
+    draw.line([SECOND_BASE, THIRD_BASE], fill=0, width=1)
+    draw.line([THIRD_BASE, HOME_PLATE], fill=0, width=1)
+
+    # Home plate (small pentagon)
+    hp_size = 5
+    draw.polygon([
+        (hx, hy + hp_size),
+        (hx - hp_size, hy),
+        (hx - hp_size + 2, hy - hp_size),
+        (hx + hp_size - 2, hy - hp_size),
+        (hx + hp_size, hy),
+    ], outline=0)
+
+    # Pitcher's mound
+    draw.ellipse([MOUND[0] - 4, MOUND[1] - 4, MOUND[0] + 4, MOUND[1] + 4], outline=0)
+
+    # Bases (empty squares, will be filled if occupied)
+    base_size = 6
+    for bx, by in [FIRST_BASE, SECOND_BASE, THIRD_BASE]:
+        draw.polygon([
+            (bx, by - base_size), (bx + base_size, by),
+            (bx, by + base_size), (bx - base_size, by),
+        ], outline=0)
+
+
+def _draw_runners(draw, data):
+    """Fill in occupied bases."""
+    base_size = 6
+    bases = [
+        (data.get('runner_first'), FIRST_BASE),
+        (data.get('runner_second'), SECOND_BASE),
+        (data.get('runner_third'), THIRD_BASE),
+    ]
+    for occupied, (bx, by) in bases:
+        if occupied:
+            draw.polygon([
+                (bx, by - base_size), (bx + base_size, by),
+                (bx, by + base_size), (bx - base_size, by),
+            ], fill=0, outline=0)
+
+
+def _transform_hit_coords(api_x, api_y):
+    """Transform API hit coordinates to pixel space.
+    API: home plate ~(125, 200), X right, Y decreases toward outfield
+    Pixel: home plate (200, 420)
+    """
+    px = 200 + (api_x - 125) * 1.5
+    py = 420 - (200 - api_y) * 1.5
+    # Clamp to field region
+    px = max(5, min(395, px))
+    py = max(5, min(475, py))
+    return int(px), int(py)
+
+
+def _draw_hit_marker(draw, data):
+    """Draw hit location marker on the field."""
+    hit = data.get('hit_coords')
+    if not hit:
+        return
+    px, py = _transform_hit_coords(hit[0], hit[1])
+    r = 5
+    draw.ellipse([px - r, py - r, px + r, py + r], fill=0)
+    # Crosshair
+    draw.line([px - r - 2, py, px + r + 2, py], fill=0)
+    draw.line([px, py - r - 2, px, py + r + 2], fill=0)
+
+
+def _draw_score_header(img, draw, fonts, data):
+    """Draw score panel at top of right half (400-799, y 5-75)."""
+    x_base = 410
+    y = 8
+
+    away_abbr = data.get('away_abbr', '')
+    home_abbr = data.get('home_abbr', '')
+    away_id = str(data.get('away_id', ''))
+    home_id = str(data.get('home_id', ''))
+
+    # Away team line
+    logo = _logo_small(away_abbr, away_id)
+    lx = x_base
+    if logo:
+        img.paste(logo, (lx, y + 2))
+        lx += 30
+    draw.text((lx, y), away_abbr, font=fonts['f18'], fill=0)
+    draw.text((lx + 55, y), str(data.get('away_runs', 0)), font=fonts['f24'], fill=0)
+
+    # Home team line
+    y2 = y + 32
+    logo = _logo_small(home_abbr, home_id)
+    lx = x_base
+    if logo:
+        img.paste(logo, (lx, y2 + 2))
+        lx += 30
+    draw.text((lx, y2), home_abbr, font=fonts['f18'], fill=0)
+    draw.text((lx + 55, y2), str(data.get('home_runs', 0)), font=fonts['f24'], fill=0)
+
+    # R/H/E labels
+    rhe_x = lx + 100
+    draw.text((rhe_x, y - 2), 'R', font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 25, y - 2), 'H', font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 50, y - 2), 'E', font=fonts['f11'], fill=0)
+
+    draw.text((rhe_x, y + 14), str(data.get('away_runs', 0)), font=fonts['f14'], fill=0)
+    draw.text((rhe_x + 25, y + 14), str(data.get('away_hits', 0)), font=fonts['f14'], fill=0)
+    draw.text((rhe_x + 50, y + 14), str(data.get('away_errors', 0)), font=fonts['f14'], fill=0)
+
+    draw.text((rhe_x, y + 14 + 32), str(data.get('home_runs', 0)), font=fonts['f14'], fill=0)
+    draw.text((rhe_x + 25, y + 14 + 32), str(data.get('home_hits', 0)), font=fonts['f14'], fill=0)
+    draw.text((rhe_x + 50, y + 14 + 32), str(data.get('home_errors', 0)), font=fonts['f14'], fill=0)
+
+
+def _draw_inning_state(img, draw, fonts, data):
+    """Draw inning, count, outs, and mini bases (y 80-140)."""
+    x_base = 410
+    y = 82
+
+    state = data.get('detailed_state', '')
+    if state in ('Final', 'Game Over', 'Final: Tied'):
+        draw.text((x_base, y), 'FINAL', font=fonts['f18'], fill=0)
+    elif state in ('Scheduled', 'Pre-Game', 'Warmup'):
+        draw.text((x_base, y), state, font=fonts['f18'], fill=0)
+    else:
+        inning_text = f"{data.get('inning_state', '')} {data.get('inning_ordinal', '')}"
+        draw.text((x_base, y), inning_text, font=fonts['f18'], fill=0)
+
+        # Count
+        count_text = f"{data.get('balls', 0)}-{data.get('strikes', 0)}"
+        draw.text((x_base + 160, y), count_text, font=fonts['f18'], fill=0)
+
+        # Outs circles
+        outs = data.get('outs', 0)
+        ox = x_base + 230
+        oy = y + 10
+        for i in range(3):
+            cx = ox + i * 18
+            filled = i < outs
+            if filled:
+                draw.ellipse([cx - 5, oy - 5, cx + 5, oy + 5], fill=0, outline=0)
+            else:
+                draw.ellipse([cx - 5, oy - 5, cx + 5, oy + 5], outline=0)
+
+    # Mini diamond for bases
+    mini_x = x_base + 320
+    mini_y = y + 10
+    sz = 8
+    bases_pts = [
+        (data.get('runner_first'), (mini_x + sz, mini_y)),
+        (data.get('runner_second'), (mini_x, mini_y - sz)),
+        (data.get('runner_third'), (mini_x - sz, mini_y)),
+    ]
+    for occupied, (bx, by) in bases_pts:
+        pts = [(bx, by - sz // 2), (bx + sz // 2, by), (bx, by + sz // 2), (bx - sz // 2, by)]
+        if occupied:
+            draw.polygon(pts, fill=0, outline=0)
+        else:
+            draw.polygon(pts, outline=0)
+
+
+def _draw_matchup(draw, fonts, data):
+    """Draw batter/pitcher info (y 145-225)."""
+    x_base = 410
+    y = 148
+
+    state = data.get('detailed_state', '')
+    if state in ('Scheduled', 'Pre-Game', 'Warmup'):
+        # Pre-game: show probable pitchers
+        draw.text((x_base, y), 'Probable Pitchers:', font=fonts['f14'], fill=0)
+        away = data.get('away_abbr', '')
+        home = data.get('home_abbr', '')
+        draw.text((x_base, y + 18), f"{away}: {data.get('away_probable', 'TBD')}", font=fonts['f14'], fill=0)
+        draw.text((x_base, y + 36), f"{home}: {data.get('home_probable', 'TBD')}", font=fonts['f14'], fill=0)
+        return
+
+    if state in ('Final', 'Game Over', 'Final: Tied'):
+        # Show WP/LP
+        draw.text((x_base, y), f"WP: {data.get('winner', '')}", font=fonts['f14'], fill=0)
+        draw.text((x_base, y + 18), f"LP: {data.get('loser', '')}", font=fonts['f14'], fill=0)
+        if data.get('save'):
+            draw.text((x_base, y + 36), f"SV: {data.get('save', '')}", font=fonts['f14'], fill=0)
+        return
+
+    # In progress: batter and pitcher
+    batter = data.get('batter', {})
+    pitcher = data.get('pitcher', {})
+
+    batter_name = batter.get('name', '')
+    pitcher_name = pitcher.get('name', '')
+
+    draw.text((x_base, y), 'AB:', font=fonts['f11'], fill=0)
+    draw.text((x_base + 22, y), batter_name, font=fonts['f14'], fill=0)
+
+    # Batter season stats
+    b_season = batter.get('season', {})
+    avg = b_season.get('avg', '')
+    hr = b_season.get('homeRuns', '')
+    rbi = b_season.get('rbi', '')
+    if avg:
+        draw.text((x_base + 22, y + 18), f"AVG {avg}  HR {hr}  RBI {rbi}", font=fonts['f11'], fill=0)
+
+    draw.text((x_base, y + 38), 'P:', font=fonts['f11'], fill=0)
+    draw.text((x_base + 16, y + 38), pitcher_name, font=fonts['f14'], fill=0)
+
+    # Pitcher game stats
+    p_stats = pitcher.get('stats', {})
+    ip = p_stats.get('inningsPitched', '')
+    k = p_stats.get('strikeOuts', '')
+    p_season = pitcher.get('season', {})
+    era = p_season.get('era', '')
+    if era:
+        draw.text((x_base + 16, y + 56), f"ERA {era}  IP {ip}  K {k}", font=fonts['f11'], fill=0)
+
+
+def _draw_strike_zone(draw, fonts, data):
+    """Draw pitch locations for the current at-bat in the upper-left corner (x=5-125, y=5-130)."""
+    pitches = data.get('pitches', [])
+    if not pitches:
+        return
+
+    # Display area (upper-left, clear of the field diagram)
+    ax, ay, aw, ah = 5, 5, 120, 125
+
+    # Coordinate ranges: pX in feet from plate center, pZ in feet off ground
+    px_min, px_max = -1.5, 1.5
+    pz_min, pz_max = 1.0, 4.5
+
+    def to_px(px, pz):
+        x = ax + int((px - px_min) / (px_max - px_min) * aw)
+        y = ay + ah - int((pz - pz_min) / (pz_max - pz_min) * ah)
+        return x, y
+
+    # Strike zone rectangle (plate ±0.708 ft wide, typical zone 1.5–3.5 ft)
+    zl, zt = to_px(-0.708, 3.5)
+    zr, zb = to_px(0.708, 1.5)
+    draw.rectangle([zl, zt, zr, zb], outline=0)
+
+    # Nine-zone grid lines inside the zone
+    third_w = (zr - zl) // 3
+    third_h = (zb - zt) // 3
+    draw.line([zl + third_w, zt, zl + third_w, zb], fill=0)
+    draw.line([zl + 2 * third_w, zt, zl + 2 * third_w, zb], fill=0)
+    draw.line([zl, zt + third_h, zr, zt + third_h], fill=0)
+    draw.line([zl, zt + 2 * third_h, zr, zt + 2 * third_h], fill=0)
+
+    # Plot pitches
+    r = 4
+    for pitch in pitches:
+        px, pz = pitch.get('px'), pitch.get('pz')
+        if px is None or pz is None:
+            continue
+        bx, by = to_px(px, pz)
+        code = pitch.get('code', '')
+        if code in ('S', 'C', 'T'):       # Strike (swinging, called, foul tip)
+            draw.ellipse([bx - r, by - r, bx + r, by + r], fill=0, outline=0)
+        elif code == 'F':                  # Foul — open with crossbar
+            draw.ellipse([bx - r, by - r, bx + r, by + r], outline=0)
+            draw.line([bx - r, by, bx + r, by], fill=0)
+        elif code == 'X':                  # In play — filled square
+            draw.rectangle([bx - r, by - r, bx + r, by + r], fill=0)
+        else:                              # Ball — open circle
+            draw.ellipse([bx - r, by - r, bx + r, by + r], outline=0)
+
+    # Count label below the zone area
+    balls = data.get('balls', 0)
+    strikes = data.get('strikes', 0)
+    draw.text((ax, ay + ah + 4), f'{balls}-{strikes}', font=fonts['f11'], fill=0)
+
+
+def _word_wrap(text, font, max_width):
+    """Simple word wrap. Returns list of lines."""
+    words = text.split()
+    lines = []
+    current = ''
+    for word in words:
+        test = f"{current} {word}".strip()
+        try:
+            w = font.getlength(test)
+        except AttributeError:
+            w = len(test) * 8
+        if w > max_width and current:
+            lines.append(current)
+            current = word
+        else:
+            current = test
+    if current:
+        lines.append(current)
+    return lines
+
+
+def _draw_last_play(draw, fonts, data):
+    """Draw last play description, word-wrapped (y 230-320)."""
+    x_base = 410
+    y = 232
+
+    last_play = data.get('last_play', '')
+    if not last_play:
+        return
+
+    draw.text((x_base, y), 'Last Play:', font=fonts['f11'], fill=0)
+    lines = _word_wrap(last_play, fonts['f14'], 370)
+    for i, line in enumerate(lines[:4]):
+        draw.text((x_base, y + 14 + i * 18), line, font=fonts['f14'], fill=0)
+
+
+def _draw_mini_linescore(draw, fonts, data):
+    """Draw mini linescore table (y 325-475)."""
+    x_base = 410
+    y = 330
+
+    innings = data.get('innings', [])
+    if not innings:
+        return
+
+    away_abbr = data.get('away_abbr', '')
+    home_abbr = data.get('home_abbr', '')
+
+    # Determine how many innings to show (cap at what fits)
+    max_inn = min(len(innings), 12)
+    col_w = 26
+    label_w = 40
+
+    # Header row
+    draw.text((x_base, y), '', font=fonts['f11'], fill=0)
+    for i in range(max_inn):
+        ix = x_base + label_w + i * col_w
+        draw.text((ix, y), str(innings[i]['num']), font=fonts['f11'], fill=0)
+
+    # R H E headers
+    rhe_x = x_base + label_w + max_inn * col_w + 5
+    draw.text((rhe_x, y), 'R', font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 20, y), 'H', font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 40, y), 'E', font=fonts['f11'], fill=0)
+
+    # Away row
+    ay = y + 16
+    draw.text((x_base, ay), away_abbr, font=fonts['f11'], fill=0)
+    for i in range(max_inn):
+        ix = x_base + label_w + i * col_w
+        val = innings[i].get('away_runs')
+        draw.text((ix, ay), str(val if val is not None else ''), font=fonts['f11'], fill=0)
+    draw.text((rhe_x, ay), str(data.get('away_runs', 0)), font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 20, ay), str(data.get('away_hits', 0)), font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 40, ay), str(data.get('away_errors', 0)), font=fonts['f11'], fill=0)
+
+    # Home row
+    hy = ay + 16
+    draw.text((x_base, hy), home_abbr, font=fonts['f11'], fill=0)
+    for i in range(max_inn):
+        ix = x_base + label_w + i * col_w
+        val = innings[i].get('home_runs')
+        draw.text((ix, hy), str(val if val is not None else ''), font=fonts['f11'], fill=0)
+    draw.text((rhe_x, hy), str(data.get('home_runs', 0)), font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 20, hy), str(data.get('home_hits', 0)), font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 40, hy), str(data.get('home_errors', 0)), font=fonts['f11'], fill=0)
+
+    # Venue
+    venue = data.get('venue', '')
+    if venue:
+        draw.text((x_base, hy + 22), venue, font=fonts['f11'], fill=0)
+
+
+def render_field_view(data, dark_mode=False):
+    """Render the field view display. Returns an 800x480 1-bit PIL Image."""
+    img = Image.new('1', (EPD_WIDTH, EPD_HEIGHT), 255)
+    draw = ImageDraw.Draw(img)
+    fonts = _load_fonts()
+
+    # Vertical divider
+    draw.line([(400, 0), (400, EPD_HEIGHT)], fill=0, width=2)
+
+    # Left half: baseball field
+    _draw_field(draw, data)
+    _draw_runners(draw, data)
+    _draw_hit_marker(draw, data)
+    _draw_strike_zone(draw, fonts, data)
+
+    # Right half: game info
+    _draw_score_header(img, draw, fonts, data)
+    _draw_inning_state(img, draw, fonts, data)
+    _draw_matchup(draw, fonts, data)
+    _draw_last_play(draw, fonts, data)
+    _draw_mini_linescore(draw, fonts, data)
+
+    if dark_mode:
+        img = ImageOps.invert(img.convert('L')).convert('1')
+
+    return img

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -49,6 +49,80 @@ def fetch_live_feed(game_pk):
     return resp.json()
 
 
+def _extract_pitches_detailed(plays):
+    """Extract pitch data with velocity and pitch type from current or last at-bat."""
+    sources = [plays.get('currentPlay', {})]
+    all_plays = plays.get('allPlays', [])
+    if all_plays:
+        sources.append(all_plays[-1])
+
+    for play in sources:
+        pitches = []
+        seq = 0
+        for event in play.get('playEvents', []):
+            if not event.get('isPitch'):
+                continue
+            seq += 1
+            pitch_data = event.get('pitchData', {})
+            coords = pitch_data.get('coordinates', {})
+            px = coords.get('pX')
+            pz = coords.get('pZ')
+            if px is None or pz is None:
+                continue
+            details = event.get('details', {})
+            pitches.append({
+                'seq': seq,
+                'px': px,
+                'pz': pz,
+                'code': details.get('type', {}).get('code', ''),
+                'pitch_type': details.get('type', {}).get('description', ''),
+                'description': details.get('description', ''),
+                'is_strike': details.get('isStrike', False),
+                'is_ball': details.get('isBall', False),
+                'speed': pitch_data.get('startSpeed'),
+            })
+        if pitches:
+            return pitches
+    return []
+
+
+def fetch_pitch_view_data(game_pk):
+    """Extract pitch view data from the live feed."""
+    data = fetch_live_feed(game_pk)
+    game_data = data.get('gameData', {})
+    live_data = data.get('liveData', {})
+    plays = live_data.get('plays', {})
+    linescore = live_data.get('linescore', {})
+    boxscore = live_data.get('boxscore', {})
+
+    status = game_data.get('status', {})
+    teams = game_data.get('teams', {})
+    away_team = teams.get('away', {})
+    home_team = teams.get('home', {})
+
+    offense = linescore.get('offense', {})
+    batter_id = offense.get('batter', {}).get('id')
+    pitcher_id = linescore.get('defense', {}).get('pitcher', {}).get('id')
+
+    return {
+        'detailed_state': status.get('detailedState', ''),
+        'away_abbr': away_team.get('abbreviation', ''),
+        'home_abbr': home_team.get('abbreviation', ''),
+        'away_id': away_team.get('id', 0),
+        'home_id': home_team.get('id', 0),
+        'away_runs': linescore.get('teams', {}).get('away', {}).get('runs', 0),
+        'home_runs': linescore.get('teams', {}).get('home', {}).get('runs', 0),
+        'inning_ordinal': linescore.get('currentInningOrdinal', ''),
+        'inning_state': linescore.get('inningState', ''),
+        'balls': linescore.get('balls', 0) or 0,
+        'strikes': linescore.get('strikes', 0) or 0,
+        'outs': linescore.get('outs', 0) or 0,
+        'batter': _get_player_info(boxscore, batter_id, 'batting'),
+        'pitcher': _get_player_info(boxscore, pitcher_id, 'pitching'),
+        'pitches': _extract_pitches_detailed(plays),
+    }
+
+
 def _extract_pitches(plays):
     """Extract pitch locations from the current at-bat, falling back to the last completed at-bat."""
     sources = [plays.get('currentPlay', {})]

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -1,0 +1,473 @@
+import requests
+
+
+def select_game(games, favorite_abbr, team_data):
+    """Pick a game to display: favorite team's game (prefer live > scheduled > final),
+    else first live game, else first game."""
+    abbr_map = team_data.get('team_abbreviation', {})
+    # Reverse map: abbr -> team_id strings
+    id_for_abbr = {}
+    for tid, ab in abbr_map.items():
+        id_for_abbr[ab] = tid
+
+    fav_ids = set()
+    if favorite_abbr:
+        fav_id = id_for_abbr.get(favorite_abbr)
+        if fav_id:
+            fav_ids.add(int(fav_id))
+
+    fav_games = []
+    live_games = []
+    for g in games:
+        is_fav = (g.get('away_team_id') in fav_ids or g.get('home_team_id') in fav_ids)
+        state = g.get('detailed_state', '')
+        is_live = state == 'In Progress'
+        is_scheduled = state in ('Scheduled', 'Pre-Game', 'Warmup')
+        is_final = state in ('Final', 'Game Over', 'Final: Tied', 'Completed Early')
+
+        if is_fav:
+            priority = 0 if is_live else (1 if is_scheduled else (2 if is_final else 3))
+            fav_games.append((priority, g))
+        if is_live:
+            live_games.append(g)
+
+    if fav_games:
+        fav_games.sort(key=lambda x: x[0])
+        return fav_games[0][1]
+    if live_games:
+        return live_games[0]
+    if games:
+        return games[0]
+    return None
+
+
+def fetch_live_feed(game_pk):
+    """Fetch the full live feed for a game."""
+    url = f'https://statsapi.mlb.com/api/v1.1/game/{game_pk}/feed/live'
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _extract_pitches(plays):
+    """Extract pitch locations from the current at-bat, falling back to the last completed at-bat."""
+    sources = [plays.get('currentPlay', {})]
+    all_plays = plays.get('allPlays', [])
+    if all_plays:
+        sources.append(all_plays[-1])
+
+    for play in sources:
+        pitches = []
+        for event in play.get('playEvents', []):
+            if not event.get('isPitch'):
+                continue
+            coords = event.get('pitchData', {}).get('coordinates', {})
+            px = coords.get('pX')
+            pz = coords.get('pZ')
+            if px is None or pz is None:
+                continue
+            details = event.get('details', {})
+            pitches.append({
+                'px': px,
+                'pz': pz,
+                'code': details.get('type', {}).get('code', ''),
+                'is_strike': details.get('isStrike', False),
+                'is_ball': details.get('isBall', False),
+            })
+        if pitches:
+            return pitches
+    return []
+
+
+def _extract_hit_coordinates(plays):
+    """Walk backward through allPlays to find most recent play with hitData coordinates."""
+    all_plays = plays.get('allPlays', [])
+    for play in reversed(all_plays):
+        hit_data = play.get('hitData', {})
+        cx = hit_data.get('coordinates', {}).get('coordX')
+        cy = hit_data.get('coordinates', {}).get('coordY')
+        if cx is not None and cy is not None:
+            return (cx, cy)
+        # Also check playEvents for hit data
+        for event in reversed(play.get('playEvents', [])):
+            hit_data = event.get('hitData', {})
+            cx = hit_data.get('coordinates', {}).get('coordX')
+            cy = hit_data.get('coordinates', {}).get('coordY')
+            if cx is not None and cy is not None:
+                return (cx, cy)
+    return None
+
+
+def fetch_field_view_data(game_pk):
+    """Extract field view data from the live feed."""
+    data = fetch_live_feed(game_pk)
+    game_data = data.get('gameData', {})
+    live_data = data.get('liveData', {})
+    plays = live_data.get('plays', {})
+    linescore = live_data.get('linescore', {})
+    boxscore = live_data.get('boxscore', {})
+
+    status = game_data.get('status', {})
+    detailed_state = status.get('detailedState', '')
+
+    # Teams
+    teams = game_data.get('teams', {})
+    away_team = teams.get('away', {})
+    home_team = teams.get('home', {})
+
+    # Score
+    away_runs = linescore.get('teams', {}).get('away', {}).get('runs', 0)
+    home_runs = linescore.get('teams', {}).get('home', {}).get('runs', 0)
+    away_hits = linescore.get('teams', {}).get('away', {}).get('hits', 0)
+    home_hits = linescore.get('teams', {}).get('home', {}).get('hits', 0)
+    away_errors = linescore.get('teams', {}).get('away', {}).get('errors', 0)
+    home_errors = linescore.get('teams', {}).get('home', {}).get('errors', 0)
+
+    # Inning state
+    current_inning = linescore.get('currentInning', 0)
+    inning_ordinal = linescore.get('currentInningOrdinal', '')
+    inning_state = linescore.get('inningState', '')  # Top/Bottom/Middle/End
+
+    # Count and outs
+    balls = linescore.get('balls', 0) or 0
+    strikes = linescore.get('strikes', 0) or 0
+    outs = linescore.get('outs', 0) or 0
+
+    # Runners
+    offense = linescore.get('offense', {})
+    runner_first = bool(offense.get('first'))
+    runner_second = bool(offense.get('second'))
+    runner_third = bool(offense.get('third'))
+
+    # Current batter/pitcher
+    batter_id = offense.get('batter', {}).get('id')
+    pitcher_id = linescore.get('defense', {}).get('pitcher', {}).get('id')
+
+    batter_info = _get_player_info(boxscore, batter_id, 'batting')
+    pitcher_info = _get_player_info(boxscore, pitcher_id, 'pitching')
+
+    # Pitch locations and hit coordinates
+    pitches = _extract_pitches(plays)
+    hit_coords = _extract_hit_coordinates(plays)
+
+    # Last play description
+    current_play = plays.get('currentPlay', {})
+    last_play_desc = current_play.get('result', {}).get('description', '')
+    if not last_play_desc:
+        all_plays = plays.get('allPlays', [])
+        if all_plays:
+            last_play_desc = all_plays[-1].get('result', {}).get('description', '')
+
+    # Linescore innings for mini table
+    innings_list = linescore.get('innings', [])
+    innings = []
+    for inn in innings_list:
+        innings.append({
+            'num': inn.get('num', 0),
+            'away_runs': inn.get('away', {}).get('runs'),
+            'home_runs': inn.get('home', {}).get('runs'),
+        })
+
+    # Decisions (WP/LP/SV)
+    decisions = live_data.get('decisions', {})
+    winner = decisions.get('winner', {}).get('fullName', '')
+    loser = decisions.get('loser', {}).get('fullName', '')
+    save = decisions.get('save', {}).get('fullName', '')
+
+    # Probable pitchers
+    away_probable = game_data.get('probablePitchers', {}).get('away', {}).get('fullName', '')
+    home_probable = game_data.get('probablePitchers', {}).get('home', {}).get('fullName', '')
+
+    # Game time
+    game_date = game_data.get('datetime', {}).get('dateTime', '')
+
+    # Venue
+    venue = game_data.get('venue', {}).get('name', '')
+
+    return {
+        'detailed_state': detailed_state,
+        'away_abbr': away_team.get('abbreviation', ''),
+        'home_abbr': home_team.get('abbreviation', ''),
+        'away_id': away_team.get('id', 0),
+        'home_id': home_team.get('id', 0),
+        'away_runs': away_runs,
+        'home_runs': home_runs,
+        'away_hits': away_hits,
+        'home_hits': home_hits,
+        'away_errors': away_errors,
+        'home_errors': home_errors,
+        'current_inning': current_inning,
+        'inning_ordinal': inning_ordinal,
+        'inning_state': inning_state,
+        'balls': balls,
+        'strikes': strikes,
+        'outs': outs,
+        'runner_first': runner_first,
+        'runner_second': runner_second,
+        'runner_third': runner_third,
+        'batter': batter_info,
+        'pitcher': pitcher_info,
+        'pitches': pitches,
+        'hit_coords': hit_coords,
+        'last_play': last_play_desc,
+        'innings': innings,
+        'winner': winner,
+        'loser': loser,
+        'save': save,
+        'away_probable': away_probable,
+        'home_probable': home_probable,
+        'game_date': game_date,
+        'venue': venue,
+    }
+
+
+def _get_player_info(boxscore, player_id, stat_type):
+    """Extract player name and stats from boxscore."""
+    if not player_id:
+        return {'name': '', 'stats': {}}
+    pid_str = f'ID{player_id}'
+    for side in ('away', 'home'):
+        players = boxscore.get('teams', {}).get(side, {}).get('players', {})
+        for key, pdata in players.items():
+            if key == pid_str or pdata.get('person', {}).get('id') == player_id:
+                name = pdata.get('person', {}).get('fullName', '')
+                stats = pdata.get('stats', {}).get(stat_type, {})
+                season = pdata.get('seasonStats', {}).get(stat_type, {})
+                return {
+                    'name': name,
+                    'stats': stats,
+                    'season': season,
+                }
+    return {'name': '', 'stats': {}, 'season': {}}
+
+
+# --- Scorecard Data ---
+
+_EVENT_CODE_MAP = {
+    'Strikeout': 'K',
+    'Strikeout Looking': 'Kl',
+    'Strikeout Double Play': 'K',
+    'Walk': 'BB',
+    'Intent Walk': 'IBB',
+    'Hit By Pitch': 'HBP',
+    'Single': '1B',
+    'Double': '2B',
+    'Triple': '3B',
+    'Home Run': 'HR',
+    'Groundout': 'GO',
+    'Flyout': 'FO',
+    'Lineout': 'LO',
+    'Pop Out': 'PO',
+    'Grounded Into DP': 'GDP',
+    'Double Play': 'DP',
+    'Triple Play': 'TP',
+    'Sac Fly': 'SF',
+    'Sac Bunt': 'SAC',
+    'Sacrifice Bunt DP': 'SAC',
+    'Fielders Choice': 'FC',
+    'Fielders Choice Out': 'FC',
+    'Field Error': 'E',
+    'Catcher Interf': 'CI',
+    'Batter Interference': 'BI',
+    'Runner Out': 'RO',
+    'Force Out': 'FO',
+    'Field Out': 'FO',
+}
+
+
+def _map_event_to_code(event):
+    """Map an API event string to a scorecard abbreviation."""
+    return _EVENT_CODE_MAP.get(event, event[:3] if event else '')
+
+
+def _build_lineup_at_bats(boxscore, plays, team_side):
+    """Build 9-slot lineup with per-inning at-bat results.
+
+    Returns list of dicts: {
+        'name': str, 'position': str, 'order': int,
+        'at_bats': {inning_num: [{'code': str, 'bases': int}, ...]},
+        'sub': bool,  # True if substitution
+        'totals': {'runs': int, 'hits': int}
+    }
+    """
+    team_box = boxscore.get('teams', {}).get(team_side, {})
+    batting_order = team_box.get('battingOrder', [])
+    players = team_box.get('players', {})
+    team_info = team_box.get('team', {})
+    team_id = team_info.get('id')
+
+    # Build player lookup
+    player_map = {}
+    for key, pdata in players.items():
+        pid = pdata.get('person', {}).get('id')
+        if pid:
+            player_map[pid] = pdata
+
+    # Initialize lineup slots (up to 9)
+    lineup = []
+    seen_orders = {}  # batting_order_slot -> lineup index
+
+    for pid in batting_order:
+        pdata = player_map.get(pid, {})
+        person = pdata.get('person', {})
+        name = person.get('fullName', '')
+        # Shorten to last name
+        parts = name.split()
+        last_name = parts[-1] if parts else name
+        position = pdata.get('position', {}).get('abbreviation', '')
+        bat_order = pdata.get('battingOrder', '')
+        order_slot = int(str(bat_order)[:1]) if bat_order else len(lineup) + 1
+
+        bat_stats = pdata.get('stats', {}).get('batting', {})
+
+        entry = {
+            'name': last_name,
+            'position': position,
+            'order': order_slot,
+            'player_id': pid,
+            'at_bats': {},
+            'sub': False,
+            'totals': {
+                'runs': bat_stats.get('runs', 0),
+                'hits': bat_stats.get('hits', 0),
+            }
+        }
+
+        if order_slot in seen_orders:
+            # Substitution — replace the player in that slot
+            idx = seen_orders[order_slot]
+            entry['sub'] = True
+            lineup[idx] = entry
+        else:
+            seen_orders[order_slot] = len(lineup)
+            lineup.append(entry)
+
+    # Build player_id -> lineup index mapping
+    pid_to_slot = {}
+    for i, entry in enumerate(lineup):
+        pid_to_slot[entry['player_id']] = i
+
+    # Walk through all plays to assign at-bats to lineup slots
+    all_plays = plays.get('allPlays', [])
+    for play in all_plays:
+        about = play.get('about', {})
+        inning = about.get('inning', 0)
+        half = about.get('halfInning', '')  # 'top' or 'bottom'
+
+        # Determine if this play belongs to our team
+        is_away = (half == 'top' and team_side == 'away')
+        is_home = (half == 'bottom' and team_side == 'home')
+        if not (is_away or is_home):
+            continue
+
+        batter_id = play.get('matchup', {}).get('batter', {}).get('id')
+        if batter_id is None:
+            continue
+
+        result = play.get('result', {})
+        event = result.get('event', '')
+        code = _map_event_to_code(event)
+        if not code:
+            continue
+
+        # Determine bases reached (0=out, 1=1B, 2=2B, 3=3B, 4=HR)
+        bases = 0
+        if event in ('Single',):
+            bases = 1
+        elif event in ('Double',):
+            bases = 2
+        elif event in ('Triple',):
+            bases = 3
+        elif event in ('Home Run',):
+            bases = 4
+        elif event in ('Walk', 'Intent Walk', 'Hit By Pitch'):
+            bases = 1
+
+        slot = pid_to_slot.get(batter_id)
+        if slot is None:
+            # Player not in current lineup (was subbed out), find their order
+            pdata = player_map.get(batter_id, {})
+            bat_order = pdata.get('battingOrder', '')
+            order_slot = int(str(bat_order)[:1]) if bat_order else None
+            if order_slot and order_slot in seen_orders:
+                slot = seen_orders[order_slot]
+
+        if slot is not None and slot < len(lineup):
+            if inning not in lineup[slot]['at_bats']:
+                lineup[slot]['at_bats'][inning] = []
+            lineup[slot]['at_bats'][inning].append({
+                'code': code,
+                'bases': bases,
+            })
+
+    # Build inning totals
+    inning_totals = {}
+    for play in all_plays:
+        about = play.get('about', {})
+        inning = about.get('inning', 0)
+        half = about.get('halfInning', '')
+        is_away = (half == 'top' and team_side == 'away')
+        is_home = (half == 'bottom' and team_side == 'home')
+        if not (is_away or is_home):
+            continue
+        if inning not in inning_totals:
+            inning_totals[inning] = 0
+        # Count runs scored on this play
+        result = play.get('result', {})
+        rbi = result.get('rbi', 0)
+        # Actually use the runs from the scoring plays
+        runners = play.get('runners', [])
+        for runner in runners:
+            movement = runner.get('movement', {})
+            if movement.get('end') == 'score':
+                inning_totals[inning] = inning_totals.get(inning, 0) + 1
+
+    return lineup[:9], inning_totals
+
+
+def fetch_scorecard_data(game_pk):
+    """Extract scorecard data from the live feed."""
+    data = fetch_live_feed(game_pk)
+    game_data = data.get('gameData', {})
+    live_data = data.get('liveData', {})
+    plays = live_data.get('plays', {})
+    linescore = live_data.get('linescore', {})
+    boxscore = live_data.get('boxscore', {})
+
+    status = game_data.get('status', {})
+    detailed_state = status.get('detailedState', '')
+
+    teams = game_data.get('teams', {})
+    away_team = teams.get('away', {})
+    home_team = teams.get('home', {})
+
+    # Linescore for totals
+    away_ls = linescore.get('teams', {}).get('away', {})
+    home_ls = linescore.get('teams', {}).get('home', {})
+
+    # Build lineups
+    away_lineup, away_inning_totals = _build_lineup_at_bats(boxscore, plays, 'away')
+    home_lineup, home_inning_totals = _build_lineup_at_bats(boxscore, plays, 'home')
+
+    # Count innings
+    innings_list = linescore.get('innings', [])
+    num_innings = len(innings_list)
+
+    return {
+        'detailed_state': detailed_state,
+        'away_abbr': away_team.get('abbreviation', ''),
+        'home_abbr': home_team.get('abbreviation', ''),
+        'away_id': away_team.get('id', 0),
+        'home_id': home_team.get('id', 0),
+        'away_lineup': away_lineup,
+        'home_lineup': home_lineup,
+        'away_inning_totals': away_inning_totals,
+        'home_inning_totals': home_inning_totals,
+        'num_innings': max(num_innings, 9),
+        'away_runs': away_ls.get('runs', 0),
+        'away_hits': away_ls.get('hits', 0),
+        'away_errors': away_ls.get('errors', 0),
+        'home_runs': home_ls.get('runs', 0),
+        'home_hits': home_ls.get('hits', 0),
+        'home_errors': home_ls.get('errors', 0),
+    }

--- a/src/pitch_view.py
+++ b/src/pitch_view.py
@@ -1,0 +1,218 @@
+import os
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+from generate_image import picdir, _logo_small
+
+EPD_WIDTH = 800
+EPD_HEIGHT = 480
+
+# Strike zone geometry (left half, centered at x=200)
+SZ_CENTER_X = 200
+SZ_BOTTOM_Y = 430      # pixel row for ground level (pZ=0)
+PX_SCALE = 80.0        # pixels per foot, horizontal
+PZ_SCALE = 80.0        # pixels per foot, vertical
+
+# Standard strike zone boundaries in feet
+SZ_HALF_WIDTH = 0.708  # half of 17-inch plate
+SZ_Z_BOT = 1.5
+SZ_Z_TOP = 3.5
+
+
+def _load_fonts():
+    font_path = os.path.join(picdir, 'Font.ttc')
+    return {
+        'f18': ImageFont.truetype(font_path, 18),
+        'f14': ImageFont.truetype(font_path, 14),
+        'f11': ImageFont.truetype(font_path, 11),
+        'f9':  ImageFont.truetype(font_path, 9),
+    }
+
+
+def _to_pixel(px_ft, pz_ft):
+    """Convert (pX feet from center, pZ feet off ground) to pixel coordinates."""
+    x = int(SZ_CENTER_X + px_ft * PX_SCALE)
+    y = int(SZ_BOTTOM_Y - pz_ft * PZ_SCALE)
+    return x, y
+
+
+def _draw_zone(draw):
+    """Draw the strike zone rectangle with 9-zone grid and home plate."""
+    zl, zt = _to_pixel(-SZ_HALF_WIDTH, SZ_Z_TOP)
+    zr, zb = _to_pixel(SZ_HALF_WIDTH, SZ_Z_BOT)
+
+    # Outer zone rectangle
+    draw.rectangle([zl, zt, zr, zb], outline=0, width=2)
+
+    # 9-zone grid
+    tw = (zr - zl) // 3
+    th = (zb - zt) // 3
+    draw.line([zl + tw,     zt + 1, zl + tw,     zb - 1], fill=0)
+    draw.line([zl + 2 * tw, zt + 1, zl + 2 * tw, zb - 1], fill=0)
+    draw.line([zl + 1, zt + th,     zr - 1, zt + th],     fill=0)
+    draw.line([zl + 1, zt + 2 * th, zr - 1, zt + 2 * th], fill=0)
+
+    # Ground line
+    ground_y = SZ_BOTTOM_Y
+    draw.line([(SZ_CENTER_X - 130, ground_y), (SZ_CENTER_X + 130, ground_y)], fill=0)
+
+    # Home plate (pentagon)
+    hx = SZ_CENTER_X
+    hy = ground_y - 4
+    s = 12
+    draw.polygon([
+        (hx,     hy + s),
+        (hx - s, hy),
+        (hx - s + 3, hy - s),
+        (hx + s - 3, hy - s),
+        (hx + s, hy),
+    ], outline=0)
+
+    # Catcher's perspective labels
+    draw.text((_to_pixel(-SZ_HALF_WIDTH - 0.3, SZ_Z_BOT - 0.25)[0], ground_y - 14),
+              'RHB', font=None, fill=0)
+
+
+def _draw_pitches(draw, fonts, pitches):
+    """Plot each pitch. Filled = strike, open = ball, F inside = foul, square = in play."""
+    r = 7
+    for pitch in pitches:
+        px, pz = pitch.get('px'), pitch.get('pz')
+        if px is None or pz is None:
+            continue
+        bx, by = _to_pixel(px, pz)
+        code = pitch.get('code', '')
+        seq = str(pitch.get('seq', ''))
+
+        if code in ('S', 'C', 'T'):
+            # Strike — filled circle, seq number to the right
+            draw.ellipse([bx - r, by - r, bx + r, by + r], fill=0, outline=0)
+            draw.text((bx + r + 2, by - 5), seq, font=fonts['f9'], fill=0)
+        elif code == 'F':
+            # Foul — open circle with 'F' inside
+            draw.ellipse([bx - r, by - r, bx + r, by + r], outline=0, width=2)
+            draw.text((bx - 3, by - 5), 'F', font=fonts['f9'], fill=0)
+        elif code == 'X':
+            # In play — filled square, seq to the right
+            draw.rectangle([bx - r, by - r, bx + r, by + r], fill=0)
+            draw.text((bx + r + 2, by - 5), seq, font=fonts['f9'], fill=0)
+        else:
+            # Ball — open circle with seq number inside
+            draw.ellipse([bx - r, by - r, bx + r, by + r], outline=0, width=2)
+            draw.text((bx - 3, by - 5), seq, font=fonts['f9'], fill=0)
+
+
+def _draw_right_panel(img, draw, fonts, data):
+    """Draw score, count, batter/pitcher, legend, and pitch log on the right half."""
+    x = 415
+
+    # --- Score header ---
+    y = 8
+    for side, abbr_key, id_key, runs_key in (
+        ('away', 'away_abbr', 'away_id', 'away_runs'),
+        ('home', 'home_abbr', 'home_id', 'home_runs'),
+    ):
+        abbr = data.get(abbr_key, '')
+        team_id = str(data.get(id_key, ''))
+        runs = data.get(runs_key, 0)
+        logo = _logo_small(abbr, team_id)
+        lx = x
+        if logo:
+            img.paste(logo, (lx, y + 2))
+            lx += 30
+        draw.text((lx, y), abbr, font=fonts['f18'], fill=0)
+        draw.text((lx + 55, y), str(runs), font=fonts['f18'], fill=0)
+        y += 32
+
+    # --- Inning / count / outs ---
+    y += 4
+    state = data.get('detailed_state', '')
+    if state in ('Final', 'Game Over', 'Final: Tied'):
+        draw.text((x, y), 'FINAL', font=fonts['f18'], fill=0)
+    else:
+        inning = f"{data.get('inning_state', '')} {data.get('inning_ordinal', '')}".strip()
+        draw.text((x, y), inning, font=fonts['f14'], fill=0)
+        balls = data.get('balls', 0)
+        strikes = data.get('strikes', 0)
+        outs = data.get('outs', 0)
+        draw.text((x, y + 18), f'Count: {balls}-{strikes}  Outs: {outs}', font=fonts['f14'], fill=0)
+    y += 42
+
+    # --- Batter ---
+    batter = data.get('batter', {})
+    draw.text((x, y), 'AB:', font=fonts['f11'], fill=0)
+    draw.text((x + 24, y), batter.get('name', ''), font=fonts['f14'], fill=0)
+    b = batter.get('season', {})
+    if b.get('avg'):
+        draw.text((x + 24, y + 17),
+                  f"AVG {b.get('avg')}  HR {b.get('homeRuns', 0)}  RBI {b.get('rbi', 0)}",
+                  font=fonts['f9'], fill=0)
+    y += 36
+
+    # --- Pitcher ---
+    pitcher = data.get('pitcher', {})
+    draw.text((x, y), 'P:', font=fonts['f11'], fill=0)
+    draw.text((x + 16, y), pitcher.get('name', ''), font=fonts['f14'], fill=0)
+    p = pitcher.get('season', {})
+    ps = pitcher.get('stats', {})
+    if p.get('era'):
+        draw.text((x + 16, y + 17),
+                  f"ERA {p.get('era')}  IP {ps.get('inningsPitched', '')}  K {ps.get('strikeOuts', '')}",
+                  font=fonts['f9'], fill=0)
+    y += 36
+
+    # --- Legend ---
+    r = 5
+    draw.text((x, y), 'Legend:', font=fonts['f11'], fill=0)
+    y += 14
+    draw.ellipse([x, y + 1, x + 10, y + 11], fill=0)
+    draw.text((x + 13, y), 'Strike (called/swinging)', font=fonts['f9'], fill=0)
+    y += 13
+    draw.ellipse([x, y + 1, x + 10, y + 11], outline=0, width=2)
+    draw.text((x + 4, y + 1), 'n', font=fonts['f9'], fill=0)
+    draw.text((x + 13, y), 'Ball (# = sequence)', font=fonts['f9'], fill=0)
+    y += 13
+    draw.ellipse([x, y + 1, x + 10, y + 11], outline=0, width=2)
+    draw.text((x + 3, y + 1), 'F', font=fonts['f9'], fill=0)
+    draw.text((x + 13, y), 'Foul', font=fonts['f9'], fill=0)
+    y += 13
+    draw.rectangle([x, y + 1, x + 10, y + 11], fill=0)
+    draw.text((x + 13, y), 'In play', font=fonts['f9'], fill=0)
+    y += 18
+
+    # --- Pitch log ---
+    draw.line([(x, y), (x + 375, y)], fill=0)
+    y += 4
+    pitches = data.get('pitches', [])
+    for pitch in pitches:
+        seq = pitch.get('seq', '')
+        code = pitch.get('code', '')
+        ptype = pitch.get('pitch_type', '')
+        speed = pitch.get('speed')
+        speed_str = f'{speed:.0f}' if speed else '--'
+        line = f"{seq:>2}. {code:<3} {ptype[:14]:<14} {speed_str}mph"
+        draw.text((x, y), line, font=fonts['f9'], fill=0)
+        y += 11
+        if y > 468:
+            break
+
+
+def render_pitch_view(data, dark_mode=False):
+    """Render the pitch location view. Returns an 800x480 1-bit PIL Image."""
+    img = Image.new('1', (EPD_WIDTH, EPD_HEIGHT), 255)
+    draw = ImageDraw.Draw(img)
+    fonts = _load_fonts()
+
+    # Vertical divider
+    draw.line([(400, 0), (400, EPD_HEIGHT)], fill=0, width=2)
+
+    # Left half: strike zone + pitches
+    _draw_zone(draw)
+    _draw_pitches(draw, fonts, data.get('pitches', []))
+
+    # Right half: game info
+    _draw_right_panel(img, draw, fonts, data)
+
+    if dark_mode:
+        img = ImageOps.invert(img.convert('L')).convert('1')
+
+    return img

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -9,6 +9,9 @@ import argparse
 from display_eink import display_image, display_partial_regions
 from refresh_tracker import needs_full_refresh
 from util import load_json_file, load_yaml_file, save_off_results
+from game_detail_fetch import select_game, fetch_field_view_data, fetch_scorecard_data
+from field_view import render_field_view
+from scorecard_view import render_scorecard_view
 import pytz
 
 # Spring Training Support:
@@ -378,6 +381,54 @@ def fetch_scoreboard_for_date(date, sport_id=None):
     
     
 
+def _get_display_mode(config):
+    """Determine display mode from config. Returns 'scoreboard', 'linescore', 'field', or 'scorecard'."""
+    mode = config.get('display_mode')
+    if mode and mode in ('scoreboard', 'linescore', 'field', 'scorecard'):
+        return mode
+    # Backward compat: use scoreboard flag
+    if config.get('scoreboard', True):
+        return 'scoreboard'
+    return 'linescore'
+
+
+def _run_single_game_mode(mode, game_state_data, team_data, config):
+    """Run field or scorecard mode for a single game."""
+    favorite = config.get('primary', '')
+    game = select_game(game_state_data, favorite, team_data)
+    if not game:
+        print("No game found for single-game display mode")
+        return
+
+    game_pk = game.get('game_pk')
+    if not game_pk:
+        print("No game_pk found")
+        return
+
+    dark_mode = config.get('dark_mode', False)
+
+    away_id = str(game.get('away_team_id', ''))
+    home_id = str(game.get('home_team_id', ''))
+    away_abbr = team_data.get('team_abbreviation', {}).get(away_id, '')
+    home_abbr = team_data.get('team_abbreviation', {}).get(home_id, '')
+    print(f"Selected game: {away_abbr} @ {home_abbr} (pk={game_pk}, mode={mode})")
+
+    try:
+        if mode == 'field':
+            data = fetch_field_view_data(game_pk)
+            image = render_field_view(data, dark_mode=dark_mode)
+        else:
+            data = fetch_scorecard_data(game_pk)
+            image = render_scorecard_view(data, dark_mode=dark_mode)
+
+        display_image(image)
+        print(f"{mode.title()} view generated successfully")
+    except Exception as e:
+        print(f"Error generating {mode} view: {e}")
+        import traceback
+        traceback.print_exc()
+
+
 def scoreboard_generate(date_str, game_data, sport_id=None):
     """
     Generate scoreboard for a specific date and sport.
@@ -398,6 +449,13 @@ def scoreboard_generate(date_str, game_data, sport_id=None):
     # Ensure team_data has the required structure
     if not team_data or 'team_abbreviation' not in team_data:
         team_data = {'team_abbreviation': {}}
+
+    config_data = load_yaml_file('config.yaml')
+    mode = _get_display_mode(config_data)
+
+    if mode in ('field', 'scorecard'):
+        _run_single_game_mode(mode, game_state_data, team_data, config_data)
+        return
 
     result = orchestrate_score_board(game_state_data, team_data, date_str)
 
@@ -534,6 +592,14 @@ Examples:
     # Ensure team_data has the required structure
     if not team_data or 'team_abbreviation' not in team_data:
         team_data = {'team_abbreviation': {}}
+
+    mode = _get_display_mode(config_data)
+
+    if mode in ('field', 'scorecard'):
+        _run_single_game_mode(mode, game_state_data, team_data, config_data)
+        print(f"\n✓ {mode.title()} view generated successfully!")
+        print(f"  View image at: resulting_image.bmp")
+        return
 
     result = orchestrate_score_board(game_state_data, team_data, date_str)
 

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -9,9 +9,10 @@ import argparse
 from display_eink import display_image, display_partial_regions
 from refresh_tracker import needs_full_refresh
 from util import load_json_file, load_yaml_file, save_off_results
-from game_detail_fetch import select_game, fetch_field_view_data, fetch_scorecard_data
+from game_detail_fetch import select_game, fetch_field_view_data, fetch_scorecard_data, fetch_pitch_view_data
 from field_view import render_field_view
 from scorecard_view import render_scorecard_view
+from pitch_view import render_pitch_view
 import pytz
 
 # Spring Training Support:
@@ -384,7 +385,7 @@ def fetch_scoreboard_for_date(date, sport_id=None):
 def _get_display_mode(config):
     """Determine display mode from config. Returns 'scoreboard', 'linescore', 'field', or 'scorecard'."""
     mode = config.get('display_mode')
-    if mode and mode in ('scoreboard', 'linescore', 'field', 'scorecard'):
+    if mode and mode in ('scoreboard', 'linescore', 'field', 'scorecard', 'pitch'):
         return mode
     # Backward compat: use scoreboard flag
     if config.get('scoreboard', True):
@@ -417,6 +418,9 @@ def _run_single_game_mode(mode, game_state_data, team_data, config):
         if mode == 'field':
             data = fetch_field_view_data(game_pk)
             image = render_field_view(data, dark_mode=dark_mode)
+        elif mode == 'pitch':
+            data = fetch_pitch_view_data(game_pk)
+            image = render_pitch_view(data, dark_mode=dark_mode)
         else:
             data = fetch_scorecard_data(game_pk)
             image = render_scorecard_view(data, dark_mode=dark_mode)
@@ -453,7 +457,7 @@ def scoreboard_generate(date_str, game_data, sport_id=None):
     config_data = load_yaml_file('config.yaml')
     mode = _get_display_mode(config_data)
 
-    if mode in ('field', 'scorecard'):
+    if mode in ('field', 'scorecard', 'pitch'):
         _run_single_game_mode(mode, game_state_data, team_data, config_data)
         return
 
@@ -595,7 +599,7 @@ Examples:
 
     mode = _get_display_mode(config_data)
 
-    if mode in ('field', 'scorecard'):
+    if mode in ('field', 'scorecard', 'pitch'):
         _run_single_game_mode(mode, game_state_data, team_data, config_data)
         print(f"\n✓ {mode.title()} view generated successfully!")
         print(f"  View image at: resulting_image.bmp")

--- a/src/scorecard_view.py
+++ b/src/scorecard_view.py
@@ -1,0 +1,230 @@
+import os
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+from generate_image import picdir, _logo_small
+
+EPD_WIDTH = 800
+EPD_HEIGHT = 480
+
+# Column layout constants
+COL_ORDER = 16
+COL_NAME = 140
+COL_POS = 24
+COL_INNING = 50
+COL_RHE = 28
+
+# Row layout constants
+ROW_HEADER = 14
+ROW_INN_HEADER = 16
+ROW_BATTER = 21
+ROW_TOTALS = 16
+TEAM_HEIGHT = 238
+
+
+def _load_fonts():
+    font_path = os.path.join(picdir, 'Font.ttc')
+    return {
+        'f14': ImageFont.truetype(font_path, 14),
+        'f11': ImageFont.truetype(font_path, 11),
+        'f9': ImageFont.truetype(font_path, 9),
+    }
+
+
+def _draw_mini_diamond(draw, x, y, bases, size=4):
+    """Draw a tiny diamond showing bases reached. bases=0-4."""
+    # Draw empty diamond outline
+    pts = [(x, y - size), (x + size, y), (x, y + size), (x - size, y)]
+    draw.polygon(pts, outline=0)
+
+    # Fill segments based on bases reached
+    if bases >= 1:
+        # First base side
+        draw.line([(x + size, y), (x, y - size)], fill=0, width=2)
+    if bases >= 2:
+        # Second base side
+        draw.line([(x, y - size), (x - size, y)], fill=0, width=2)
+    if bases >= 3:
+        # Third base side
+        draw.line([(x - size, y), (x, y + size)], fill=0, width=2)
+    if bases >= 4:
+        # Home (fill entire diamond)
+        draw.polygon(pts, fill=0, outline=0)
+
+
+def _draw_team_scorecard(img, draw, fonts, y_offset, team_data, team_abbr, team_id,
+                          num_innings, inning_totals, runs, hits, errors):
+    """Draw a single team's scorecard at y_offset."""
+    x = 0
+
+    # Cap displayed innings at 9, with 10+ summary if needed
+    display_innings = min(num_innings, 9)
+    has_extras = num_innings > 9
+
+    # Team header row
+    logo = _logo_small(team_abbr, str(team_id), size=12)
+    hx = x + 4
+    if logo:
+        small = logo.copy()
+        small.thumbnail((12, 12))
+        img.paste(small, (hx, y_offset + 1))
+        hx += 14
+    draw.text((hx, y_offset), team_abbr, font=fonts['f11'], fill=0)
+    y = y_offset + ROW_HEADER
+
+    # Inning headers
+    ix = x + COL_ORDER + COL_NAME + COL_POS
+    draw.text((x + 2, y), '#', font=fonts['f9'], fill=0)
+    draw.text((x + COL_ORDER, y), 'Player', font=fonts['f9'], fill=0)
+    draw.text((x + COL_ORDER + COL_NAME, y + 2), 'P', font=fonts['f9'], fill=0)
+
+    for i in range(display_innings):
+        col_x = ix + i * COL_INNING
+        draw.text((col_x + 18, y), str(i + 1), font=fonts['f11'], fill=0)
+
+    if has_extras:
+        col_x = ix + display_innings * COL_INNING
+        draw.text((col_x + 10, y), '10+', font=fonts['f9'], fill=0)
+        extra_col = display_innings
+    else:
+        extra_col = None
+
+    # R H E headers
+    rhe_x = ix + (display_innings + (1 if has_extras else 0)) * COL_INNING
+    draw.text((rhe_x + 8, y), 'R', font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 8 + COL_RHE, y), 'H', font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 8 + 2 * COL_RHE, y), 'E', font=fonts['f11'], fill=0)
+
+    y += ROW_INN_HEADER
+
+    # Horizontal line under header
+    draw.line([(x, y), (EPD_WIDTH, y)], fill=0)
+
+    # Batter rows
+    lineup = team_data
+    for slot_idx in range(9):
+        by = y + slot_idx * ROW_BATTER
+
+        if slot_idx < len(lineup):
+            entry = lineup[slot_idx]
+            name = entry.get('name', '')
+            pos = entry.get('position', '')
+            order = entry.get('order', slot_idx + 1)
+            sub = entry.get('sub', False)
+            at_bats = entry.get('at_bats', {})
+            totals = entry.get('totals', {})
+
+            # Order number
+            order_str = f"{'*' if sub else ''}{order}"
+            draw.text((x + 2, by + 2), order_str, font=fonts['f9'], fill=0)
+
+            # Player name (truncate if needed)
+            display_name = name[:16]
+            draw.text((x + COL_ORDER, by + 2), display_name, font=fonts['f11'], fill=0)
+
+            # Position
+            draw.text((x + COL_ORDER + COL_NAME, by + 2), pos, font=fonts['f9'], fill=0)
+
+            # Per-inning at-bat cells
+            for inn_num in range(1, display_innings + 1):
+                col_x = ix + (inn_num - 1) * COL_INNING
+                abs_list = at_bats.get(inn_num, [])
+                if abs_list:
+                    # Show most recent at-bat in this inning
+                    ab = abs_list[-1]
+                    code = ab.get('code', '')
+                    bases = ab.get('bases', 0)
+                    draw.text((col_x + 4, by + 2), code, font=fonts['f11'], fill=0)
+                    # Mini diamond
+                    _draw_mini_diamond(draw, col_x + COL_INNING - 8, by + ROW_BATTER - 7, bases)
+
+            # Extra innings summary
+            if has_extras:
+                col_x = ix + display_innings * COL_INNING
+                extra_abs = []
+                for inn_num in range(10, num_innings + 1):
+                    extra_abs.extend(at_bats.get(inn_num, []))
+                if extra_abs:
+                    ab = extra_abs[-1]
+                    draw.text((col_x + 4, by + 2), ab.get('code', ''), font=fonts['f11'], fill=0)
+
+            # R and H for this batter
+            draw.text((rhe_x + 10, by + 2), str(totals.get('runs', 0)), font=fonts['f11'], fill=0)
+            draw.text((rhe_x + 10 + COL_RHE, by + 2), str(totals.get('hits', 0)), font=fonts['f11'], fill=0)
+
+        # Horizontal grid line
+        draw.line([(ix, by + ROW_BATTER), (EPD_WIDTH, by + ROW_BATTER)], fill=0)
+
+    # Vertical grid lines for inning columns
+    grid_top = y
+    grid_bottom = y + 9 * ROW_BATTER + ROW_TOTALS
+    for i in range(display_innings + (1 if has_extras else 0) + 1):
+        lx = ix + i * COL_INNING
+        draw.line([(lx, grid_top - ROW_INN_HEADER), (lx, grid_bottom)], fill=0)
+
+    # RHE vertical lines
+    for i in range(4):
+        lx = rhe_x + i * COL_RHE
+        draw.line([(lx, grid_top - ROW_INN_HEADER), (lx, grid_bottom)], fill=0)
+
+    # Totals row
+    ty = y + 9 * ROW_BATTER
+    draw.line([(x, ty), (EPD_WIDTH, ty)], fill=0, width=2)
+
+    for inn_num in range(1, display_innings + 1):
+        col_x = ix + (inn_num - 1) * COL_INNING
+        inn_runs = inning_totals.get(inn_num, 0)
+        draw.text((col_x + 18, ty + 2), str(inn_runs), font=fonts['f11'], fill=0)
+
+    if has_extras:
+        col_x = ix + display_innings * COL_INNING
+        extra_runs = sum(inning_totals.get(i, 0) for i in range(10, num_innings + 1))
+        draw.text((col_x + 18, ty + 2), str(extra_runs), font=fonts['f11'], fill=0)
+
+    draw.text((rhe_x + 10, ty + 2), str(runs), font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 10 + COL_RHE, ty + 2), str(hits), font=fonts['f11'], fill=0)
+    draw.text((rhe_x + 10 + 2 * COL_RHE, ty + 2), str(errors), font=fonts['f11'], fill=0)
+
+
+def render_scorecard_view(data, dark_mode=False):
+    """Render the scorecard view display. Returns an 800x480 1-bit PIL Image."""
+    img = Image.new('1', (EPD_WIDTH, EPD_HEIGHT), 255)
+    draw = ImageDraw.Draw(img)
+    fonts = _load_fonts()
+
+    num_innings = data.get('num_innings', 9)
+
+    # Away team (top half: y=0 to 237)
+    _draw_team_scorecard(
+        img, draw, fonts,
+        y_offset=2,
+        team_data=data.get('away_lineup', []),
+        team_abbr=data.get('away_abbr', ''),
+        team_id=data.get('away_id', 0),
+        num_innings=num_innings,
+        inning_totals=data.get('away_inning_totals', {}),
+        runs=data.get('away_runs', 0),
+        hits=data.get('away_hits', 0),
+        errors=data.get('away_errors', 0),
+    )
+
+    # Divider
+    draw.line([(0, TEAM_HEIGHT), (EPD_WIDTH, TEAM_HEIGHT)], fill=0, width=2)
+
+    # Home team (bottom half: y=240 to 479)
+    _draw_team_scorecard(
+        img, draw, fonts,
+        y_offset=TEAM_HEIGHT + 2,
+        team_data=data.get('home_lineup', []),
+        team_abbr=data.get('home_abbr', ''),
+        team_id=data.get('home_id', 0),
+        num_innings=num_innings,
+        inning_totals=data.get('home_inning_totals', {}),
+        runs=data.get('home_runs', 0),
+        hits=data.get('home_hits', 0),
+        errors=data.get('home_errors', 0),
+    )
+
+    if dark_mode:
+        img = ImageOps.invert(img.convert('L')).convert('1')
+
+    return img


### PR DESCRIPTION
Introduces three new modules:
- game_detail_fetch: fetches live feed data, selects game by favorite/live priority, extracts pitches and hit coordinates
- field_view: renders baseball diamond with runners, hit marker, strike zone pitch plot, score/count/matchup panel, and mini linescore
- scorecard_view: renders official-scorer-style per-batter at-bat grid for both teams

Also wires display_mode config into scoreboard_generate (field/scorecard modes), fixes the left foul line vector math in field_view, and adds pitch location extraction with ball/strike/foul/in-play differentiation.