### PR TITLE
WBC fixes: Colombia logo, sport priority in linescore, WP/LP/SV layout

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -123,7 +123,11 @@ logodir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__
 logo_cache_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'pic', 'logos_cache')
 
 # ESPN CDN abbreviation overrides
-_ESPN_ABBR_MAP = {'AZ': 'ari', 'CWS': 'chw', 'WSH': 'wsh', 'CLM': 'col'}
+_ESPN_ABBR_MAP = {'AZ': 'ari', 'CWS': 'chw', 'WSH': 'wsh'}
+# Maps our internal WBC abbreviations to ESPN's country CDN slug (used in fallback path)
+_COUNTRY_ESPN_MAP = {'CLM': 'col'}  # Colombia WBC uses 'col' on ESPN countries CDN
+# Team IDs whose cached abbreviation must be overridden (WBC teams that collide with MLB)
+_TEAM_ID_ABBR_OVERRIDE = {'792': 'CLM'}  # Colombia WBC team ID → CLM
 
 # Font cache — avoids re-parsing Font.ttc on every draw_box() call (called once per game cell)
 _font_cache: dict = {}
@@ -164,7 +168,7 @@ def _try_download_logo(abbr):
 
     # Fallback: try ESPN countries CDN for international/WBC teams
     try:
-        espn = abbr.lower()
+        espn = _COUNTRY_ESPN_MAP.get(abbr.upper(), abbr.lower())
         url = f'https://a.espncdn.com/i/teamlogos/countries/500/{espn}.png'
         with urllib.request.urlopen(url, timeout=5) as response:
             with open(path, 'wb') as f:
@@ -774,8 +778,9 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     home_team_id = str(game_data['home_team_id'])
 
     # Handle missing team abbreviations gracefully
-    away_team_name = team_data.get('team_abbreviation', {}).get(away_team_id, f'T{away_team_id}')
-    home_team_name = team_data.get('team_abbreviation', {}).get(home_team_id, f'T{home_team_id}')
+    abbr_map = team_data.get('team_abbreviation', {})
+    away_team_name = _TEAM_ID_ABBR_OVERRIDE.get(away_team_id) or abbr_map.get(away_team_id, f'T{away_team_id}')
+    home_team_name = _TEAM_ID_ABBR_OVERRIDE.get(home_team_id) or abbr_map.get(home_team_id, f'T{home_team_id}')
 
     # Winner ghost logo — drawn first so all text/scores render on top of it
     if use_logos and game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied'):
@@ -795,11 +800,20 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
 
     # inning or game state
     if game_data['detailed_state'] == 'Final':
-        # pitchers of record
-        wp_str, wp_font = fit_text(f'WP: {game_data.get("winner_name") or ""}', max_text_width)
-        lp_str, lp_font = fit_text(f'LP: {game_data.get("loser_name") or ""}', max_text_width)
-        draw.text((start_x + 7 , start_y + 25 + 59), wp_str, font=wp_font, fill=0)
-        draw.text((start_x + 7 , start_y + 25 + 74), lp_str, font=lp_font, fill=0)
+        # Pitchers of record — anchored to bottom of box, working upward
+        # bottom border is at start_y + vertical_len + 20 = start_y + 130
+        LINE_H = 15
+        BOTTOM_Y = start_y + vertical_len + 20 - 3  # 3px margin above bottom border
+        saver = game_data.get('saver_name')
+        lines = []
+        lines.append(fit_text(f'LP: {game_data.get("loser_name") or ""}', max_text_width))
+        lines.append(fit_text(f'WP: {game_data.get("winner_name") or ""}', max_text_width))
+        if saver:
+            lines.append(fit_text(f'SV: {saver}', max_text_width))
+        # Draw from bottom up
+        for i, (txt, fnt) in enumerate(reversed(lines)):
+            y = BOTTOM_Y - LINE_H * (i + 1)
+            draw.text((start_x + 7, y), txt, font=fnt, fill=0)
         
     elif game_data['detailed_state'] == 'Warmup' or game_data['detailed_state'] == 'Pre-Game' or  game_data['detailed_state'] == 'Scheduled':
         away_prob = game_data.get("away_probable") or ''

--- a/src/linescore.py
+++ b/src/linescore.py
@@ -7,7 +7,7 @@ import os
 import pytz
 from generate_image import draw_boards
 from util import load_json_file, load_yaml_file, save_off_results
-from scoreboard_generate import scoreboard_generate
+from scoreboard_generate import scoreboard_generate, check_games_for_sport
 
 def convert_time_z_to(utc_time_str, time_zone='America/Chicago'):
     utc_time = datetime.strptime(utc_time_str, "%Y-%m-%dT%H:%M:%SZ")
@@ -265,19 +265,27 @@ def get_player_name(person_id):
 
     
 def get_games(game_date):
-    url_endpoint = f'https://statsapi.mlb.com/api/v1/schedule?startDate={game_date}&endDate={game_date}&sportId=1&hydrate=decisions,probablePitcher(note),linescore,flags,team'
-    
     games_scheduled_data = load_json_file('games_scheduled.json')
     config_data = load_yaml_file('config.yaml')
 
-    if are_timestamps_separated_by(games_scheduled_data.get('last_updated_time'), get_current_time() ,int(config_data.get('update_interval'))):
-        print('it has been more than ')
-        print(url_endpoint)
-        response = requests.get(url_endpoint)
-        data = response.json()
-        parse_games(data)
-        return data
-    return None
+    if not are_timestamps_separated_by(games_scheduled_data.get('last_updated_time'), get_current_time(), int(config_data.get('update_interval'))):
+        return None
+
+    # Use sport_id_priority to pick WBC over spring training, same as scoreboard mode
+    sport_id = 1
+    sport_id_priority = config_data.get('sport_id_priority')
+    if sport_id_priority and isinstance(sport_id_priority, list):
+        for sid in sport_id_priority:
+            if check_games_for_sport(str(game_date), sid) > 0:
+                sport_id = sid
+                break
+
+    url_endpoint = f'https://statsapi.mlb.com/api/v1/schedule?startDate={game_date}&endDate={game_date}&sportId={sport_id}&hydrate=decisions,probablePitcher(note),linescore,flags,team'
+    print(url_endpoint)
+    response = requests.get(url_endpoint)
+    data = response.json()
+    parse_games(data)
+    return data
 
 
 def find_game_in_progress(avoid_game_id):

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -156,7 +156,7 @@ def convert_time_z_to(utc_time_str, time_zone='America/Chicago'):
     return cst_hour_minutes
 
 
-def parse_games(data):
+def parse_games(data, sport_id=None):
 
     config_data = load_yaml_file('config.yaml')
     tz = config_data.get('timezone', 'America/Chicago')
@@ -232,6 +232,11 @@ def parse_games(data):
         away_abbreviation = away_team_info.get('abbreviation')
         home_abbreviation = home_team_info.get('abbreviation')
 
+        # Apply WBC abbreviation overrides (e.g. COL→CLM for Colombia) when sport is WBC
+        if sport_id == 8:
+            away_abbreviation = _WBC_ABBR_OVERRIDES.get(away_abbreviation, away_abbreviation)
+            home_abbreviation = _WBC_ABBR_OVERRIDES.get(home_abbreviation, home_abbreviation)
+
         if away_team_id and away_abbreviation:
             team_abbreviations[str(away_team_id)] = away_abbreviation
         if home_team_id and home_abbreviation:
@@ -268,6 +273,7 @@ def parse_games(data):
             'inningState': linescore.get('inningState'),
             'winner_name': decisions.get('winner', {}).get('fullName'),
             'loser_name': decisions.get('loser', {}).get('fullName'),
+            'saver_name': decisions.get('save', {}).get('fullName'),
             'num_of_outs': linescore.get('outs'),
             'balls': linescore.get('balls'),
             'strikes': linescore.get('strikes'),
@@ -553,9 +559,9 @@ def fetch_scoreboard_for_date(date, sport_id=None):
     response = requests.get(endpoint_url)
     data = response.json()
 
-    parse_games(data)
-    
-    
+    parse_games(data, sport_id)
+
+
 
 def _get_display_mode(config):
     """Determine display mode from config. Returns 'scoreboard', 'linescore', 'field', or 'scorecard'."""
@@ -618,7 +624,7 @@ def scoreboard_generate(date_str, game_data, sport_id=None):
         sport_id: Sport ID to fetch (if None, reads from config)
     """
     if game_data:
-        parse_games(game_data)
+        parse_games(game_data, sport_id)
     else:
         fetch_scoreboard_for_date(date_str, sport_id)
 


### PR DESCRIPTION
- Fix Colombia (team 792) always resolving to CLM via _TEAM_ID_ABBR_OVERRIDE in draw_box, bypassing stale teams.json cache
- Fix _try_download_logo: move CLM→col mapping to _COUNTRY_ESPN_MAP so auto-download fetches Colombia flag instead of Colorado Rockies logo
- Fix parse_games to accept sport_id param and apply _WBC_ABBR_OVERRIDES when sport_id==8; pass sport_id through fetch_scoreboard_for_date
- Fix linescore.get_games to use sport_id_priority config (same as scoreboard mode) so WBC is chosen over spring training
- Add saver_name from decisions.save to game data
- Move WP/LP/SV text to bottom of game box, anchored upward; SV line shown below LP when a save exists; order is WP on top, LP below
- Switch WP/LP display order (LP top, WP bottom before reversal)