### PR TITLE
Fix spring training games filtered out, showing college baseball instead

### DIFF
--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -494,10 +494,13 @@ def check_games_for_sport(date, sport_id):
             game_dates = data.get('dates', [])
             if game_dates and len(game_dates) > 0:
                 games = game_dates[0].get('games', [])
-                # For MLB (sport_id=1), only count regular/postseason games — not spring training ('S')
-                # This allows WBC (sport_id=8) to take priority during spring training period
+                # For MLB (sport_id=1), prefer regular/postseason games over spring training ('S')
+                # but fall back to spring training if no regular games exist (avoids picking up
+                # college baseball when spring training is the only MLB-affiliated action).
                 if sport_id == 1:
-                    games = [g for g in games if g.get('gameType') not in ('S', 'E')]
+                    regular = [g for g in games if g.get('gameType') not in ('S', 'E')]
+                    if regular:
+                        games = regular
                 return len(games)
     except Exception as e:
         print(f"Error checking games for sport {sport_id}: {e}")


### PR DESCRIPTION
## Summary
- `check_games_for_sport` was unconditionally replacing MLB games with a regular-season-only filter during spring training
- This returned 0 for `sport_id=1`, causing the priority loop to fall through to `sport_id=11` (College Baseball), which had exactly 1 game — the only game shown on the display
- Fix: only apply the regular-game filter if regular-season games actually exist; otherwise fall back to spring training games

## Root cause
```python
# Before (buggy): always filters to regular games
if sport_id == 1:
    games = [g for g in games if g.get('gameType') not in ('S', 'E')]
return len(games)  # returns 0 during spring training!

# After: only filters when regular games exist
if sport_id == 1:
    regular = [g for g in games if g.get('gameType') not in ('S', 'E')]
    if regular:
        games = regular
return len(games)  # correctly returns spring training game count
```

## Test plan
- [ ] Deploy to Pi and confirm spring training games load (should be 10 games for 2026-03-24 via sport_id=1)
- [ ] Delete `data/schedule_state.json` on Pi to clear the throttle state from the bad fetch
- [ ] Verify WBC still takes priority over spring training when WBC games exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)