### PR TITLE
Load MLBAM wall polygons from JSON; add pipeline entry points

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,8 +7,9 @@ scoreboard: true
 # "field"     = single-game field diagram with runners, hit location, strike zone overlay
 # "scorecard" = official scorer-style per-batter at-bat grid for both teams
 # "pitch"     = full strike zone with pitch locations for current at-bat
-# display_mode: "scoreboard"
-primary: NYY
+display_mode: "scoreboard"
+
+primary: BOS
 primary_backup: BOS
 primary_backup_2: NYM
 secondary: NYY_DOUBLE

--- a/main.py
+++ b/main.py
@@ -1,0 +1,341 @@
+"""
+MLB Display — full pipeline orchestrator.
+
+Usage:
+    python main.py [--date YYYY-MM-DD] [--sport-id N] [--fetch-teams] [--local] [--config PATH]
+"""
+import sys
+import os
+import json
+import platform
+import argparse
+from datetime import datetime, timedelta
+
+import pytz
+
+# Ensure src/ is on the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from config_loader import load_config, add_config_arg
+from fetch_games import fetch_scoreboard_for_date, fetch_all_team_abbreviations, find_next_game_date, SPORT_NAMES
+from render_scoreboard import render
+from display import send_to_display
+from util import load_json_file
+
+
+# ---------------------------------------------------------------------------
+# Private helpers (night mode, Discord, smart polling) — stay in main.py only
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def _data_path(filename):
+    return os.path.join(_REPO_ROOT, 'data', filename)
+
+
+def _config_path():
+    return os.path.join(_REPO_ROOT, 'config', 'config.yaml')
+
+
+def _in_night_window(config):
+    """Return True if we are currently inside the configured night mode window."""
+    night_start = config.get('night_start', 0)
+    night_end = config.get('night_end', 7)
+    tz = config.get('timezone', 'America/Chicago')
+    local_tz = pytz.timezone(tz)
+    current_hour = datetime.now(local_tz).hour
+    if night_start >= night_end:
+        return current_hour >= night_start or current_hour < night_end
+    return night_start <= current_hour < night_end
+
+
+def _load_discord_state():
+    path = _data_path('discord_state.json')
+    try:
+        with open(path) as f:
+            state = json.load(f)
+        if not state.get('applied', True):
+            return state
+    except (FileNotFoundError, Exception):
+        pass
+    return None
+
+
+def _mark_discord_applied():
+    path = _data_path('discord_state.json')
+    try:
+        with open(path) as f:
+            state = json.load(f)
+        state['applied'] = True
+        with open(path, 'w') as f:
+            json.dump(state, f, indent=2)
+    except (FileNotFoundError, Exception):
+        pass
+
+
+def _apply_discord_change(state, config):
+    """Apply pending Discord changes to in-memory config and persist config.yaml."""
+    import yaml
+    changed = False
+    if state.get('pending_mode') and state['pending_mode'] in ('scoreboard', 'linescore', 'field', 'scorecard', 'pitch'):
+        config['display_mode'] = state['pending_mode']
+        changed = True
+    if state.get('pending_team'):
+        config['primary'] = state['pending_team'].upper()
+        changed = True
+    if changed:
+        try:
+            with open(_config_path(), 'w') as f:
+                yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
+        except Exception as e:
+            print(f"Warning: could not save config.yaml after Discord change: {e}")
+    return changed
+
+
+def _render_discord_overlay(state, dark_mode=False):
+    from PIL import Image, ImageDraw, ImageFont
+    picdir = os.path.join(_REPO_ROOT, 'pic')
+    img = Image.new('1', (800, 480), 255)
+    draw = ImageDraw.Draw(img)
+    try:
+        font_lg = ImageFont.truetype(os.path.join(picdir, 'Font.ttc'), 48)
+        font_md = ImageFont.truetype(os.path.join(picdir, 'Font.ttc'), 28)
+        font_sm = ImageFont.truetype(os.path.join(picdir, 'Font.ttc'), 22)
+    except Exception:
+        font_lg = font_md = font_sm = ImageFont.load_default()
+
+    mode = state.get('pending_mode', '').upper()
+    team = state.get('pending_team', '').upper()
+    user = state.get('requested_by', '')
+
+    lines = [
+        ('Display Changing', font_md, 120),
+        (mode or team, font_lg, 185),
+    ]
+    if mode and team:
+        lines.append((f'Team: {team}', font_md, 265))
+    lines.append((f'Requested by @{user}', font_sm, 340))
+
+    for text, font, y in lines:
+        try:
+            w = font.getlength(text)
+        except AttributeError:
+            w = len(text) * 12
+        draw.text(((800 - w) // 2, y), text, font=font, fill=0)
+
+    draw.rectangle([10, 10, 789, 469], outline=0, width=3)
+    if dark_mode:
+        img = img.point(lambda p: 0 if p == 255 else 255)
+    return img
+
+
+def _load_schedule_state():
+    path = _data_path('schedule_state.json')
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def _save_schedule_state(state):
+    path = _data_path('schedule_state.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as f:
+        json.dump(state, f, indent=2)
+
+
+def _should_skip_poll(date_str, config, sched):
+    """Return (should_skip, reason_str) based on smart polling state."""
+    next_game_date = sched.get('next_game_date')
+    if next_game_date and next_game_date > date_str:
+        return True, f"No games until {next_game_date} — skipping API call"
+
+    try:
+        cached_games = load_json_file('games.json').get('games', [])
+    except Exception:
+        cached_games = []
+
+    _final_states = {'Final', 'Game Over', 'Final: Tied', 'Postponed', 'Delayed', 'Completed Early'}
+    any_live = any(g.get('detailed_state') == 'In Progress' for g in cached_games)
+    all_done = bool(cached_games) and all(g.get('detailed_state') in _final_states for g in cached_games)
+
+    if any_live:
+        return False, ""
+
+    if all_done:
+        interval_min = 60
+    elif not cached_games:
+        interval_min = 60
+    else:
+        interval_min = config.get('update_interval', 14)
+
+    last_fetch = sched.get('last_game_fetch')
+    if last_fetch:
+        try:
+            elapsed = datetime.now() - datetime.fromisoformat(last_fetch)
+            if elapsed < timedelta(minutes=interval_min):
+                mins = int(elapsed.total_seconds() // 60)
+                state_label = 'all_done' if all_done else 'pre-game'
+                return True, f"Throttled — {mins}min since last fetch (interval={interval_min}min, state={state_label})"
+        except Exception:
+            pass
+
+    return False, ""
+
+
+def _update_schedule_state(game_state_data, date_str, config, sched):
+    sched['last_game_fetch'] = datetime.now().isoformat(timespec='seconds')
+    if not game_state_data:
+        priority = config.get('sport_id_priority', [1, 8, 16])
+        tomorrow = (datetime.now().date() + timedelta(days=1)).strftime('%Y-%m-%d')
+        next_date = find_next_game_date(priority, tomorrow)
+        sched['next_game_date'] = next_date
+        _save_schedule_state(sched)
+        if next_date:
+            print(f"No games today. Next games: {next_date}")
+        return True  # signal: no games, caller should return early
+    else:
+        sched.pop('next_game_date', None)
+        _save_schedule_state(sched)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='MLB Display — fetch → render → display pipeline',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  python main.py
+  python main.py --date 2025-04-01
+  python main.py --sport-id 8 --date 2023-03-21
+  python main.py --local
+        ''',
+    )
+    parser.add_argument('--date', type=str, help='Date (YYYY-MM-DD). Default: today')
+    parser.add_argument('--sport-id', type=int, help='Sport ID override')
+    parser.add_argument('--fetch-teams', action='store_true',
+                        help='Fetch and cache all team abbreviations, then exit')
+    parser.add_argument('--local', action='store_true',
+                        help='Local dev mode: bypass night mode and smart polling, auto-open output')
+    add_config_arg(parser)
+    args = parser.parse_args()
+
+    system_platform = platform.system()
+    print(f"Running on platform: {system_platform}")
+    if system_platform == 'Darwin':
+        print("Development mode - e-ink display updates will be skipped")
+
+    config = load_config(args.config)
+
+    # 3. Night mode gate
+    if config.get('night_mode', False) and not args.local:
+        if _in_night_window(config):
+            tz = config.get('timezone', 'America/Chicago')
+            now_str = datetime.now(pytz.timezone(tz)).strftime('%H:%M')
+            print(f"Night mode: skipping refresh ({now_str})")
+            return
+
+    dark_mode = config.get('dark_mode', False)
+
+    # 4. Discord state gate
+    discord_state = _load_discord_state()
+    if discord_state:
+        user = discord_state.get('requested_by', 'unknown')
+        mode_req = discord_state.get('pending_mode', '')
+        team_req = discord_state.get('pending_team', '')
+        print(f"Discord change requested by @{user}: mode={mode_req or '(unchanged)'} team={team_req or '(unchanged)'}")
+        _apply_discord_change(discord_state, config)
+        overlay = _render_discord_overlay(discord_state, dark_mode=dark_mode)
+        from display_eink import display_image
+        display_image(overlay)
+        _mark_discord_applied()
+
+    # Handle --sport-id / --fetch-teams
+    if args.sport_id:
+        sport_id = args.sport_id
+        print(f"Using specified sport: {SPORT_NAMES.get(sport_id, f'Sport ID {sport_id}')}")
+        if args.fetch_teams:
+            fetch_all_team_abbreviations(sport_id)
+            return
+    else:
+        sport_id_priority = config.get('sport_id_priority')
+        if sport_id_priority and isinstance(sport_id_priority, list):
+            print(f"Using sport priority: {' > '.join([SPORT_NAMES.get(sid, str(sid)) for sid in sport_id_priority])}")
+            sport_id = None
+        else:
+            sport_id = config.get('sport_id', 1)
+            print(f"Tracking: {SPORT_NAMES.get(sport_id, f'Sport ID {sport_id}')}")
+        if args.fetch_teams:
+            target = sport_id if sport_id else (sport_id_priority[0] if sport_id_priority else 1)
+            fetch_all_team_abbreviations(target)
+            return
+
+    # Determine date
+    if args.date:
+        date_str = args.date
+        print(f"Using specified date: {date_str}")
+    else:
+        date_str = datetime.now().date().strftime('%Y-%m-%d')
+        print(f"Using today's date: {date_str}")
+
+    # 5. Smart polling gate (only for automatic runs on today's date)
+    if not args.date and not args.local:
+        sched = _load_schedule_state()
+        skip, reason = _should_skip_poll(date_str, config, sched)
+        if skip:
+            print(reason)
+            return
+    else:
+        sched = {}
+
+    # 6. Fetch
+    fetch_scoreboard_for_date(date_str, sport_id, config)
+
+    # 7. Update schedule state
+    if not args.date and not args.local:
+        game_state_data = load_json_file('games.json').get('games', [])
+        no_games = _update_schedule_state(game_state_data, date_str, config, sched)
+        if no_games:
+            return
+
+    # 8. Render
+    output_path = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
+    result = render(config, date_str=date_str, output_path=output_path)
+
+    if not result:
+        print("No display update needed - image unchanged")
+        return
+
+    image, changed_regions = result
+
+    # 9. Send to display
+    from refresh_tracker import needs_full_refresh
+    if needs_full_refresh() or not changed_regions:
+        print("Scoreboard: full refresh")
+        refresh_mode = 'full'
+    else:
+        print(f"Scoreboard: partial refresh ({len(changed_regions)} region(s))")
+        refresh_mode = 'partial'
+
+    send_to_display(output_path, changed_regions if refresh_mode == 'partial' else None)
+
+    print(f"\n✓ Display updated successfully!")
+    print(f"  Image: {output_path}")
+
+    # 10. --local: auto-open on macOS
+    if args.local and system_platform == 'Darwin':
+        import subprocess
+        subprocess.run(['open', output_path], check=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
     {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
@@ -19,6 +20,7 @@ description = "The Real First Universal Charset Detector. Open, modern and activ
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d"},
     {file = "charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8"},
@@ -142,6 +144,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
@@ -151,12 +154,342 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "numpy"
+version = "2.0.2"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version < \"3.11\" and (sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\")"
+files = [
+    {file = "numpy-2.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51129a29dbe56f9ca83438b706e2e69a39892b5eda6cedcb6b0c9fdc9b0d3ece"},
+    {file = "numpy-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f15975dfec0cf2239224d80e32c3170b1d168335eaedee69da84fbe9f1f9cd04"},
+    {file = "numpy-2.0.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:8c5713284ce4e282544c68d1c3b2c7161d38c256d2eefc93c1d683cf47683e66"},
+    {file = "numpy-2.0.2-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:becfae3ddd30736fe1889a37f1f580e245ba79a5855bff5f2a29cb3ccc22dd7b"},
+    {file = "numpy-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2da5960c3cf0df7eafefd806d4e612c5e19358de82cb3c343631188991566ccd"},
+    {file = "numpy-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:496f71341824ed9f3d2fd36cf3ac57ae2e0165c143b55c3a035ee219413f3318"},
+    {file = "numpy-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a61ec659f68ae254e4d237816e33171497e978140353c0c2038d46e63282d0c8"},
+    {file = "numpy-2.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d731a1c6116ba289c1e9ee714b08a8ff882944d4ad631fd411106a30f083c326"},
+    {file = "numpy-2.0.2-cp310-cp310-win32.whl", hash = "sha256:984d96121c9f9616cd33fbd0618b7f08e0cfc9600a7ee1d6fd9b239186d19d97"},
+    {file = "numpy-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:c7b0be4ef08607dd04da4092faee0b86607f111d5ae68036f16cc787e250a131"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:49ca4decb342d66018b01932139c0961a8f9ddc7589611158cb3c27cbcf76448"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:11a76c372d1d37437857280aa142086476136a8c0f373b2e648ab2c8f18fb195"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:807ec44583fd708a21d4a11d94aedf2f4f3c3719035c76a2bbe1fe8e217bdc57"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8cafab480740e22f8d833acefed5cc87ce276f4ece12fdaa2e8903db2f82897a"},
+    {file = "numpy-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a15f476a45e6e5a3a79d8a14e62161d27ad897381fecfa4a09ed5322f2085669"},
+    {file = "numpy-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13e689d772146140a252c3a28501da66dfecd77490b498b168b501835041f951"},
+    {file = "numpy-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9ea91dfb7c3d1c56a0e55657c0afb38cf1eeae4544c208dc465c3c9f3a7c09f9"},
+    {file = "numpy-2.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c1c9307701fec8f3f7a1e6711f9089c06e6284b3afbbcd259f7791282d660a15"},
+    {file = "numpy-2.0.2-cp311-cp311-win32.whl", hash = "sha256:a392a68bd329eafac5817e5aefeb39038c48b671afd242710b451e76090e81f4"},
+    {file = "numpy-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:286cd40ce2b7d652a6f22efdfc6d1edf879440e53e76a75955bc0c826c7e64dc"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c"},
+    {file = "numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692"},
+    {file = "numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a"},
+    {file = "numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c"},
+    {file = "numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded"},
+    {file = "numpy-2.0.2-cp312-cp312-win32.whl", hash = "sha256:671bec6496f83202ed2d3c8fdc486a8fc86942f2e69ff0e986140339a63bcbe5"},
+    {file = "numpy-2.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729"},
+    {file = "numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1"},
+    {file = "numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd"},
+    {file = "numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d"},
+    {file = "numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d"},
+    {file = "numpy-2.0.2-cp39-cp39-win32.whl", hash = "sha256:905d16e0c60200656500c95b6b8dca5d109e23cb24abc701d41c02d74c6b3afa"},
+    {file = "numpy-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f0a0c6f12e07fa94133c8a67404322845220c06a9e80e85999afe727f7438b8"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:312950fdd060354350ed123c0e25a71327d3711584beaef30cdaa93320c392d4"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26df23238872200f63518dd2aa984cfca675d82469535dc7162dc2ee52d9dd5c"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a46288ec55ebbd58947d31d72be2c63cbf839f0a63b49cb755022310792a3385"},
+    {file = "numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78"},
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.3"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "(sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\") and python_version >= \"3.11\""
+files = [
+    {file = "numpy-2.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:33b3bf58ee84b172c067f56aeadc7ee9ab6de69c5e800ab5b10295d54c581adb"},
+    {file = "numpy-2.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8ba7b51e71c05aa1f9bc3641463cd82308eab40ce0d5c7e1fd4038cbf9938147"},
+    {file = "numpy-2.4.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a1988292870c7cb9d0ebb4cc96b4d447513a9644801de54606dc7aabf2b7d920"},
+    {file = "numpy-2.4.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:23b46bb6d8ecb68b58c09944483c135ae5f0e9b8d8858ece5e4ead783771d2a9"},
+    {file = "numpy-2.4.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a016db5c5dba78fa8fe9f5d80d6708f9c42ab087a739803c0ac83a43d686a470"},
+    {file = "numpy-2.4.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:715de7f82e192e8cae5a507a347d97ad17598f8e026152ca97233e3666daaa71"},
+    {file = "numpy-2.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2ddb7919366ee468342b91dea2352824c25b55814a987847b6c52003a7c97f15"},
+    {file = "numpy-2.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a315e5234d88067f2d97e1f2ef670a7569df445d55400f1e33d117418d008d52"},
+    {file = "numpy-2.4.3-cp311-cp311-win32.whl", hash = "sha256:2b3f8d2c4589b1a2028d2a770b0fc4d1f332fb5e01521f4de3199a896d158ddd"},
+    {file = "numpy-2.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:77e76d932c49a75617c6d13464e41203cd410956614d0a0e999b25e9e8d27eec"},
+    {file = "numpy-2.4.3-cp311-cp311-win_arm64.whl", hash = "sha256:eb610595dd91560905c132c709412b512135a60f1851ccbd2c959e136431ff67"},
+    {file = "numpy-2.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:61b0cbabbb6126c8df63b9a3a0c4b1f44ebca5e12ff6997b80fcf267fb3150ef"},
+    {file = "numpy-2.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7395e69ff32526710748f92cd8c9849b361830968ea3e24a676f272653e8983e"},
+    {file = "numpy-2.4.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:abdce0f71dcb4a00e4e77f3faf05e4616ceccfe72ccaa07f47ee79cda3b7b0f4"},
+    {file = "numpy-2.4.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:48da3a4ee1336454b07497ff7ec83903efa5505792c4e6d9bf83d99dc07a1e18"},
+    {file = "numpy-2.4.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e3bef222ad6b052280311d1d60db8e259e4947052c3ae7dd6817451fc8a4c5"},
+    {file = "numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7dd01a46700b1967487141a66ac1a3cf0dd8ebf1f08db37d46389401512ca97"},
+    {file = "numpy-2.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:76f0f283506c28b12bba319c0fab98217e9f9b54e6160e9c79e9f7348ba32e9c"},
+    {file = "numpy-2.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:737f630a337364665aba3b5a77e56a68cc42d350edd010c345d65a3efa3addcc"},
+    {file = "numpy-2.4.3-cp312-cp312-win32.whl", hash = "sha256:26952e18d82a1dbbc2f008d402021baa8d6fc8e84347a2072a25e08b46d698b9"},
+    {file = "numpy-2.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:65f3c2455188f09678355f5cae1f959a06b778bc66d535da07bf2ef20cd319d5"},
+    {file = "numpy-2.4.3-cp312-cp312-win_arm64.whl", hash = "sha256:2abad5c7fef172b3377502bde47892439bae394a71bc329f31df0fd829b41a9e"},
+    {file = "numpy-2.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b346845443716c8e542d54112966383b448f4a3ba5c66409771b8c0889485dd3"},
+    {file = "numpy-2.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2629289168f4897a3c4e23dc98d6f1731f0fc0fe52fb9db19f974041e4cc12b9"},
+    {file = "numpy-2.4.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bb2e3cf95854233799013779216c57e153c1ee67a0bf92138acca0e429aefaee"},
+    {file = "numpy-2.4.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7f3408ff897f8ab07a07fbe2823d7aee6ff644c097cc1f90382511fe982f647f"},
+    {file = "numpy-2.4.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:decb0eb8a53c3b009b0962378065589685d66b23467ef5dac16cbe818afde27f"},
+    {file = "numpy-2.4.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5f51900414fc9204a0e0da158ba2ac52b75656e7dce7e77fb9f84bfa343b4cc"},
+    {file = "numpy-2.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6bd06731541f89cdc01b261ba2c9e037f1543df7472517836b78dfb15bd6e476"},
+    {file = "numpy-2.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22654fe6be0e5206f553a9250762c653d3698e46686eee53b399ab90da59bd92"},
+    {file = "numpy-2.4.3-cp313-cp313-win32.whl", hash = "sha256:d71e379452a2f670ccb689ec801b1218cd3983e253105d6e83780967e899d687"},
+    {file = "numpy-2.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:0a60e17a14d640f49146cb38e3f105f571318db7826d9b6fef7e4dce758faecd"},
+    {file = "numpy-2.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:c9619741e9da2059cd9c3f206110b97583c7152c1dc9f8aafd4beb450ac1c89d"},
+    {file = "numpy-2.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7aa4e54f6469300ebca1d9eb80acd5253cdfa36f2c03d79a35883687da430875"},
+    {file = "numpy-2.4.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d1b90d840b25874cf5cd20c219af10bac3667db3876d9a495609273ebe679070"},
+    {file = "numpy-2.4.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a749547700de0a20a6718293396ec237bb38218049cfce788e08fcb716e8cf73"},
+    {file = "numpy-2.4.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f3c4a151a2e529adf49c1d54f0f57ff8f9b233ee4d44af623a81553ab86368"},
+    {file = "numpy-2.4.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22c31dc07025123aedf7f2db9e91783df13f1776dc52c6b22c620870dc0fab22"},
+    {file = "numpy-2.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:148d59127ac95979d6f07e4d460f934ebdd6eed641db9c0db6c73026f2b2101a"},
+    {file = "numpy-2.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a97cbf7e905c435865c2d939af3d93f99d18eaaa3cabe4256f4304fb51604349"},
+    {file = "numpy-2.4.3-cp313-cp313t-win32.whl", hash = "sha256:be3b8487d725a77acccc9924f65fd8bce9af7fac8c9820df1049424a2115af6c"},
+    {file = "numpy-2.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1ec84fd7c8e652b0f4aaaf2e6e9cc8eaa9b1b80a537e06b2e3a2fb176eedcb26"},
+    {file = "numpy-2.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:120df8c0a81ebbf5b9020c91439fccd85f5e018a927a39f624845be194a2be02"},
+    {file = "numpy-2.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5884ce5c7acfae1e4e1b6fde43797d10aa506074d25b531b4f54bde33c0c31d4"},
+    {file = "numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:297837823f5bc572c5f9379b0c9f3a3365f08492cbdc33bcc3af174372ebb168"},
+    {file = "numpy-2.4.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a111698b4a3f8dcbe54c64a7708f049355abd603e619013c346553c1fd4ca90b"},
+    {file = "numpy-2.4.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:4bd4741a6a676770e0e97fe9ab2e51de01183df3dcbcec591d26d331a40de950"},
+    {file = "numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54f29b877279d51e210e0c80709ee14ccbbad647810e8f3d375561c45ef613dd"},
+    {file = "numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24"},
+    {file = "numpy-2.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d84f0f881cb2225c2dfd7f78a10a5645d487a496c6668d6cc39f0f114164f3d0"},
+    {file = "numpy-2.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d213c7e6e8d211888cc359bab7199670a00f5b82c0978b9d1c75baf1eddbeac0"},
+    {file = "numpy-2.4.3-cp314-cp314-win32.whl", hash = "sha256:52077feedeff7c76ed7c9f1a0428558e50825347b7545bbb8523da2cd55c547a"},
+    {file = "numpy-2.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:0448e7f9caefb34b4b7dd2b77f21e8906e5d6f0365ad525f9f4f530b13df2afc"},
+    {file = "numpy-2.4.3-cp314-cp314-win_arm64.whl", hash = "sha256:b44fd60341c4d9783039598efadd03617fa28d041fc37d22b62d08f2027fa0e7"},
+    {file = "numpy-2.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a195f4216be9305a73c0e91c9b026a35f2161237cf1c6de9b681637772ea657"},
+    {file = "numpy-2.4.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:cd32fbacb9fd1bf041bf8e89e4576b6f00b895f06d00914820ae06a616bdfef7"},
+    {file = "numpy-2.4.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:2e03c05abaee1f672e9d67bc858f300b5ccba1c21397211e8d77d98350972093"},
+    {file = "numpy-2.4.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d1ce23cce91fcea443320a9d0ece9b9305d4368875bab09538f7a5b4131938a"},
+    {file = "numpy-2.4.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c59020932feb24ed49ffd03704fbab89f22aa9c0d4b180ff45542fe8918f5611"},
+    {file = "numpy-2.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9684823a78a6cd6ad7511fc5e25b07947d1d5b5e2812c93fe99d7d4195130720"},
+    {file = "numpy-2.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0200b25c687033316fb39f0ff4e3e690e8957a2c3c8d22499891ec58c37a3eb5"},
+    {file = "numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0"},
+    {file = "numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b"},
+    {file = "numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e"},
+    {file = "numpy-2.4.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c6b124bfcafb9e8d3ed09130dbee44848c20b3e758b6bbf006e641778927c028"},
+    {file = "numpy-2.4.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:76dbb9d4e43c16cf9aa711fcd8de1e2eeb27539dcefb60a1d5e9f12fae1d1ed8"},
+    {file = "numpy-2.4.3-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:29363fbfa6f8ee855d7569c96ce524845e3d726d6c19b29eceec7dd555dab152"},
+    {file = "numpy-2.4.3-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:bc71942c789ef415a37f0d4eab90341425a00d538cd0642445d30b41023d3395"},
+    {file = "numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e58765ad74dcebd3ef0208a5078fba32dc8ec3578fe84a604432950cd043d79"},
+    {file = "numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e236dbda4e1d319d681afcbb136c0c4a8e0f1a5c58ceec2adebb547357fe857"},
+    {file = "numpy-2.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b42639cdde6d24e732ff823a3fa5b701d8acad89c4142bc1d0bd6dc85200ba5"},
+    {file = "numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd"},
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version < \"3.11\" and (sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\")"
+files = [
+    {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
+    {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
+    {file = "pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1"},
+    {file = "pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838"},
+    {file = "pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250"},
+    {file = "pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4"},
+    {file = "pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826"},
+    {file = "pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523"},
+    {file = "pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45"},
+    {file = "pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66"},
+    {file = "pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b"},
+    {file = "pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791"},
+    {file = "pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151"},
+    {file = "pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c"},
+    {file = "pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53"},
+    {file = "pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35"},
+    {file = "pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908"},
+    {file = "pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89"},
+    {file = "pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98"},
+    {file = "pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084"},
+    {file = "pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b"},
+    {file = "pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713"},
+    {file = "pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8"},
+    {file = "pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d"},
+    {file = "pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac"},
+    {file = "pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c"},
+    {file = "pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493"},
+    {file = "pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee"},
+    {file = "pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5"},
+    {file = "pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21"},
+    {file = "pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78"},
+    {file = "pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110"},
+    {file = "pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86"},
+    {file = "pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc"},
+    {file = "pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0"},
+    {file = "pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593"},
+    {file = "pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c"},
+    {file = "pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b"},
+    {file = "pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6"},
+    {file = "pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3"},
+    {file = "pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5"},
+    {file = "pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec"},
+    {file = "pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7"},
+    {file = "pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450"},
+    {file = "pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5"},
+    {file = "pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788"},
+    {file = "pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87"},
+    {file = "pandas-2.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c503ba5216814e295f40711470446bc3fd00f0faea8a086cbc688808e26f92a2"},
+    {file = "pandas-2.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a637c5cdfa04b6d6e2ecedcb81fc52ffb0fd78ce2ebccc9ea964df9f658de8c8"},
+    {file = "pandas-2.3.3-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:854d00d556406bffe66a4c0802f334c9ad5a96b4f1f868adf036a21b11ef13ff"},
+    {file = "pandas-2.3.3-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf1f8a81d04ca90e32a0aceb819d34dbd378a98bf923b6398b9a3ec0bf44de29"},
+    {file = "pandas-2.3.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:23ebd657a4d38268c7dfbdf089fbc31ea709d82e4923c5ffd4fbd5747133ce73"},
+    {file = "pandas-2.3.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5554c929ccc317d41a5e3d1234f3be588248e61f08a74dd17c9eabb535777dc9"},
+    {file = "pandas-2.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:d3e28b3e83862ccf4d85ff19cf8c20b2ae7e503881711ff2d534dc8f761131aa"},
+    {file = "pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b"},
+]
+
+[package.dependencies]
+numpy = {version = ">=1.22.4", markers = "python_version < \"3.11\""}
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.7"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
+aws = ["s3fs (>=2022.11.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
+compression = ["zstandard (>=0.19.0)"]
+computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
+feather = ["pyarrow (>=10.0.1)"]
+fss = ["fsspec (>=2022.11.0)"]
+gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
+hdf5 = ["tables (>=3.8.0)"]
+html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
+mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=10.0.1)"]
+performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
+plot = ["matplotlib (>=3.6.3)"]
+postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
+pyarrow = ["pyarrow (>=10.0.1)"]
+spss = ["pyreadstat (>=1.2.0)"]
+sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.9.2)"]
+
+[[package]]
+name = "pandas"
+version = "3.0.1"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "(sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\") and python_version >= \"3.11\""
+files = [
+    {file = "pandas-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de09668c1bf3b925c07e5762291602f0d789eca1b3a781f99c1c78f6cac0e7ea"},
+    {file = "pandas-3.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24ba315ba3d6e5806063ac6eb717504e499ce30bd8c236d8693a5fd3f084c796"},
+    {file = "pandas-3.0.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:406ce835c55bac912f2a0dcfaf27c06d73c6b04a5dde45f1fd3169ce31337389"},
+    {file = "pandas-3.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:830994d7e1f31dd7e790045235605ab61cff6c94defc774547e8b7fdfbff3dc7"},
+    {file = "pandas-3.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a64ce8b0f2de1d2efd2ae40b0abe7f8ae6b29fbfb3812098ed5a6f8e235ad9bf"},
+    {file = "pandas-3.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9832c2c69da24b602c32e0c7b1b508a03949c18ba08d4d9f1c1033426685b447"},
+    {file = "pandas-3.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:84f0904a69e7365f79a0c77d3cdfccbfb05bf87847e3a51a41e1426b0edb9c79"},
+    {file = "pandas-3.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:4a68773d5a778afb31d12e34f7dd4612ab90de8c6fb1d8ffe5d4a03b955082a1"},
+    {file = "pandas-3.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:476f84f8c20c9f5bc47252b66b4bb25e1a9fc2fa98cead96744d8116cb85771d"},
+    {file = "pandas-3.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ab749dfba921edf641d4036c4c21c0b3ea70fea478165cb98a998fb2a261955"},
+    {file = "pandas-3.0.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8e36891080b87823aff3640c78649b91b8ff6eea3c0d70aeabd72ea43ab069b"},
+    {file = "pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:532527a701281b9dd371e2f582ed9094f4c12dd9ffb82c0c54ee28d8ac9520c4"},
+    {file = "pandas-3.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:356e5c055ed9b0da1580d465657bc7d00635af4fd47f30afb23025352ba764d1"},
+    {file = "pandas-3.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9d810036895f9ad6345b8f2a338dd6998a74e8483847403582cab67745bff821"},
+    {file = "pandas-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:536232a5fe26dd989bd633e7a0c450705fdc86a207fec7254a55e9a22950fe43"},
+    {file = "pandas-3.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f463ebfd8de7f326d38037c7363c6dacb857c5881ab8961fb387804d6daf2f7"},
+    {file = "pandas-3.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5272627187b5d9c20e55d27caf5f2cd23e286aba25cadf73c8590e432e2b7262"},
+    {file = "pandas-3.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:661e0f665932af88c7877f31da0dc743fe9c8f2524bdffe23d24fdcb67ef9d56"},
+    {file = "pandas-3.0.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75e6e292ff898679e47a2199172593d9f6107fd2dd3617c22c2946e97d5df46e"},
+    {file = "pandas-3.0.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ff8cf1d2896e34343197685f432450ec99a85ba8d90cce2030c5eee2ef98791"},
+    {file = "pandas-3.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eca8b4510f6763f3d37359c2105df03a7a221a508f30e396a51d0713d462e68a"},
+    {file = "pandas-3.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06aff2ad6f0b94a17822cf8b83bbb563b090ed82ff4fe7712db2ce57cd50d9b8"},
+    {file = "pandas-3.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fea306c783e28884c29057a1d9baa11a349bbf99538ec1da44c8476563d1b25"},
+    {file = "pandas-3.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:a8d37a43c52917427e897cb2e429f67a449327394396a81034a4449b99afda59"},
+    {file = "pandas-3.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d54855f04f8246ed7b6fc96b05d4871591143c46c0b6f4af874764ed0d2d6f06"},
+    {file = "pandas-3.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e1b677accee34a09e0dc2ce5624e4a58a1870ffe56fc021e9caf7f23cd7668f"},
+    {file = "pandas-3.0.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9cabbdcd03f1b6cd254d6dda8ae09b0252524be1592594c00b7895916cb1324"},
+    {file = "pandas-3.0.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ae2ab1f166668b41e770650101e7090824fd34d17915dd9cd479f5c5e0065e9"},
+    {file = "pandas-3.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6bf0603c2e30e2cafac32807b06435f28741135cb8697eae8b28c7d492fc7d76"},
+    {file = "pandas-3.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6c426422973973cae1f4a23e51d4ae85974f44871b24844e4f7de752dd877098"},
+    {file = "pandas-3.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b03f91ae8c10a85c1613102c7bef5229b5379f343030a3ccefeca8a33414cf35"},
+    {file = "pandas-3.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:99d0f92ed92d3083d140bf6b97774f9f13863924cf3f52a70711f4e7588f9d0a"},
+    {file = "pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3b66857e983208654294bb6477b8a63dee26b37bdd0eb34d010556e91261784f"},
+    {file = "pandas-3.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56cf59638bf24dc9bdf2154c81e248b3289f9a09a6d04e63608c159022352749"},
+    {file = "pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1a9f55e0f46951874b863d1f3906dcb57df2d9be5c5847ba4dfb55b2c815249"},
+    {file = "pandas-3.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1849f0bba9c8a2fb0f691d492b834cc8dadf617e29015c66e989448d58d011ee"},
+    {file = "pandas-3.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3d288439e11b5325b02ae6e9cc83e6805a62c40c5a6220bea9beb899c073b1c"},
+    {file = "pandas-3.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:93325b0fe372d192965f4cca88d97667f49557398bbf94abdda3bf1b591dbe66"},
+    {file = "pandas-3.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:97ca08674e3287c7148f4858b01136f8bdfe7202ad25ad04fec602dd1d29d132"},
+    {file = "pandas-3.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:58eeb1b2e0fb322befcf2bbc9ba0af41e616abadb3d3414a6bc7167f6cbfce32"},
+    {file = "pandas-3.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cd9af1276b5ca9e298bd79a26bda32fa9cc87ed095b2a9a60978d2ca058eaf87"},
+    {file = "pandas-3.0.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f87a04984d6b63788327cd9f79dda62b7f9043909d2440ceccf709249ca988"},
+    {file = "pandas-3.0.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85fe4c4df62e1e20f9db6ebfb88c844b092c22cd5324bdcf94bfa2fc1b391221"},
+    {file = "pandas-3.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:331ca75a2f8672c365ae25c0b29e46f5ac0c6551fdace8eec4cd65e4fac271ff"},
+    {file = "pandas-3.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15860b1fdb1973fffade772fdb931ccf9b2f400a3f5665aef94a00445d7d8dd5"},
+    {file = "pandas-3.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:44f1364411d5670efa692b146c748f4ed013df91ee91e9bec5677fb1fd58b937"},
+    {file = "pandas-3.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:108dd1790337a494aa80e38def654ca3f0968cf4f362c85f44c15e471667102d"},
+    {file = "pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.26.0", markers = "python_version < \"3.14\""},
+    {version = ">=2.3.3", markers = "python_version >= \"3.14\""},
+]
+python-dateutil = ">=2.8.2"
+tzdata = {version = "*", markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""}
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)", "beautifulsoup4 (>=4.12.3)", "bottleneck (>=1.4.2)", "fastparquet (>=2024.11.0)", "fsspec (>=2024.10.0)", "gcsfs (>=2024.10.0)", "html5lib (>=1.1)", "hypothesis (>=6.116.0)", "jinja2 (>=3.1.5)", "lxml (>=5.3.0)", "matplotlib (>=3.9.3)", "numba (>=0.60.0)", "numexpr (>=2.10.2)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "psycopg2 (>=2.9.10)", "pyarrow (>=13.0.0)", "pyiceberg (>=0.8.1)", "pymysql (>=1.1.1)", "pyreadstat (>=1.2.8)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)", "python-calamine (>=0.3.0)", "pytz (>=2024.2)", "pyxlsb (>=1.0.10)", "qtpy (>=2.4.2)", "s3fs (>=2024.10.0)", "scipy (>=1.14.1)", "tables (>=3.10.1)", "tabulate (>=0.9.0)", "xarray (>=2024.10.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)", "zstandard (>=0.23.0)"]
+aws = ["s3fs (>=2024.10.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.4.2)"]
+compression = ["zstandard (>=0.23.0)"]
+computation = ["scipy (>=1.14.1)", "xarray (>=2024.10.0)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "python-calamine (>=0.3.0)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)"]
+feather = ["pyarrow (>=13.0.0)"]
+fss = ["fsspec (>=2024.10.0)"]
+gcp = ["gcsfs (>=2024.10.0)"]
+hdf5 = ["tables (>=3.10.1)"]
+html = ["beautifulsoup4 (>=4.12.3)", "html5lib (>=1.1)", "lxml (>=5.3.0)"]
+iceberg = ["pyiceberg (>=0.8.1)"]
+mysql = ["SQLAlchemy (>=2.0.36)", "pymysql (>=1.1.1)"]
+output-formatting = ["jinja2 (>=3.1.5)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=13.0.0)"]
+performance = ["bottleneck (>=1.4.2)", "numba (>=0.60.0)", "numexpr (>=2.10.2)"]
+plot = ["matplotlib (>=3.9.3)"]
+postgresql = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "psycopg2 (>=2.9.10)"]
+pyarrow = ["pyarrow (>=13.0.0)"]
+spss = ["pyreadstat (>=1.2.8)"]
+sql-other = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)"]
+test = ["hypothesis (>=6.116.0)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)"]
+timezone = ["pytz (>=2024.2)"]
+xml = ["lxml (>=5.3.0)"]
+
+[[package]]
 name = "pillow"
 version = "11.3.0"
 description = "Python Imaging Library (Fork)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
     {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
@@ -276,12 +609,69 @@ typing = ["typing-extensions ; python_version < \"3.10\""]
 xmp = ["defusedxml"]
 
 [[package]]
+name = "pyreadr"
+version = "0.5.4"
+description = "Reads/writes R RData and Rds files into/from pandas data frames."
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
+files = [
+    {file = "pyreadr-0.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9feb78c82641b57e33f6459362249d7e8db9b185e8596438708551ed9fe3a607"},
+    {file = "pyreadr-0.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5aaa7f25448698eb8a871b725477baf3b02bb05ceaad9a9208f0b03c821652c3"},
+    {file = "pyreadr-0.5.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79f0a72045ef8040b09578038a4aacb094b6f6a337e82e1e5c15424e7118bbb2"},
+    {file = "pyreadr-0.5.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:943d8c6ecc70ccb86c7a9ec3b659dc65886ee9a630543443b656474a03431552"},
+    {file = "pyreadr-0.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:faa5be4ec11a96bc5d8855ce46398fcb66990e0866058b24d7d0ad95e85912c3"},
+    {file = "pyreadr-0.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3e5aad55a467d05de870992c37657ef40fb5a241a831a0c5d403a128d5ad849e"},
+    {file = "pyreadr-0.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:16248c594dd23da8f651315972541b502f49bdd83e293fe3c863abe27e89c3fe"},
+    {file = "pyreadr-0.5.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe6445586cdd362a1f955b40f261631339c7152dc1f7d8aa246b4b3f22829994"},
+    {file = "pyreadr-0.5.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b983d8a4bc8033e448ea7bcef596afd791a3bb9bfaa631b51d3e2121b286f2f"},
+    {file = "pyreadr-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:8d745b0d501359c7172ee7df8080a2081015b4b636975d52baabbd42c2012638"},
+    {file = "pyreadr-0.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cae7b1588f2693c5bf6f4bc8b4dcffb87cdb184e38139fc587eb8519ed4e14b4"},
+    {file = "pyreadr-0.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f8698fb9c7f282a5b74f0c688f41830fde37cb1e2ff924dc8e5c94b16be6c0e4"},
+    {file = "pyreadr-0.5.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ada87f4c33267babf3f974d7e8a74d01b38c23f16441375323f9d7378abd3b6e"},
+    {file = "pyreadr-0.5.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5faf24517615bb8d30e7cc8a684a562f66496e415348823bf1f5f9fff7a39607"},
+    {file = "pyreadr-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:d0a5251cb2c36a7c72fffc689789d16d7d9f25ed28bd01e1ab35fc4ef66ef642"},
+    {file = "pyreadr-0.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9390ca0cdb99bc72d3125bbb28bf36a31d1ba8cd07d7512cd522e5630656e5be"},
+    {file = "pyreadr-0.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:53410aef1b517e814aedfc6f6dc25d5c6ff9ed07961971f5c7ef83e96846d1e7"},
+    {file = "pyreadr-0.5.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63fd4db6b279b9dd909d333fe441d001a5d199558aadf75b3e69d22027815fc7"},
+    {file = "pyreadr-0.5.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6564c003792c281ae49739f1938a146708640aacb7f97b04c7b47d6f86467f7a"},
+    {file = "pyreadr-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:ea541cc5248e0792a93caa1d79aea83a52561a8de72bb01a395c28bf352c4c6c"},
+    {file = "pyreadr-0.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4bd6c2a12ffa9e71c34ec6732f1ef811217d81a97ac644ad90d6b36ef0ac48ba"},
+    {file = "pyreadr-0.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9af6b4bffbf17bdf9b8b6bf06d1e217d1ab791d9b42450bd4753e294fb414c94"},
+    {file = "pyreadr-0.5.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54292e3745533d267a856394c4d019330219f36e838898c9b387da05bb99a220"},
+    {file = "pyreadr-0.5.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e247d2b69bfb636f7e1c15df7360829f7eff4af0736d2dc0c495747cb86c69ac"},
+    {file = "pyreadr-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:730041e7f46fce79b40e54bdbbb7cd2bcb96951163d0962221b7a11b7c46157f"},
+    {file = "pyreadr-0.5.4.tar.gz", hash = "sha256:05b18cc830dceda3ef3d477bd8e50f072474e177f0cf67b6ad4fb3d7f3de11fd"},
+]
+
+[package.dependencies]
+pandas = ">=1.2.0"
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pytz"
 version = "2024.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
     {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
@@ -294,6 +684,7 @@ description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -377,6 +768,7 @@ description = "Alternative regular expression module, to replace re."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "regex-2026.1.15-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4e3dd93c8f9abe8aa4b6c652016da9a3afa190df5ad822907efe6b206c09896e"},
     {file = "regex-2026.1.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:97499ff7862e868b1977107873dd1a06e151467129159a6ffd07b66706ba3a9f"},
@@ -518,6 +910,7 @@ description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -534,12 +927,39 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or python_version < \"3.11\" and sys_platform != \"win32\" and sys_platform != \"emscripten\""
+files = [
+    {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
+    {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
@@ -554,4 +974,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "4a15df2157e3c5596e78c56ff477d4bc155e4a40f0e2bb7b7a9ae44d861080a4"
+content-hash = "f84f1d560d2dadb929fe75948eadc0e6f6ac7790846c24dddf138ddf47ceed5c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requests = "^2.31.0"
 pytz = "^2024.1"
 regex = "^2026.1.15"
 pyyaml = "^6.0.0"
+pyreadr = "^0.5.4"
 
 
 [build-system]

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,32 @@
+"""Canonical config loader. Every standalone script imports this."""
+import os
+import yaml
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DEFAULT_CONFIG = os.path.join(_REPO_ROOT, 'config', 'config.yaml')
+
+
+def load_config(config_path=None):
+    """Load config.yaml from default path or given path. Returns dict."""
+    path = config_path or _DEFAULT_CONFIG
+    try:
+        with open(path, 'r') as f:
+            data = yaml.safe_load(f)
+            return data if data else {}
+    except FileNotFoundError:
+        print(f"Config file not found: {path}")
+        return {}
+    except Exception as e:
+        print(f"Error loading config: {e}")
+        return {}
+
+
+def add_config_arg(parser):
+    """Add --config PATH argument to any ArgumentParser."""
+    parser.add_argument(
+        '--config',
+        type=str,
+        default=None,
+        metavar='PATH',
+        help=f'Path to config.yaml (default: {_DEFAULT_CONFIG})',
+    )

--- a/src/display.py
+++ b/src/display.py
@@ -1,0 +1,67 @@
+"""
+Thin wrapper over display_eink.py with a CLI.
+
+Standalone CLI:
+    python src/display.py --image output/scoreboard.bmp [--full-refresh] [--config PATH]
+"""
+import os
+import sys
+import argparse
+
+# Allow running as a standalone script from any directory
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from PIL import Image
+from display_eink import display_image, display_partial_regions
+from refresh_tracker import needs_full_refresh
+from config_loader import load_config, add_config_arg
+
+
+def send_to_display(image_path, changed_regions=None, force_full=False):
+    """
+    Load image from path and push to e-ink.
+
+    Args:
+        image_path: Path to the image file to display
+        changed_regions: List of (x, y, w, h) tuples for partial refresh, or None
+        force_full: Force a full refresh even if partial is possible
+
+    Returns:
+        'full' or 'partial'
+    """
+    image = Image.open(image_path)
+    if force_full or needs_full_refresh() or not changed_regions:
+        display_image(image, output_filename=image_path)
+        return 'full'
+    else:
+        display_partial_regions(image, changed_regions, output_filename=image_path)
+        return 'partial'
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Send an image file to the e-ink display',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  python src/display.py --image resulting_image.bmp
+  python src/display.py --image resulting_image.bmp --full-refresh
+        ''',
+    )
+    parser.add_argument('--image', type=str, required=True,
+                        help='Path to image file to display')
+    parser.add_argument('--full-refresh', action='store_true',
+                        help='Force a full e-ink refresh')
+    add_config_arg(parser)
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.image):
+        print(f"Error: image file not found: {args.image}")
+        sys.exit(1)
+
+    mode = send_to_display(args.image, force_full=args.full_refresh)
+    print(f"Display updated ({mode} refresh)")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/extract_mlbam_walls.py
+++ b/src/extract_mlbam_walls.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""extract_mlbam_walls.py — Extract outfield wall shapes from MLBAM stadium data.
+
+Reads the MLBStadiumsPathData dataset (from the GeomMLBStadiums R package)
+and outputs detailed wall polygons for all 30 MLB stadiums.
+
+Data source: https://github.com/bdilday/GeomMLBStadiums
+The dataset contains MLBAM's canonical wall shapes used on Baseball Savant
+spray charts, with 100 `outfield_outer` coordinate points per stadium.
+
+Coordinate transform (MLBAM hc_x/hc_y → field feet):
+    x_ft = 2.495671 * (hc_x - 125.0)
+    y_ft = 2.495671 * (199.0 - hc_y)
+    Home plate at (0, 0), +x = RF, +y = CF
+
+Usage:
+    python3 src/extract_mlbam_walls.py /tmp/MLBStadiaPathData.rda
+    python3 src/extract_mlbam_walls.py /tmp/MLBStadiaPathData.rda --epsilon 3.0
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+
+import pyreadr
+
+# MLBAM coordinate transform constants
+_SCALE = 2.495671
+_HC_X_CENTER = 125.0
+_HC_Y_CENTER = 199.0
+
+# Minimum distance from home plate (feet) to be considered part of the wall
+_MIN_WALL_DIST = 280.0
+
+# Map from MLBAM team key to stadium name (matching stadium_polygons.py)
+_TEAM_TO_STADIUM = {
+    'angels':       'Angel Stadium',
+    'astros':       'Minute Maid Park',
+    'athletics':    'Oakland Coliseum',
+    'blue_jays':    'Rogers Centre',
+    'braves':       'Truist Park',
+    'brewers':      'American Family Field',
+    'cardinals':    'Busch Stadium',
+    'cubs':         'Wrigley Field',
+    'diamondbacks': 'Chase Field',
+    'dodgers':      'Dodger Stadium',
+    'giants':       'Oracle Park',
+    'guardians':    'Progressive Field',
+    'mariners':     'T-Mobile Park',
+    'marlins':      'loanDepot park',
+    'mets':         'Citi Field',
+    'nationals':    'Nationals Park',
+    'orioles':      'Camden Yards',
+    'padres':       'Petco Park',
+    'phillies':     'Citizens Bank Park',
+    'pirates':      'PNC Park',
+    'rangers':      'Globe Life Field',
+    'rays':         'Tropicana Field',
+    'red_sox':      'Fenway Park',
+    'reds':         'Great American Ball Park',
+    'rockies':      'Coors Field',
+    'royals':       'Kauffman Stadium',
+    'tigers':       'Comerica Park',
+    'twins':        'Target Field',
+    'white_sox':    'Guaranteed Rate Field',
+    'yankees':      'Yankee Stadium',
+}
+
+
+def _mlbam_to_field(hc_x, hc_y):
+    """Transform MLBAM coordinates to field feet (home plate at origin)."""
+    x_ft = _SCALE * (hc_x - _HC_X_CENTER)
+    y_ft = _SCALE * (_HC_Y_CENTER - hc_y)
+    return x_ft, y_ft
+
+
+def _extract_wall_arc(points):
+    """Extract the contiguous wall arc from outfield_outer points.
+
+    Filters to points with distance > _MIN_WALL_DIST from home plate,
+    keeping only the longest contiguous run to avoid stray near-home points.
+    Orders points from LF (most-negative x) to RF (most-positive x).
+    """
+    # Tag each point with its distance
+    tagged = []
+    for x, y in points:
+        dist = math.sqrt(x * x + y * y)
+        tagged.append((x, y, dist))
+
+    # Find contiguous runs of points with dist > threshold
+    runs = []
+    current_run = []
+    for x, y, dist in tagged:
+        if dist > _MIN_WALL_DIST:
+            current_run.append((x, y))
+        else:
+            if current_run:
+                runs.append(current_run)
+                current_run = []
+    if current_run:
+        runs.append(current_run)
+
+    if not runs:
+        return []
+
+    # Take the longest contiguous run
+    wall = max(runs, key=len)
+
+    # Sort LF to RF (most-negative x to most-positive x)
+    # The data is already ordered around the arc, but we want LF→RF
+    # Check if first point is on LF or RF side
+    if wall[0][0] > wall[-1][0]:
+        wall = list(reversed(wall))
+
+    return wall
+
+
+def extract_all(rda_path, epsilon=None):
+    """Extract wall polygons from the RDA file.
+
+    Returns dict of stadium_name → [(x_ft, y_ft), ...].
+    """
+    result = pyreadr.read_r(rda_path)
+    df = result['MLBStadiumsPathData']
+
+    walls = {}
+    for team_key, stadium_name in sorted(_TEAM_TO_STADIUM.items()):
+        oo = df[(df['team'] == team_key) & (df['segment'] == 'outfield_outer')]
+        if oo.empty:
+            print(f'  WARNING: no outfield_outer data for {team_key}', file=sys.stderr)
+            continue
+
+        # Transform all points
+        field_pts = [_mlbam_to_field(row['x'], row['y']) for _, row in oo.iterrows()]
+
+        # Extract wall arc
+        wall = _extract_wall_arc(field_pts)
+        if not wall:
+            print(f'  WARNING: no wall points for {team_key}', file=sys.stderr)
+            continue
+
+        # Optional RDP simplification
+        if epsilon is not None:
+            from fetch_stadium_polygons import rdp_simplify
+            wall = rdp_simplify(wall, epsilon=epsilon)
+
+        # Round to 1 decimal
+        wall = [(round(x, 1), round(y, 1)) for x, y in wall]
+        walls[stadium_name] = wall
+        dists = [round(math.sqrt(x**2 + y**2)) for x, y in wall]
+        print(f'  {stadium_name:<30s} {len(wall):2d} pts  '
+              f'LF={dists[0]}  CF={max(dists)}  RF={dists[-1]}')
+
+    return walls
+
+
+def save_json(walls, output_path):
+    """Save wall data as JSON."""
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, 'w') as fh:
+        json.dump(
+            {name: [[x, y] for x, y in pts] for name, pts in walls.items()},
+            fh,
+            indent=2,
+        )
+    return output_path
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Extract outfield wall shapes from MLBAM stadium data.')
+    parser.add_argument('rda_path', help='Path to MLBStadiaPathData.rda')
+    parser.add_argument('--out', default='data/mlbam_walls.json',
+                        help='Output JSON path (default: data/mlbam_walls.json)')
+    parser.add_argument('--epsilon', type=float, default=None,
+                        help='RDP simplification tolerance in feet (omit for no simplification)')
+    args = parser.parse_args()
+
+    # Resolve output path relative to repo root
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    out_path = os.path.join(root, args.out)
+
+    # Add src to path for fetch_stadium_polygons import
+    sys.path.insert(0, os.path.join(root, 'src'))
+
+    print('Extracting MLBAM wall data...')
+    walls = extract_all(args.rda_path, epsilon=args.epsilon)
+    print(f'\nExtracted {len(walls)} stadiums')
+
+    path = save_json(walls, out_path)
+    print(f'Saved → {path}')

--- a/src/fetch_stadium_polygons.py
+++ b/src/fetch_stadium_polygons.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""fetch_stadium_polygons.py — Fetch and parse Baseball Savant park SVGs.
+
+NOTE: The Baseball Savant park SVG endpoint is not publicly accessible (returns
+404). This script is kept as a utility for future use if SVG access becomes
+available. The primary data source for stadium wall polygons is now the
+MLB Stats API fieldInfo endpoint combined with known wall topology research,
+stored directly in stadium_polygons.py.
+
+If the Savant SVG URL changes in the future, update SVG_URL and test with:
+    python3 src/fetch_stadium_polygons.py --probe 3
+
+Outputs Cartesian (x_ft, y_ft) wall polygons for all 30 MLB stadiums.
+The result is printed as Python-literal dict entries that can be pasted
+directly into the STADIUM_POLYGONS dict in stadium_polygons.py.
+
+Usage:
+    python3 src/fetch_stadium_polygons.py               # all stadiums
+    python3 src/fetch_stadium_polygons.py Fenway        # single park (fuzzy match)
+    python3 src/fetch_stadium_polygons.py --probe 3     # dump raw SVG paths for venueId=3
+
+Coordinate system (output):
+    Home plate = (0, 0) in feet
+    +x = RF / 1B side,  -x = LF / 3B side,  +y = toward CF
+
+Baseball Savant SVG coordinate system (input, when available):
+    Home plate ≈ (125.42, 204.5) in SVG units.
+    1 SVG unit ≈ 1 foot.  Y increases downward (SVG convention).
+    Transform: x_ft = svg_x - 125.42,  y_ft = 204.5 - svg_y
+"""
+
+import json
+import math
+import os
+import re
+import sys
+import time
+import urllib.request
+import xml.etree.ElementTree as ET
+from urllib.error import URLError, HTTPError
+
+# ---------------------------------------------------------------------------
+# Venue ID map (MLB Stats API venueId for all active 2024/2025 parks)
+# ---------------------------------------------------------------------------
+VENUE_IDS = {
+    # AL East
+    'Yankee Stadium':             3313,
+    'Fenway Park':                3,
+    'Camden Yards':               2,
+    'Rogers Centre':              14,
+    'Tropicana Field':            12,
+    # AL Central
+    'Guaranteed Rate Field':      4,
+    'Progressive Field':          5,
+    'Comerica Park':              2394,
+    'Kauffman Stadium':           7,
+    'Target Field':               3312,
+    # AL West
+    'Minute Maid Park':           2392,
+    'Angel Stadium':              1,
+    'T-Mobile Park':              680,
+    'Globe Life Field':           5325,
+    'Sutter Health Park':         2529,  # A's in Sacramento 2025
+    # NL East
+    'Truist Park':                4705,
+    'Citi Field':                 3289,
+    'Citizens Bank Park':         2681,
+    'Nationals Park':             3309,
+    'loanDepot park':             4169,
+    # NL Central
+    'Wrigley Field':              17,
+    'Great American Ball Park':   2602,
+    'American Family Field':      32,
+    'PNC Park':                   31,
+    'Busch Stadium':              2889,
+    # NL West
+    'Dodger Stadium':             22,
+    'Chase Field':                15,
+    'Coors Field':                16,
+    'Oracle Park':                2395,
+    'Petco Park':                 2680,
+}
+
+# URL template for Baseball Savant park SVGs
+SVG_URL = 'https://baseballsavant.mlb.com/assets/img/gameday/park-SVGs/{venue_id}.svg'
+
+# Home plate anchor in SVG coordinate space (SVG units ≈ feet)
+HOME_PLATE_SVG_X = 125.42
+HOME_PLATE_SVG_Y = 204.5
+
+# Cache directory for raw SVG files (avoid re-fetching)
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CACHE_DIR = os.path.join(_ROOT, 'data', 'savant_svgs')
+
+# SVG namespaces used by Baseball Savant
+_NS = {'svg': 'http://www.w3.org/2000/svg'}
+
+
+# ---------------------------------------------------------------------------
+# Fetch and cache
+# ---------------------------------------------------------------------------
+
+def fetch_svg(venue_id, force_refresh=False):
+    """Return raw SVG bytes for *venue_id*, using disk cache when available."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    cache_path = os.path.join(CACHE_DIR, f'{venue_id}.svg')
+
+    if not force_refresh and os.path.exists(cache_path):
+        with open(cache_path, 'rb') as fh:
+            return fh.read()
+
+    url = SVG_URL.format(venue_id=venue_id)
+    try:
+        req = urllib.request.Request(url, headers={'User-Agent': 'mlb-display/1.0'})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = resp.read()
+    except HTTPError as e:
+        print(f'    HTTP {e.code} for venueId={venue_id}', file=sys.stderr)
+        return None
+    except URLError as e:
+        print(f'    URL error for venueId={venue_id}: {e.reason}', file=sys.stderr)
+        return None
+
+    with open(cache_path, 'wb') as fh:
+        fh.write(data)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# SVG path parsing
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r'([MmLlHhVvCcSsQqTtAaZz])|([+-]?[0-9]*\.?[0-9]+(?:[eE][+-]?[0-9]+)?)')
+
+
+def _parse_path_d(d):
+    """Parse an SVG path `d` attribute into a flat list of (cmd, [args]) tuples.
+
+    Only M, L, H, V, C, S, Q, T, Z are handled (no A arcs — none in MLB SVGs).
+    Returns a list of absolute (x, y) coordinate pairs representing the path.
+    """
+    tokens = _TOKEN_RE.findall(d)
+    # tokens is list of (cmd_or_empty, num_or_empty)
+    items = []
+    for cmd_tok, num_tok in tokens:
+        if cmd_tok:
+            items.append(('CMD', cmd_tok))
+        elif num_tok:
+            items.append(('NUM', float(num_tok)))
+
+    points = []
+    cmd = 'M'
+    cx, cy = 0.0, 0.0  # current position
+    nums = []
+    i = 0
+
+    def consume_nums(count):
+        nonlocal i
+        result = []
+        while len(result) < count and i < len(items):
+            if items[i][0] == 'NUM':
+                result.append(items[i][1])
+                i += 1
+            else:
+                break
+        return result
+
+    while i < len(items):
+        t, v = items[i]
+        if t == 'CMD':
+            cmd = v
+            i += 1
+            continue
+
+        # Consume coordinates for current command
+        if cmd in ('M', 'm'):
+            xy = consume_nums(2)
+            if len(xy) < 2:
+                break
+            if cmd == 'm':
+                cx, cy = cx + xy[0], cy + xy[1]
+            else:
+                cx, cy = xy[0], xy[1]
+            points.append((cx, cy))
+            # Subsequent pairs treated as implicit lineto
+            cmd = 'l' if cmd == 'm' else 'L'
+
+        elif cmd in ('L', 'l'):
+            xy = consume_nums(2)
+            if len(xy) < 2:
+                break
+            if cmd == 'l':
+                cx, cy = cx + xy[0], cy + xy[1]
+            else:
+                cx, cy = xy[0], xy[1]
+            points.append((cx, cy))
+
+        elif cmd in ('H', 'h'):
+            n = consume_nums(1)
+            if not n:
+                break
+            cx = (cx + n[0]) if cmd == 'h' else n[0]
+            points.append((cx, cy))
+
+        elif cmd in ('V', 'v'):
+            n = consume_nums(1)
+            if not n:
+                break
+            cy = (cy + n[0]) if cmd == 'v' else n[0]
+            points.append((cx, cy))
+
+        elif cmd in ('C', 'c'):
+            # Cubic bezier — 6 params, take endpoint + 2 intermediate samples
+            xy6 = consume_nums(6)
+            if len(xy6) < 6:
+                break
+            if cmd == 'c':
+                p1x, p1y = cx + xy6[0], cy + xy6[1]
+                p2x, p2y = cx + xy6[2], cy + xy6[3]
+                ex, ey   = cx + xy6[4], cy + xy6[5]
+            else:
+                p1x, p1y = xy6[0], xy6[1]
+                p2x, p2y = xy6[2], xy6[3]
+                ex, ey   = xy6[4], xy6[5]
+            # Sample bezier at t=0.33 and t=0.67 to preserve curve shape
+            for t in (0.33, 0.67):
+                mt = 1 - t
+                bx = mt**3*cx + 3*mt**2*t*p1x + 3*mt*t**2*p2x + t**3*ex
+                by = mt**3*cy + 3*mt**2*t*p1y + 3*mt*t**2*p2y + t**3*ey
+                points.append((bx, by))
+            points.append((ex, ey))
+            cx, cy = ex, ey
+
+        elif cmd in ('S', 's'):
+            # Smooth cubic bezier — 4 params
+            xy4 = consume_nums(4)
+            if len(xy4) < 4:
+                break
+            if cmd == 's':
+                p2x, p2y = cx + xy4[0], cy + xy4[1]
+                ex, ey   = cx + xy4[2], cy + xy4[3]
+            else:
+                p2x, p2y = xy4[0], xy4[1]
+                ex, ey   = xy4[2], xy4[3]
+            # Reflection of previous control point — use p2 only (approximation)
+            for t in (0.33, 0.67):
+                mt = 1 - t
+                bx = mt**2*cx + 2*mt*t*p2x + t**2*ex
+                by = mt**2*cy + 2*mt*t*p2y + t**2*ey
+                points.append((bx, by))
+            points.append((ex, ey))
+            cx, cy = ex, ey
+
+        elif cmd in ('Q', 'q'):
+            # Quadratic bezier — 4 params
+            xy4 = consume_nums(4)
+            if len(xy4) < 4:
+                break
+            if cmd == 'q':
+                p1x, p1y = cx + xy4[0], cy + xy4[1]
+                ex, ey   = cx + xy4[2], cy + xy4[3]
+            else:
+                p1x, p1y = xy4[0], xy4[1]
+                ex, ey   = xy4[2], xy4[3]
+            for t in (0.33, 0.67):
+                mt = 1 - t
+                bx = mt**2*cx + 2*mt*t*p1x + t**2*ex
+                by = mt**2*cy + 2*mt*t*p1y + t**2*ey
+                points.append((bx, by))
+            points.append((ex, ey))
+            cx, cy = ex, ey
+
+        elif cmd in ('T', 't'):
+            xy = consume_nums(2)
+            if len(xy) < 2:
+                break
+            if cmd == 't':
+                cx, cy = cx + xy[0], cy + xy[1]
+            else:
+                cx, cy = xy[0], xy[1]
+            points.append((cx, cy))
+
+        elif cmd in ('Z', 'z'):
+            # Close path — stop collecting
+            break
+
+        else:
+            # Unknown command — skip
+            i += 1
+
+    return points
+
+
+# ---------------------------------------------------------------------------
+# Coordinate transform: SVG → field feet
+# ---------------------------------------------------------------------------
+
+def svg_to_field(svg_x, svg_y):
+    """Transform a Baseball Savant SVG point to field-foot coordinates.
+
+    Baseball Savant SVG space:
+        - home plate ≈ (125.42, 204.5)
+        - Y increases downward
+        - units are approximately feet
+
+    Field space (this project):
+        - home plate = (0, 0)
+        - +x = RF (1B side), -x = LF (3B side)
+        - +y = toward CF
+    """
+    x_ft = svg_x - HOME_PLATE_SVG_X
+    y_ft = HOME_PLATE_SVG_Y - svg_y   # flip Y
+    return x_ft, y_ft
+
+
+# ---------------------------------------------------------------------------
+# Path bounding-box area helper
+# ---------------------------------------------------------------------------
+
+def _bbox_area(points):
+    """Return bounding box area of a list of (x,y) SVG points."""
+    if not points:
+        return 0.0
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    return (max(xs) - min(xs)) * (max(ys) - min(ys))
+
+
+# ---------------------------------------------------------------------------
+# Wall path extraction
+# ---------------------------------------------------------------------------
+
+# IDs / CSS classes that typically identify the outfield wall in Savant SVGs
+_WALL_IDS = {'outfield_outer', 'fence', 'wall', 'of-fence', 'outfield-fence', 'fence_outer'}
+_WALL_CLASSES = {'outfield_outer', 'fence', 'wall'}
+
+
+def _extract_paths(svg_bytes):
+    """Return list of (id_attr, class_attr, raw_d) for every <path> element in the SVG."""
+    try:
+        root = ET.fromstring(svg_bytes)
+    except ET.ParseError as e:
+        print(f'  SVG parse error: {e}', file=sys.stderr)
+        return []
+
+    paths = []
+    # Walk the entire tree (handles nested groups)
+    for el in root.iter():
+        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
+        if tag == 'path':
+            d = el.get('d', '')
+            if d:
+                paths.append({
+                    'id':    el.get('id', ''),
+                    'class': el.get('class', ''),
+                    'd':     d,
+                })
+    return paths
+
+
+def find_wall_path(svg_bytes, probe=False):
+    """Return the outfield wall path `d` string from raw SVG bytes.
+
+    Strategy:
+      1. Look for a <path> whose id or class matches known wall identifiers.
+      2. Fall back to the <path> with the largest bounding-box area.
+
+    Returns (d_string, id_used) or (None, None) on failure.
+    """
+    paths = _extract_paths(svg_bytes)
+    if not paths:
+        return None, None
+
+    if probe:
+        print(f'\n  Found {len(paths)} path elements:')
+        for p in paths:
+            pts = _parse_path_d(p['d'])
+            area = _bbox_area(pts)
+            print(f"    id={p['id']!r:30s}  class={p['class']!r:20s}  pts={len(pts):4d}  bbox_area={area:.0f}")
+        print()
+
+    # Priority 1: id match
+    for p in paths:
+        if p['id'].lower() in _WALL_IDS:
+            return p['d'], f"id={p['id']!r}"
+
+    # Priority 2: class match
+    for p in paths:
+        cls = set(p['class'].lower().split())
+        if cls & _WALL_CLASSES:
+            return p['d'], f"class={p['class']!r}"
+
+    # Fallback: largest bounding box area
+    best = max(paths, key=lambda p: _bbox_area(_parse_path_d(p['d'])))
+    return best['d'], f"id={best['id']!r} (fallback: largest bbox)"
+
+
+# ---------------------------------------------------------------------------
+# Douglas-Peucker simplification
+# ---------------------------------------------------------------------------
+
+def _perp_dist(pt, line_start, line_end):
+    """Perpendicular distance from *pt* to the line through *line_start*→*line_end*."""
+    x0, y0 = pt
+    x1, y1 = line_start
+    x2, y2 = line_end
+    dx, dy = x2 - x1, y2 - y1
+    if dx == dy == 0:
+        return math.hypot(x0 - x1, y0 - y1)
+    return abs(dy * x0 - dx * y0 + x2 * y1 - y2 * x1) / math.hypot(dx, dy)
+
+
+def rdp_simplify(points, epsilon=2.0):
+    """Ramer-Douglas-Peucker polyline simplification with tolerance *epsilon* feet."""
+    if len(points) <= 2:
+        return list(points)
+    # Find point with max distance from start-end line
+    max_dist = 0.0
+    max_idx = 0
+    for i in range(1, len(points) - 1):
+        d = _perp_dist(points[i], points[0], points[-1])
+        if d > max_dist:
+            max_dist = d
+            max_idx = i
+    if max_dist > epsilon:
+        left  = rdp_simplify(points[:max_idx + 1], epsilon)
+        right = rdp_simplify(points[max_idx:], epsilon)
+        return left[:-1] + right
+    return [points[0], points[-1]]
+
+
+# ---------------------------------------------------------------------------
+# Trim polygon to outfield arc (drop points behind home plate)
+# ---------------------------------------------------------------------------
+
+def trim_to_outfield(field_pts):
+    """Keep only points with y_ft > -10 (i.e., at or past home plate level)."""
+    return [(x, y) for x, y in field_pts if y > -10.0]
+
+
+def sort_lf_to_rf(field_pts):
+    """Sort points left (most-negative x) to right (most-positive x)."""
+    return sorted(field_pts, key=lambda p: p[0])
+
+
+# ---------------------------------------------------------------------------
+# Main extraction pipeline
+# ---------------------------------------------------------------------------
+
+def extract_wall_polygon(svg_bytes, probe=False, epsilon=2.0):
+    """Full pipeline: SVG bytes → simplified [(x_ft, y_ft)] wall polygon.
+
+    Returns (points, method_note) or (None, error_message).
+    """
+    d, method = find_wall_path(svg_bytes, probe=probe)
+    if d is None:
+        return None, 'no path found'
+
+    # Parse SVG path to raw SVG coordinate list
+    raw_svg_pts = _parse_path_d(d)
+    if not raw_svg_pts:
+        return None, 'path parsed to 0 points'
+
+    # Transform to field feet
+    field_pts = [svg_to_field(x, y) for x, y in raw_svg_pts]
+
+    # Filter to outfield arc
+    field_pts = trim_to_outfield(field_pts)
+    if not field_pts:
+        return None, 'no points in outfield region'
+
+    # Sort LF → RF
+    field_pts = sort_lf_to_rf(field_pts)
+
+    # Simplify
+    simplified = rdp_simplify(field_pts, epsilon=epsilon)
+
+    return simplified, method
+
+
+# ---------------------------------------------------------------------------
+# Probe a single venue to inspect SVG structure
+# ---------------------------------------------------------------------------
+
+def probe_venue(venue_id):
+    """Fetch and dump all path elements for *venue_id* for manual inspection."""
+    print(f'\nProbing venueId={venue_id}...')
+    data = fetch_svg(venue_id)
+    if data is None:
+        print('  Failed to fetch SVG')
+        return
+    d, method = find_wall_path(data, probe=True)
+    if d is None:
+        return
+    print(f'  Selected path via: {method}')
+    pts = _parse_path_d(d)
+    print(f'  Raw points: {len(pts)}')
+    field_pts = [svg_to_field(x, y) for x, y in pts]
+    field_pts = trim_to_outfield(field_pts)
+    field_pts = sort_lf_to_rf(field_pts)
+    simplified = rdp_simplify(field_pts, epsilon=2.0)
+    print(f'  Simplified points ({len(simplified)}):')
+    for x, y in simplified:
+        dist = math.sqrt(x**2 + y**2)
+        print(f'    ({x:7.1f}, {y:7.1f})  dist={dist:.0f} ft')
+
+
+# ---------------------------------------------------------------------------
+# Process all venues
+# ---------------------------------------------------------------------------
+
+def process_all(name_filter=None, epsilon=2.0, force_refresh=False):
+    """Fetch and parse all venues, returning dict of name → [(x_ft, y_ft)]."""
+    results = {}
+    seen_ids = {}  # venue_id → first name, to avoid duplicate fetches
+
+    for name, vid in VENUE_IDS.items():
+        if name_filter and name_filter.lower() not in name.lower():
+            continue
+        if vid is None:
+            print(f'  {name}: SKIP (no venueId)')
+            continue
+        if vid in seen_ids:
+            print(f'  {name}: SKIP (same venueId={vid} as {seen_ids[vid]})')
+            continue
+        seen_ids[vid] = name
+
+        print(f'  {name} (venueId={vid})...', end=' ', flush=True)
+        data = fetch_svg(vid, force_refresh=force_refresh)
+        if data is None:
+            print('FAILED')
+            continue
+
+        pts, method = extract_wall_polygon(data, epsilon=epsilon)
+        if pts is None:
+            print(f'ERROR: {method}')
+            continue
+
+        # Validate: should have at least 5 points and wall points should be >200 ft from home
+        dists = [math.sqrt(x**2 + y**2) for x, y in pts]
+        if len(pts) < 5 or max(dists) < 200:
+            print(f'WARNING: suspicious result ({len(pts)} pts, max dist={max(dists):.0f} ft)')
+
+        results[name] = pts
+        print(f'{len(pts)} pts  [{method}]')
+        time.sleep(0.1)  # polite rate limiting
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def format_python_literal(results):
+    """Return a Python dict literal string suitable for pasting into stadium_polygons.py."""
+    lines = ['STADIUM_POLYGONS = {']
+    for name, pts in results.items():
+        pts_str = ', '.join(f'({x:.1f}, {y:.1f})' for x, y in pts)
+        lines.append(f"    {name!r}: [{pts_str}],")
+    lines.append('}')
+    return '\n'.join(lines)
+
+
+def save_json(results, path):
+    """Save results as JSON array (same schema as stadium_polygons.export_json)."""
+    from stadium_polygons import TEAM_NAMES
+    records = [
+        {
+            'stadium': name,
+            'team': TEAM_NAMES.get(name, ''),
+            'wall_polygon': [[round(x, 1), round(y, 1)] for x, y in pts],
+        }
+        for name, pts in results.items()
+    ]
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as fh:
+        json.dump(records, fh, indent=2)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Fetch Baseball Savant park SVGs and extract outfield wall polygons.')
+    parser.add_argument('stadium', nargs='?', default=None,
+                        help='Stadium name filter (fuzzy match). Omit for all 30.')
+    parser.add_argument('--probe', metavar='VENUE_ID', type=int, default=None,
+                        help='Dump all SVG path elements for a venue ID (debug mode)')
+    parser.add_argument('--epsilon', type=float, default=2.0,
+                        help='RDP simplification tolerance in feet (default: 2.0)')
+    parser.add_argument('--refresh', action='store_true',
+                        help='Force re-fetch (ignore disk cache)')
+    parser.add_argument('--json', default=None,
+                        help='Also save results to JSON file')
+    args = parser.parse_args()
+
+    # Add src dir to path so we can import stadium_polygons for TEAM_NAMES
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+    if args.probe is not None:
+        probe_venue(args.probe)
+        sys.exit(0)
+
+    print('Fetching park SVGs from Baseball Savant...')
+    results = process_all(
+        name_filter=args.stadium,
+        epsilon=args.epsilon,
+        force_refresh=args.refresh,
+    )
+
+    if not results:
+        print('No results.', file=sys.stderr)
+        sys.exit(1)
+
+    print(f'\n--- Python literal (paste into stadium_polygons.py) ---\n')
+    print(format_python_literal(results))
+
+    if args.json:
+        path = save_json(results, args.json)
+        print(f'\nSaved JSON → {path}')

--- a/src/field_view.py
+++ b/src/field_view.py
@@ -5,7 +5,7 @@ from PIL import Image, ImageDraw, ImageFont, ImageOps
 from generate_image import (
     picdir, _logo_small, _load_logo_gray, draw_diamond, draw_circle,
 )
-from stadium_polygons import get_polygon, dimensions_to_polygon
+from stadium_polygons import get_polygon
 
 EPD_WIDTH = 800
 EPD_HEIGHT = 480
@@ -26,10 +26,14 @@ MOUND = (200, 375)
 FIELD_SCALE = 0.75
 
 # Fallback wall polygon used when the venue isn't recognized.
-# Cartesian (x_ft, y_ft) with home plate at origin, +Y toward CF.
-_DEFAULT_WALL_POLY = dimensions_to_polygon(
-    [(330,-45),(360,-33),(375,-22.5),(392,-11),(400,0),(392,11),(375,22.5),(360,33),(330,45)]
-)
+# Generic symmetric 400-ft park. Cartesian (x_ft, y_ft), home plate at origin.
+_DEFAULT_WALL_POLY = [
+    (-233.3, 233.3),   # LF foul pole, 330 ft
+    (-109.6, 343.6),   # LF-CF gap, 360 ft
+    (0.0,    400.0),   # deep CF, 400 ft
+    (109.6,  343.6),   # RF-CF gap, 360 ft
+    (233.3,  233.3),   # RF foul pole, 330 ft
+]
 
 
 def _load_fonts():
@@ -115,12 +119,17 @@ def _draw_field(draw, data, fonts=None):
             (bx, by + base_size), (bx - base_size, by),
         ], outline=0)
 
-    # Distance labels: foul poles + deepest CF point + intermediate labeled points
+    # Distance labels: foul poles, deepest CF, and power alleys
     font_tiny = fonts.get('f9') if fonts else None
     if font_tiny:
         def _dist(xy):
             return round(math.sqrt(xy[0] ** 2 + xy[1] ** 2))
 
+        def _angle(xy):
+            """Bearing in degrees from CF axis: -45=LF pole, 0=CF, +45=RF pole."""
+            return math.degrees(math.atan2(xy[0], xy[1]))
+
+        # Deepest CF point (highest y on screen = lowest pixel y)
         deepest_idx = min(range(len(wall_pts)), key=lambda i: wall_pts[i][1])
         cf_pt   = wall_pts[deepest_idx]
         cf_dist = _dist(wall_poly[deepest_idx])
@@ -132,20 +141,19 @@ def _draw_field(draw, data, fonts=None):
         draw.text((lf_pole[0] + 2, lf_pole[1]),    str(lf_dist), font=font_tiny, fill=0)
         draw.text((rf_pole[0] - 18, rf_pole[1]),   str(rf_dist), font=font_tiny, fill=0)
 
-        # For parks with 8+ wall points, also label 2 intermediate ones:
-        # pick the most-LF non-pole point (x_ft most negative) and most-RF (x_ft most positive)
-        if len(wall_poly) >= 8:
-            inner = [(wall_poly[i], wall_pts[i])
+        # Label power alleys: find points closest to ±22° bearing (LF/RF alleys)
+        if len(wall_poly) >= 5:
+            inner = [(i, wall_poly[i], wall_pts[i])
                      for i in range(1, len(wall_poly) - 1)
                      if i != deepest_idx]
-            lf_mid = min(inner, key=lambda t: t[0][0], default=None)   # most-negative x
-            rf_mid = max(inner, key=lambda t: t[0][0], default=None)   # most-positive x
-            if lf_mid:
-                pt = lf_mid[1]
-                draw.text((pt[0] + 2, pt[1] - 2), str(_dist(lf_mid[0])), font=font_tiny, fill=0)
-            if rf_mid:
-                pt = rf_mid[1]
-                draw.text((pt[0] - 18, pt[1] - 2), str(_dist(rf_mid[0])), font=font_tiny, fill=0)
+            lf_alley = min(inner, key=lambda t: abs(_angle(t[1]) - (-22)), default=None)
+            rf_alley = min(inner, key=lambda t: abs(_angle(t[1]) - 22), default=None)
+            if lf_alley:
+                pt = lf_alley[2]
+                draw.text((pt[0] + 2, pt[1] - 2), str(_dist(lf_alley[1])), font=font_tiny, fill=0)
+            if rf_alley:
+                pt = rf_alley[2]
+                draw.text((pt[0] - 18, pt[1] - 2), str(_dist(rf_alley[1])), font=font_tiny, fill=0)
 
 
 def _draw_runners(draw, data):

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -750,6 +750,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         game_data = dict(game_data)
         game_data['detailed_state'] = 'Final'
 
+    # Normalize mid-game review/challenge states to In Progress
+    if game_data.get('detailed_state') in ('Player challenge', 'Manager challenge'):
+        game_data = dict(game_data)
+        game_data['detailed_state'] = 'In Progress'
+
     draw = ImageDraw.Draw(Himage)
     font26 = _get_font(26)
     font24 = _get_font(24)

--- a/src/render_scoreboard.py
+++ b/src/render_scoreboard.py
@@ -1,0 +1,162 @@
+"""
+Render scoreboard image from cached data/games.json.
+Does NOT call the MLB API — run fetch_games.py first.
+
+Standalone CLI:
+    python src/render_scoreboard.py [--date 2025-04-01] [--mode field|scorecard|pitch|scoreboard]
+                                    [--output output/test.bmp] [--open] [--config PATH]
+"""
+import os
+import sys
+import argparse
+
+# Allow running as a standalone script from any directory
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from util import load_json_file
+from config_loader import load_config, add_config_arg
+from generate_image import orchestrate_score_board
+from game_detail_fetch import select_game, fetch_field_view_data, fetch_scorecard_data, fetch_pitch_view_data
+from field_view import render_field_view
+from scorecard_view import render_scorecard_view
+from pitch_view import render_pitch_view
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DEFAULT_OUTPUT = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
+
+
+def _get_display_mode(config):
+    """Determine display mode from config."""
+    mode = config.get('display_mode')
+    if mode and mode in ('scoreboard', 'linescore', 'field', 'scorecard', 'pitch'):
+        return mode
+    if config.get('scoreboard', True):
+        return 'scoreboard'
+    return 'linescore'
+
+
+def _render_single_game_mode(mode, game_state_data, team_data, config, output_path=None):
+    """Render field/scorecard/pitch view for a single game. Returns image or None."""
+    favorite = config.get('primary', '')
+    game = select_game(game_state_data, favorite, team_data)
+    if not game:
+        print("No game found for single-game display mode")
+        return None
+
+    game_pk = game.get('game_pk')
+    if not game_pk:
+        print("No game_pk found")
+        return None
+
+    dark_mode = config.get('dark_mode', False)
+
+    away_id = str(game.get('away_team_id', ''))
+    home_id = str(game.get('home_team_id', ''))
+    away_abbr = team_data.get('team_abbreviation', {}).get(away_id, '')
+    home_abbr = team_data.get('team_abbreviation', {}).get(home_id, '')
+    print(f"Selected game: {away_abbr} @ {home_abbr} (pk={game_pk}, mode={mode})")
+
+    try:
+        if mode == 'field':
+            data = fetch_field_view_data(game_pk)
+            image = render_field_view(data, dark_mode=dark_mode)
+        elif mode == 'pitch':
+            data = fetch_pitch_view_data(game_pk)
+            image = render_pitch_view(data, dark_mode=dark_mode)
+        else:
+            data = fetch_scorecard_data(game_pk)
+            image = render_scorecard_view(data, dark_mode=dark_mode)
+
+        if output_path:
+            image.save(output_path)
+            print(f"Image saved to {output_path}")
+
+        return image
+    except Exception as e:
+        print(f"Error generating {mode} view: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+
+
+def render(config, date_str=None, output_path=None):
+    """
+    Render display from cached data/games.json.
+
+    Args:
+        config: Config dict
+        date_str: Date string for scoreboard header (optional)
+        output_path: Where to save the output image (default: resulting_image.bmp)
+
+    Returns:
+        (PIL.Image, changed_regions) tuple, or None if no update needed.
+    """
+    if output_path is None:
+        output_path = _DEFAULT_OUTPUT
+
+    game_state_data = load_json_file('games.json').get('games', [])
+    team_data = load_json_file('teams.json')
+    if not team_data or 'team_abbreviation' not in team_data:
+        team_data = {'team_abbreviation': {}}
+
+    mode = _get_display_mode(config)
+
+    if mode in ('field', 'scorecard', 'pitch'):
+        image = _render_single_game_mode(mode, game_state_data, team_data, config, output_path)
+        if image:
+            return (image, [])
+        return None
+
+    result = orchestrate_score_board(game_state_data, team_data, date_str)
+    if result:
+        image, changed_regions = result
+        image.save(output_path)
+        print(f"Image saved to {output_path}")
+        return (image, changed_regions)
+
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Render scoreboard image from cached data/games.json',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  python src/render_scoreboard.py
+  python src/render_scoreboard.py --mode field
+  python src/render_scoreboard.py --date 2025-04-01 --output output/test.bmp --open
+        ''',
+    )
+    parser.add_argument('--date', type=str, help='Date string for scoreboard header')
+    parser.add_argument('--mode', type=str,
+                        choices=['scoreboard', 'linescore', 'field', 'scorecard', 'pitch'],
+                        help='Display mode override')
+    parser.add_argument('--output', type=str, default=None,
+                        help=f'Output image path (default: {_DEFAULT_OUTPUT})')
+    parser.add_argument('--open', action='store_true',
+                        help='Auto-open image after rendering (macOS)')
+    add_config_arg(parser)
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    if args.mode:
+        config['display_mode'] = args.mode
+
+    output_path = args.output or _DEFAULT_OUTPUT
+    result = render(config, date_str=args.date, output_path=output_path)
+
+    if result:
+        image, changed_regions = result
+        print(f"\n✓ Image written to {output_path}")
+        if args.open:
+            import platform
+            if platform.system() == 'Darwin':
+                import subprocess
+                subprocess.run(['open', output_path], check=False)
+    else:
+        print("No output generated")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/stadium_polygons.py
+++ b/src/stadium_polygons.py
@@ -5,9 +5,12 @@ Coordinate system (feet, home plate = origin):
   x negative → third base / LF side
   y positive → center field direction
 
-Conversion from BALLPARK_DIMENSIONS (dist_ft, angle_deg):
-  x = dist_ft * sin(radians(angle_deg))
-  y = dist_ft * cos(radians(angle_deg))
+Wall polygons are loaded from data/mlbam_walls.json (detailed ~50-point shapes
+extracted from MLBAM's canonical stadium data via extract_mlbam_walls.py).
+Points are ordered left (LF foul pole) to right (RF foul pole).
+
+Sutter Health Park (A's temporary Sacramento stadium) is not in the MLBAM
+dataset and uses a simple 5-point polygon from the MLB Stats API.
 """
 
 import json
@@ -15,61 +18,35 @@ import math
 import os
 
 # ---------------------------------------------------------------------------
-# Raw ballpark wall data — canonical source for all 30 MLB stadiums.
-# field_view.py imports get_polygon() from here rather than maintaining its own copy.
-# Each value is a list of (distance_ft, angle_deg) pairs.
-# angle_deg: -45 = LF foul pole, 0 = straight CF, +45 = RF foul pole.
+# Load detailed MLBAM wall polygons from JSON data file.
+# Falls back to empty dict if file is missing.
 # ---------------------------------------------------------------------------
-def _w(a, b, c, d, e, f, g, h, i):
-    return [
-        (a, -45), (b, -33), (c, -22.5), (d, -11),
-        (e,   0), (f,  11), (g,  22.5), (h,  33), (i,  45),
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_MLBAM_WALLS_PATH = os.path.join(_ROOT, 'data', 'mlbam_walls.json')
+
+
+def _load_mlbam_walls():
+    """Load wall polygons from data/mlbam_walls.json."""
+    if not os.path.exists(_MLBAM_WALLS_PATH):
+        return {}
+    with open(_MLBAM_WALLS_PATH) as fh:
+        raw = json.load(fh)
+    # Convert [[x, y], ...] lists to [(x, y), ...] tuples
+    return {name: [tuple(pt) for pt in pts] for name, pts in raw.items()}
+
+
+STADIUM_POLYGONS = _load_mlbam_walls()
+
+# Sutter Health Park — not in MLBAM dataset (A's temporary Sacramento stadium)
+if 'Sutter Health Park' not in STADIUM_POLYGONS:
+    STADIUM_POLYGONS['Sutter Health Park'] = [
+        (-233.3, 233.3),   # LF foul pole, 330 ft
+        (-111.1, 363.4),   # LF-CF gap, 380 ft
+        (0.0,    403.0),   # deep CF, 403 ft
+        (111.1,  363.4),   # RF-CF gap, 380 ft
+        (229.8,  229.8),   # RF foul pole, 325 ft
     ]
 
-BALLPARK_DIMENSIONS = {
-    # AL East
-    'Yankee Stadium':  _w(318, 390, 399, 405, 408, 400, 385, 353, 314),
-    'Fenway Park': [
-        (310, -45), (379, -25), (390, -12), (420, -4),
-        (380,  17), (302,  45),
-    ],
-    'Camden Yards':              _w(333, 357, 364, 390, 410, 390, 373, 347, 318),
-    'Rogers Centre':             _w(328, 356, 375, 393, 400, 393, 375, 356, 328),
-    'Tropicana Field':           _w(315, 345, 370, 392, 404, 392, 370, 348, 322),
-    # AL Central
-    'Guaranteed Rate Field':     _w(330, 357, 377, 392, 400, 387, 372, 356, 335),
-    'Progressive Field':         _w(325, 350, 370, 393, 405, 390, 375, 352, 325),
-    'Comerica Park':             _w(345, 360, 370, 403, 420, 395, 365, 352, 330),
-    'Kauffman Stadium':          _w(330, 357, 375, 398, 410, 398, 375, 357, 330),
-    'Target Field':              _w(339, 361, 377, 395, 404, 387, 367, 350, 328),
-    # AL West
-    'Minute Maid Park':          _w(315, 339, 362, 418, 435, 400, 373, 350, 326),
-    'Angel Stadium':             _w(330, 360, 383, 397, 400, 388, 370, 353, 330),
-    'Oakland Coliseum':          _w(330, 362, 388, 396, 400, 382, 362, 349, 330),
-    'T-Mobile Park':             _w(331, 356, 378, 393, 401, 393, 381, 354, 326),
-    'Globe Life Field':          _w(329, 355, 374, 396, 407, 396, 374, 352, 326),
-    # NL East
-    'Truist Park':               _w(335, 361, 380, 393, 400, 390, 375, 352, 325),
-    'Citi Field':                _w(335, 348, 358, 390, 408, 393, 375, 354, 330),
-    'Citizens Bank Park':        _w(329, 352, 369, 390, 401, 390, 369, 352, 330),
-    'Nationals Park':            _w(336, 360, 377, 393, 402, 388, 370, 355, 335),
-    'loanDepot park':            _w(344, 368, 386, 400, 407, 400, 392, 366, 335),
-    # NL Central
-    'Wrigley Field':             _w(355, 363, 368, 385, 400, 385, 368, 363, 353),
-    'Great American Ball Park':  _w(328, 356, 379, 395, 404, 388, 370, 350, 325),
-    'American Family Field':     _w(344, 361, 371, 390, 400, 390, 374, 363, 345),
-    'PNC Park':                  _w(325, 360, 389, 396, 399, 390, 375, 350, 320),
-    'Busch Stadium':             _w(336, 360, 375, 392, 400, 392, 375, 360, 335),
-    # NL West
-    'Dodger Stadium':            _w(330, 360, 375, 392, 400, 392, 375, 360, 330),
-    'Chase Field':               _w(330, 357, 374, 396, 407, 396, 374, 358, 335),
-    'Coors Field':               _w(347, 372, 390, 407, 415, 395, 375, 366, 350),
-    'Oracle Park': [
-        (339, -45), (362, -33), (382, -22.5), (396, -11), (399, 0),
-        (410,  11), (421,  22.5), (360,  35), (309,  45),
-    ],
-    'Petco Park':                _w(336, 354, 367, 385, 396, 392, 391, 360, 322),
-}
 
 # ---------------------------------------------------------------------------
 # Team name mapping (stadium → franchise name)
@@ -90,7 +67,7 @@ TEAM_NAMES = {
     # AL West
     'Minute Maid Park':         'Houston Astros',
     'Angel Stadium':            'Los Angeles Angels',
-    'Oakland Coliseum':         'Oakland Athletics',
+    'Sutter Health Park':       'Oakland Athletics',
     'T-Mobile Park':            'Seattle Mariners',
     'Globe Life Field':         'Texas Rangers',
     # NL East
@@ -115,13 +92,35 @@ TEAM_NAMES = {
 
 
 # ---------------------------------------------------------------------------
-# Core conversion
+# Backward-compatibility shim for callers that expect (dist, angle) pairs.
+# generate_stadium_svgs.py uses BALLPARK_DIMENSIONS in _warning_track() and
+# _distance_labels(). These callers derive angles from Cartesian — the angles
+# will be geometrically correct (not the old fixed 9-slot scheme).
+# ---------------------------------------------------------------------------
+def _cartesian_to_polar(pts):
+    """Convert [(x_ft, y_ft)] to [(dist_ft, angle_deg)] for compat callers."""
+    result = []
+    for x, y in pts:
+        dist = math.sqrt(x * x + y * y)
+        angle = math.degrees(math.atan2(x, y))  # atan2(x,y) gives bearing from +y axis
+        result.append((round(dist, 1), round(angle, 2)))
+    return result
+
+
+BALLPARK_DIMENSIONS = {
+    name: _cartesian_to_polar(pts)
+    for name, pts in STADIUM_POLYGONS.items()
+}
+
+
+# ---------------------------------------------------------------------------
+# Legacy conversion helper — retained for field_view.py's _DEFAULT_WALL_POLY.
 # ---------------------------------------------------------------------------
 
 def dimensions_to_polygon(dims):
     """Convert list of (dist_ft, angle_deg) to list of [x_ft, y_ft].
 
-    angle_deg convention (from field_view.py):
+    angle_deg convention:
       -45 = LF foul pole,  0 = straight-away CF,  +45 = RF foul pole
     """
     pts = []
@@ -131,13 +130,6 @@ def dimensions_to_polygon(dims):
         y = round(dist * math.cos(rad), 1)
         pts.append([x, y])
     return pts
-
-
-# Build polygon dict at import time (fast — pure arithmetic on 270 pairs)
-STADIUM_POLYGONS = {
-    name: dimensions_to_polygon(dims)
-    for name, dims in BALLPARK_DIMENSIONS.items()
-}
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +156,7 @@ def get_polygon(venue_name):
 # ---------------------------------------------------------------------------
 
 def export_json(filepath):
-    """Write all 30 stadiums to *filepath* as a JSON array.
+    """Write all stadiums to *filepath* as a JSON array.
 
     Each element: {"stadium": str, "team": str, "wall_polygon": [[x,y], ...]}
     Returns the resolved filepath.
@@ -176,9 +168,9 @@ def export_json(filepath):
         {
             "stadium": name,
             "team": TEAM_NAMES.get(name, ""),
-            "wall_polygon": poly,
+            "wall_polygon": [[round(x, 1), round(y, 1)] for x, y in pts],
         }
-        for name, poly in STADIUM_POLYGONS.items()
+        for name, pts in STADIUM_POLYGONS.items()
     ]
 
     with open(filepath, 'w') as fh:
@@ -206,3 +198,6 @@ if __name__ == '__main__':
     )
     path = export_json(out)
     print(f'Wrote {len(STADIUM_POLYGONS)} stadiums to {path}')
+    for name, pts in STADIUM_POLYGONS.items():
+        dists = [round(math.sqrt(x**2 + y**2)) for x, y in pts]
+        print(f'  {name:<35s} {len(pts):2d} pts  LF={dists[0]}  CF={max(dists)}  RF={dists[-1]}')

--- a/src/test_stadiums.py
+++ b/src/test_stadiums.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Generate a field-view test image for every stadium in BALLPARK_DIMENSIONS.
+Run from project root: python3 src/test_stadiums.py
+
+Output: output/stadium/<Venue Name>.png  (one per ballpark)
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+from field_view import render_field_view
+from stadium_polygons import STADIUM_POLYGONS as BALLPARK_DIMENSIONS
+
+OUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'output', 'stadium')
+os.makedirs(OUT_DIR, exist_ok=True)
+
+SAMPLE_DATA = {
+    'away_abbr': 'NYY', 'home_abbr': 'BOS',
+    'away_id': '147',   'home_id': '111',
+    'away_runs': 3,     'home_runs': 2,
+    'away_hits': 7,     'home_hits': 5,
+    'away_errors': 0,   'home_errors': 1,
+    'detailed_state': 'In Progress',
+    'inning_state': 'Top',
+    'inning_ordinal': '7th',
+    'current_inning': 7,
+    'balls': 2, 'strikes': 1, 'outs': 1,
+    'runner_first': True, 'runner_second': False, 'runner_third': True,
+    'batter': {
+        'name': 'A. Judge',
+        'season': {'avg': '.310', 'homeRuns': 45, 'rbi': 102},
+    },
+    'pitcher': {
+        'name': 'C. Sale',
+        'stats': {'inningsPitched': '6.1', 'strikeOuts': 8},
+        'season': {'era': '2.94'},
+    },
+    'on_deck': {
+        'name': 'G. Stanton',
+        'season': {'avg': '.265', 'homeRuns': 32, 'rbi': 78},
+        'stats': {},
+    },
+    'last_play': 'Single to left field, Soto scores from second',
+    'all_hits': [
+        # Previous innings — rendered as ghost/outline markers
+        {'x': 100, 'y': 155, 'is_hr': False, 'is_hit': False, 'is_out': True,  'player': 'Torres', 'inning': 3, 'half': 'bottom'},
+        {'x': 130, 'y': 145, 'is_hr': False, 'is_hit': True,  'is_out': False, 'player': 'Betts',  'inning': 4, 'half': 'top'},
+        {'x': 18,  'y': 88,  'is_hr': True,  'is_hit': True,  'is_out': False, 'player': 'Devers', 'inning': 5, 'half': 'bottom'},
+        # Current half-inning (inning=7, half='top') — rendered filled
+        {'x': 127, 'y': -10, 'is_hr': True,  'is_hit': True,  'is_out': False, 'player': 'Judge',  'inning': 7, 'half': 'top'},
+        {'x': 115, 'y': 155, 'is_hr': False, 'is_hit': False, 'is_out': True,  'player': 'Rizzo',  'inning': 7, 'half': 'top'},
+        {'x': 142, 'y': 138, 'is_hr': False, 'is_hit': True,  'is_out': False, 'player': 'Soto',   'inning': 7, 'half': 'top'},
+    ],
+    'pitches': [
+        {'px': -0.3, 'pz': 2.8, 'code': 'S'},   # strike, mid-left
+        {'px':  1.1, 'pz': 2.2, 'code': 'B'},   # ball, outside right edge
+        {'px': -0.1, 'pz': 2.5, 'code': 'F'},   # foul, center
+        {'px':  0.2, 'pz': 2.9, 'code': 'C'},   # called strike, center-right
+        {'px': -0.9, 'pz': 3.8, 'code': 'B'},   # ball, high and outside left
+    ],
+    'innings': [
+        {'num': i, 'away_runs': (i % 2), 'home_runs': (i % 3 == 0 and 1 or 0)}
+        for i in range(1, 8)
+    ],
+    'winner': '', 'loser': '', 'save': '',
+}
+
+for venue in sorted(BALLPARK_DIMENSIONS.keys()):
+    data = dict(SAMPLE_DATA, venue=venue)
+    img = render_field_view(data, dark_mode=False)
+    safe_name = venue.replace('/', '-').replace(' ', '_')
+    path = os.path.join(OUT_DIR, f'{safe_name}.png')
+    img.save(path)
+    print(f'  {venue}')
+
+print(f'\nSaved {len(BALLPARK_DIMENSIONS)} images to {OUT_DIR}/')

--- a/src/util.py
+++ b/src/util.py
@@ -2,13 +2,19 @@ import os
 import json
 import yaml
 
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DATA_DIR = os.path.join(_REPO_ROOT, 'data')
+_CONFIG_DIR = os.path.join(_REPO_ROOT, 'config')
 
-def load_json_file(file_name, file_path='data/'):
+
+def load_json_file(file_name, file_path=None):
+    base = file_path if file_path is not None else _DATA_DIR
+    full = os.path.join(base, file_name)
     data_dict = {}
     try:
-        if not os.path.isfile(file_path + file_name):
+        if not os.path.isfile(full):
             return data_dict
-        with open(file_path + file_name, 'r') as file:
+        with open(full, 'r') as file:
             data_dict = json.load(file)
             return data_dict
     except:
@@ -16,22 +22,25 @@ def load_json_file(file_name, file_path='data/'):
         return data_dict
 
 
-def load_yaml_file(file_name, file_path='config/'):
+def load_yaml_file(file_name, file_path=None):
+    base = file_path if file_path is not None else _CONFIG_DIR
+    full = os.path.join(base, file_name)
     data_dict = {}
     try:
-        if not os.path.isfile(file_path + file_name):
+        if not os.path.isfile(full):
             return data_dict
-        with open(file_path + file_name, 'r') as file:
+        with open(full, 'r') as file:
             data_dict = yaml.safe_load(file)
             return data_dict if data_dict else {}
     except Exception as e:
         print(f'Error parsing YAML file: {e}')
         return data_dict
 
-   
-def save_off_results(data, output, file_path='data/'):
-    os.makedirs(file_path, exist_ok=True)
-    with open(file_path + output + '.json', 'w') as f:
+
+def save_off_results(data, output, file_path=None):
+    base = file_path if file_path is not None else _DATA_DIR
+    os.makedirs(base, exist_ok=True)
+    with open(os.path.join(base, output + '.json'), 'w') as f:
         json.dump(data, f, indent=4)
 
 


### PR DESCRIPTION
## Summary
- Replace hardcoded 9-slot `BALLPARK_DIMENSIONS` estimates in `stadium_polygons.py` with detailed ~50-point wall shapes loaded from `data/mlbam_walls.json` (MLBAM canonical data). Backward-compat `BALLPARK_DIMENSIONS` shim derived via polar conversion.
- `field_view.py`: switch power-alley distance labels from extremal-x to ±22° angle-bearing approach for accurate placement on asymmetric parks; clean up default fallback polygon.
- `generate_image.py`: normalize `Player challenge` / `Manager challenge` detailed states to `In Progress` so live-game UI renders correctly during replay reviews.
- `util.py`: use repo-root-relative `_DATA_DIR` / `_CONFIG_DIR` constants so scripts work regardless of working directory.
- Add `main.py` full pipeline orchestrator (fetch → render → display) as primary entry point.
- Add standalone CLIs: `src/config_loader.py`, `src/display.py`, `src/render_scoreboard.py`.
- Add extraction/debug utilities: `src/extract_mlbam_walls.py`, `src/fetch_stadium_polygons.py`, `src/test_stadiums.py`.

## Test plan
- [ ] Run `python3 src/test_stadiums.py` and verify output PNGs in `output/stadium/` show correct wall shapes for a few known parks (Fenway, Oracle, Wrigley)
- [ ] Run `python3 main.py --local` and confirm full pipeline executes without errors
- [ ] Trigger a game in `Player challenge` or `Manager challenge` state and confirm bases/outs are rendered (not blank)
- [ ] Run `python3 src/render_scoreboard.py` from a non-root directory to confirm CWD-independent path resolution works

🤖 Generated with [Claude Code](https://claude.com/claude-code)