### PR TITLE
Scoreboard: last play in header from winProbability endpoint

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,6 @@ secondary_backup: LIVE
 secondary_backup_2: STL
 update_interval: 14
 max_live_game_calls: 15
-fetch_last_play: false 
 
 # Timezone for game start times (IANA timezone string, e.g. America/Chicago, America/New_York)
 timezone: America/Chicago

--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -38,55 +38,38 @@ def convert_time_z_to(utc_time_str, time_zone='America/Chicago'):
     return local_time.strftime("%-I:%M %p")
 
 
-def get_last_play_result(game_pk):
-    """Fetch the last play result for a game in progress."""
-    try:
-        response = requests.get(f'https://statsapi.mlb.com/api/v1/game/{game_pk}/feed/live')
-        if response.status_code == 200:
-            data = response.json()
-            plays_data = data.get('liveData', {}).get('plays', {})
-            current_play = plays_data.get('currentPlay', {})
-            result = current_play.get('result', {}).get('description', '')
-            if result:
-                return result
-            event = current_play.get('result', {}).get('event', '')
-            if event:
-                return event
-            all_plays = plays_data.get('allPlays', [])
-            if all_plays:
-                last_play = all_plays[-1]
-                result = last_play.get('result', {}).get('description', '')
-                if result:
-                    return result
-                event = last_play.get('result', {}).get('event', '')
-                if event:
-                    return event
-    except Exception as e:
-        print(f"Error fetching last play for game {game_pk}: {e}")
-    return None
-
+_SUBSTITUTION_TYPES = ('substitution', 'timeout', 'advisory')
 
 def fetch_win_probability(game_pk):
-    """Return (away_wp, home_wp) as floats 0-100 for the most recent play, or (None, None)."""
+    """Return (away_wp, home_wp, last_play) from the winProbability endpoint, or (None, None, None)."""
     try:
         url = f'https://statsapi.mlb.com/api/v1/game/{game_pk}/winProbability'
         response = requests.get(url, timeout=5)
         data = response.json()
         if not isinstance(data, list) or not data:
-            return None, None
+            return None, None, None
         last = data[-1]
         away_wp = last.get('awayTeamWinProbability')
         home_wp = last.get('homeTeamWinProbability')
+        # Scan backwards for the last real play (skip substitutions/challenges)
+        last_play = None
+        for entry in reversed(data):
+            event_type = (entry.get('result', {}).get('eventType') or '').lower()
+            event = entry.get('result', {}).get('event') or ''
+            if event and not any(s in event_type for s in _SUBSTITUTION_TYPES):
+                last_play = event
+                break
         if away_wp is not None and home_wp is not None:
             away_wp = float(away_wp)
             home_wp = float(home_wp)
             if away_wp + home_wp <= 1.5:  # API returns 0-1 fractions
                 away_wp *= 100
                 home_wp *= 100
-            return away_wp, home_wp
-        return None, None
+        else:
+            away_wp, home_wp = None, None
+        return away_wp, home_wp, last_play
     except Exception:
-        return None, None
+        return None, None, None
 
 
 def fetch_all_team_abbreviations(sport_id=1):
@@ -205,7 +188,6 @@ def parse_games(data, sport_id=None, config=None):
 
     game_array = []
     max_live_calls = config.get('max_live_game_calls', 5)
-    fetch_last_play = config.get('fetch_last_play', True)
     live_calls_made = 0
 
     team_abbreviations = load_json_file('teams.json').get('team_abbreviation', {})
@@ -229,13 +211,6 @@ def parse_games(data, sport_id=None, config=None):
         home_team_id = home_team_info.get('id')
 
         last_play_result = None
-        if fetch_last_play and detailed_state == 'In Progress':
-            if live_calls_made < max_live_calls:
-                print(f"Fetching live game data for game {game_id} ({live_calls_made + 1}/{max_live_calls})")
-                last_play_result = get_last_play_result(game_id)
-                live_calls_made += 1
-            else:
-                print(f"Skipping live game data for game {game_id} (limit of {max_live_calls} reached)")
 
         save_situation = False
         if detailed_state == 'In Progress':
@@ -319,10 +294,13 @@ def parse_games(data, sport_id=None, config=None):
             'save_situation': save_situation,
             'game_pk': game_id,
         }
-        if config.get('scoreboard_win_probability', False) and game_dict.get('detailed_state') == 'In Progress':
-            away_wp, home_wp = fetch_win_probability(game_id)
-            game_dict['away_win_probability'] = away_wp
-            game_dict['home_win_probability'] = home_wp
+        if game_dict.get('detailed_state') == 'In Progress' and live_calls_made < max_live_calls:
+            away_wp, home_wp, last_play = fetch_win_probability(game_id)
+            live_calls_made += 1
+            game_dict['last_play'] = last_play
+            if config.get('scoreboard_win_probability', False):
+                game_dict['away_win_probability'] = away_wp
+                game_dict['home_win_probability'] = home_wp
         game_array.append(game_dict)
 
     save_off_results({'games': game_array}, 'games')

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -988,19 +988,10 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             venue_ppd_txt, venue_ppd_fnt = fit_text(venue_ppd, max_text_width)
             draw.text((start_x + 7, start_y + 25 + 74), venue_ppd_txt, font=venue_ppd_fnt, fill=0)
     elif game_data['detailed_state'] == 'In Progress':
-        # Show last play result if available, otherwise show pitcher/hitter
-        last_play = game_data.get('last_play')
-        if last_play:
-            if len(last_play) > 45:
-                last_play = last_play[:42] + '...'
-            draw.text((start_x + 5, start_y + 25 + 59), 'Last:', font=font14, fill=0)
-            draw.text((start_x + 5, start_y + 25 + 74), last_play, font=font14, fill=0)
-        else:
-            # Fallback to showing current matchup
-            pitcher_str, pitcher_font = fit_text(f'P: {game_data.get("current_pitcher") or ""}', max_text_width)
-            hitter_str, hitter_font = fit_text(f'AB: {game_data.get("current_hitter") or ""}', max_text_width)
-            draw.text((start_x + 5, start_y + 25 + 74), pitcher_str, font=pitcher_font, fill=0)
-            draw.text((start_x + 7, start_y + 25 + 89), hitter_str, font=hitter_font, fill=0)
+        pitcher_str, pitcher_font = fit_text(f'P: {game_data.get("current_pitcher") or ""}', max_text_width)
+        hitter_str, hitter_font = fit_text(f'AB: {game_data.get("current_hitter") or ""}', max_text_width)
+        draw.text((start_x + 5, start_y + 25 + 74), pitcher_str, font=pitcher_font, fill=0)
+        draw.text((start_x + 7, start_y + 25 + 89), hitter_str, font=hitter_font, fill=0)
         
     if game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied', 'Postponed', 'Delayed'):
         # Normalize display labels
@@ -1075,12 +1066,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         if raw_play:
             max_play_w = horizonta_len - _total_time_w - 10
             play_text = raw_play
-            while play_text and int(font11.getlength(play_text)) > max_play_w:
+            _play_font = _get_font(12)
+            while play_text and int(_play_font.getlength(play_text)) > max_play_w:
                 play_text = play_text[:-2] + '…'
             if play_text:
-                pw = int(font11.getlength(play_text))
+                pw = int(_play_font.getlength(play_text))
                 px = start_x + horizonta_len - pw - 2
-                draw.text((px, start_y + 5), play_text, font=font11, fill=0)
+                draw.text((px, start_y + 4), play_text, font=_play_font, fill=0)
+                draw.text((px + 1, start_y + 4), play_text, font=_play_font, fill=0)
 
     # Initialize score variables (will be used later for winner display)
     away_runs = str(game_data.get('away_runs', 0) if game_data.get('away_runs', 0) is not None else 0)
@@ -1221,7 +1214,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
 
         if game_data.get('save_situation'):
             sv_w = int(font11.getlength('SV'))
-            draw.text((start_x + horizonta_len - sv_w - 2, start_y + 25 + 59), 'SV', font=font11, fill=0)
+            draw.text((start_x + horizonta_len - sv_w - 2, start_y + 25 + 61), 'SV', font=font11, fill=0)
     else:
 
         # Perfect game takes precedence over no-hitter display

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -304,10 +304,12 @@ def parse_games(data, sport_id=None):
             'game_pk': game_id,
         }
 
-        if config_data.get('scoreboard_win_probability', False) and game_dict.get('detailed_state') == 'In Progress':
-            away_wp, home_wp = fetch_win_probability(game_id)
-            game_dict['away_win_probability'] = away_wp
-            game_dict['home_win_probability'] = home_wp
+        if game_dict.get('detailed_state') == 'In Progress':
+            away_wp, home_wp, last_play = fetch_win_probability(game_id)
+            game_dict['last_play'] = last_play
+            if config_data.get('scoreboard_win_probability', False):
+                game_dict['away_win_probability'] = away_wp
+                game_dict['home_win_probability'] = home_wp
 
         game_array.append(game_dict)
 


### PR DESCRIPTION
## Summary
- Removed broken `get_last_play_result()` (used `/feed/live` which returns 404 for current season games)
- `fetch_win_probability()` now returns `(away_wp, home_wp, last_play)` — last play scanned backwards from the winProbability payload, skipping substitutions, timeouts, advisories, and other non-play events
- Always fetches for in-progress games (up to `max_live_game_calls`); win probability stored only when `scoreboard_win_probability` is enabled
- Last play shown bold, font12, right-anchored in box header (In Progress only)
- Removed body "Last:" display — body always shows pitcher/hitter
- SV indicator moved to strikes row (right-anchored, 2px lower)
- Removed `fetch_last_play` config key

## Test plan
- [ ] Verify last play (e.g. "Strikeout", "Single") appears right-anchored in header for in-progress games
- [ ] Verify non-play events (Game Advisory, substitutions, timeouts) are skipped
- [ ] Verify last play does not appear on Final games
- [ ] Verify SV appears on strikes row during save situations
- [ ] Verify pitcher/hitter always shown in body for in-progress games

🤖 Generated with [Claude Code](https://claude.com/claude-code)