### PR TITLE
feat: time-travel, GIF generation, and full wildcard display

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1018,6 +1018,32 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         game_data = dict(game_data)
         game_data['detailed_state'] = 'In Progress'
 
+    # Only show score once the first pitch has been thrown. Evidence of play:
+    # a ball/strike in the current at-bat, any out, any hit, a runner on base,
+    # an inning break, or the game past inning 1. If none of these are present
+    # the game hasn't officially started despite the API saying "In Progress".
+    if game_data.get('detailed_state') == 'In Progress':
+        # Only show score once the first pitch has been thrown.
+        # away_hits/home_hits are intentionally excluded: in the GIF path they
+        # are inherited from the final game box score and are always non-zero,
+        # causing false positives before the game starts.
+        _has_play = (
+            (game_data.get('balls') or 0) > 0
+            or (game_data.get('strikes') or 0) > 0
+            or (game_data.get('num_of_outs') or 0) > 0
+            or (game_data.get('away_runs') or 0) > 0
+            or (game_data.get('home_runs') or 0) > 0
+            or game_data.get('inningState') in ('Middle', 'End')
+            or (game_data.get('current_inning') or 1) > 1
+            or game_data.get('runner_on_first')
+            or game_data.get('runner_on_second')
+            or game_data.get('runner_on_third')
+            or game_data.get('last_play')
+        )
+        if not _has_play:
+            game_data = dict(game_data)
+            game_data['detailed_state'] = 'Pre-Game'
+
     draw = ImageDraw.Draw(Himage)
     font26 = _get_font(26)
     font24 = _get_font(24)
@@ -1395,8 +1421,21 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
 
     draw = ImageDraw.Draw(Himage)
 
-    # draw.line((col_start, 60 + row_start, 580 + col_start, 60 + row_start), fill = 0)
-    # draw.line((col_start, 90 + row_start, 580 + col_start, 90 + row_start), fill = 0)
+    # --- Date label: centered in the top strip, as large as possible, bold ---
+    if date_str:
+        from datetime import datetime as _dt
+        try:
+            _d = _dt.strptime(date_str, '%Y-%m-%d')
+            _label = _d.strftime('%B %-d, %Y')
+        except (ValueError, AttributeError):
+            _label = date_str
+        _font_date = _get_font(24)
+        _lw = int(_font_date.getlength(_label))
+        _lx = (800 - _lw) // 2
+        _ly = max(0, (_WC_STRIP_H - 24) // 2)
+        draw.text((_lx,     _ly), _label, font=_font_date, fill=0)
+        draw.text((_lx + 1, _ly), _label, font=_font_date, fill=0)  # bold stroke
+
     x_start = 32
     y_start = 30
 

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -868,8 +868,8 @@ def derive_wildcard_from_standings(standings_data):
     """Build {'AL': [...], 'NL': [...]} from standings.json.
 
     Collects all non-division-leader teams per league, sorts by league_rank
-    (overall AL/NL rank already accounts for wildcard position correctly),
-    returns the top 10 per league.
+    (overall AL/NL rank already accounts for wildcard position correctly).
+    Returns all eligible wildcard teams (max 12: 15 teams minus 3 division leaders).
     Each entry: {'abbr': str, 'team_id': str, 'gb': str}.
     """
     abbr_map = standings_data.get('team_abbreviation', {})
@@ -881,7 +881,7 @@ def derive_wildcard_from_standings(standings_data):
         for div in div_names:
             for t in divisions.get(div, []):
                 if str(t.get('divisionRank', '')) == '1':
-                    continue  # skip division leaders
+                    continue  # skip division leaders — they aren't competing for the wildcard
                 team_id = str(t.get('team_id', ''))
                 abbr = abbr_map.get(team_id, t.get('team_name', '???')[:3].upper())
                 try:
@@ -895,19 +895,22 @@ def derive_wildcard_from_standings(standings_data):
                     'rank': rank,
                 })
         teams.sort(key=lambda t: t['rank'])
-        result[league_key] = teams[:10]
+        result[league_key] = teams  # all eligible, no cap
 
     return result
+
+
+_WC_WILDCARD_SPOTS = 3   # number of wildcard playoff berths per league
+_WC_MAX_TEAMS      = 12  # max eligible per league (15 teams - 3 division leaders)
 
 
 def draw_wildcard_header(Himage, wildcard_data):
     """Draw a compact wildcard standings strip across the top of the display (y=0..30).
 
-    AL wildcard (10 teams) left-to-right in the left half (rank 1 at left edge).
-    NL wildcard (10 teams) right-to-left in the right half (rank 1 at right edge).
-    Each slot shows only the team logo, centered vertically and horizontally.
+    AL wildcard (all eligible, up to 12) left-to-right in the left half, rank 1 at left edge.
+    NL wildcard (all eligible, up to 12) right-to-left in the right half, rank 1 at right edge.
+    A rounded rectangle is drawn around the top-3 wildcard leaders on each side.
     Falls back to 3-letter abbreviation (font9) when no logo is available.
-    No separator lines are drawn.
     """
     draw = ImageDraw.Draw(Himage)
     font = _get_font(9)
@@ -926,16 +929,36 @@ def draw_wildcard_header(Himage, wildcard_data):
             abbr_w = int(font.getlength(abbr))
             draw.text((slot_x + (_WC_SLOT_W - abbr_w) // 2, (_WC_STRIP_H - 9) // 2), abbr, font=font, fill=0)
 
-    al_teams = wildcard_data.get('AL', [])
-    nl_teams = wildcard_data.get('NL', [])
+    al_teams = wildcard_data.get('AL', [])[:_WC_MAX_TEAMS]
+    nl_teams = wildcard_data.get('NL', [])[:_WC_MAX_TEAMS]
 
-    # AL: rank 1 at left box edge (x=32), rank 10 toward center
-    for i, team in enumerate(al_teams[:10]):
+    # AL: rank 1 at left box edge (x=32), higher ranks toward center
+    for i, team in enumerate(al_teams):
         _draw_slot(_WC_BOX_X_START + i * _WC_SLOT_W, team)
 
-    # NL: rank 1 at right box edge (x=767), rank 10 toward center
-    for i, team in enumerate(nl_teams[:10]):
+    # NL: rank 1 at right box edge (x=767), higher ranks toward center
+    for i, team in enumerate(nl_teams):
         _draw_slot(_WC_BOX_X_END - (i + 1) * _WC_SLOT_W, team)
+
+    # Draw a rounded box around the wildcard leaders (top _WC_WILDCARD_SPOTS per league)
+    n_al = min(len(al_teams), _WC_WILDCARD_SPOTS)
+    n_nl = min(len(nl_teams), _WC_WILDCARD_SPOTS)
+
+    if n_al > 0:
+        box_x0 = _WC_BOX_X_START
+        box_x1 = _WC_BOX_X_START + n_al * _WC_SLOT_W
+        try:
+            draw.rounded_rectangle([box_x0, 1, box_x1, _WC_STRIP_H - 2], radius=3, outline=0, width=1)
+        except AttributeError:
+            draw.rectangle([box_x0, 1, box_x1, _WC_STRIP_H - 2], outline=0, width=1)
+
+    if n_nl > 0:
+        box_x0 = _WC_BOX_X_END - n_nl * _WC_SLOT_W
+        box_x1 = _WC_BOX_X_END
+        try:
+            draw.rounded_rectangle([box_x0, 1, box_x1, _WC_STRIP_H - 2], radius=3, outline=0, width=1)
+        except AttributeError:
+            draw.rectangle([box_x0, 1, box_x1, _WC_STRIP_H - 2], outline=0, width=1)
 
     return Himage
 
@@ -1404,35 +1427,41 @@ def load_and_sort_json(json_string):
 
 
 
-def  orchestrate_score_board(game_state_data, team_data, date_str=None):
+def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_cache=False):
     """Returns (image, changed_regions) or None if nothing changed.
 
     changed_regions is a list of (x, y, w, h) tuples for partial refresh.
     An empty list signals that a full refresh should be used.
+
+    bypass_cache=True skips the unchanged-image check and state persistence.
+    Use this when generating GIFs or rendering historical snapshots.
     """
     config = load_yaml_file('config.yaml')
     use_logos = config.get('use_team_logos', False)
     logo_x_offset = config.get('small_logo_x_offset', 2)
     show_win_prob = config.get('scoreboard_win_probability', False)
 
-    old_data = load_json_file('old_scoreboard_state.json')
+    if bypass_cache:
+        new_dict = old_dict = None  # skip comparison below
+    else:
+        old_data = load_json_file('old_scoreboard_state.json')
 
-    new_data_str = json.dumps(game_state_data)
-    old_data_str = json.dumps(old_data)
+        new_data_str = json.dumps(game_state_data)
+        old_data_str = json.dumps(old_data)
 
+        new_dict = load_and_sort_json(new_data_str)
+        old_dict = load_and_sort_json(old_data_str)
 
-    new_dict = load_and_sort_json(new_data_str)
-    old_dict = load_and_sort_json(old_data_str)
-
-    save_off_results(game_state_data, "old_scoreboard_state")
+        save_off_results(game_state_data, "old_scoreboard_state")
 
     # Build map of old game data by game_pk for per-game comparison
     old_by_pk = {}
-    if old_data and isinstance(old_data, list):
-        for g in old_data:
-            pk = str(g.get('game_pk', ''))
-            if pk:
-                old_by_pk[pk] = g
+    if not bypass_cache:
+        if old_data and isinstance(old_data, list):
+            for g in old_data:
+                pk = str(g.get('game_pk', ''))
+                if pk:
+                    old_by_pk[pk] = g
 
     # Track all games with ANY data change (for partial refresh regions)
     refreshed_game_ids = set()
@@ -1443,28 +1472,29 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None):
         if old_by_pk.get(pk) != game:
             refreshed_game_ids.add(pk)
 
-    # --- Score change detection ---
-    old_scores = load_json_file('score_alerts.json')
-    new_scores = {}
     changed_game_ids = set()
-    for game in game_state_data:
-        pk = str(game.get('game_pk', ''))
-        if not pk:
-            continue
-        away_runs = game.get('away_runs')
-        home_runs = game.get('home_runs')
-        new_scores[pk] = {'away_runs': away_runs, 'home_runs': home_runs}
-        if pk in old_scores:
-            old_entry = old_scores[pk]
-            if away_runs != old_entry.get('away_runs') or home_runs != old_entry.get('home_runs'):
-                changed_game_ids.add(pk)
-                print(f'Score change detected for game {pk}: {old_entry} -> {new_scores[pk]}')
-    save_off_results(new_scores, 'score_alerts')
-    # --- End score change detection ---
+    if not bypass_cache:
+        # --- Score change detection ---
+        old_scores = load_json_file('score_alerts.json')
+        new_scores = {}
+        for game in game_state_data:
+            pk = str(game.get('game_pk', ''))
+            if not pk:
+                continue
+            away_runs = game.get('away_runs')
+            home_runs = game.get('home_runs')
+            new_scores[pk] = {'away_runs': away_runs, 'home_runs': home_runs}
+            if pk in old_scores:
+                old_entry = old_scores[pk]
+                if away_runs != old_entry.get('away_runs') or home_runs != old_entry.get('home_runs'):
+                    changed_game_ids.add(pk)
+                    print(f'Score change detected for game {pk}: {old_entry} -> {new_scores[pk]}')
+        save_off_results(new_scores, 'score_alerts')
+        # --- End score change detection ---
 
-    if compare_json_dicts_sorted(new_dict, old_dict):
-        print('images the same')
-        return None
+        if compare_json_dicts_sorted(new_dict, old_dict):
+            print('images the same')
+            return None
 
     print('image is different')
     Himage = Image.new('1', (800, 480), 255)

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -684,63 +684,276 @@ def scoreboard_generate(date_str, game_data, sport_id=None):
         print("No display update needed - image unchanged")
 
 
-def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame_delay_ms, sport_id, config_data):
-    """Generate an animated GIF of the scoreboard between two local times on a given date.
+_INNING_ORDINALS = {
+    1:'1st', 2:'2nd', 3:'3rd', 4:'4th', 5:'5th', 6:'6th',
+    7:'7th', 8:'8th', 9:'9th', 10:'10th', 11:'11th', 12:'12th',
+    13:'13th', 14:'14th', 15:'15th', 16:'16th', 17:'17th', 18:'18th',
+}
 
-    Fetches game state at each interval step via the MLB API timecode parameter,
-    renders each frame using orchestrate_score_board(bypass_cache=True), and
-    assembles all frames into an animated GIF.
+def _ordinal(n):
+    try:
+        return _INNING_ORDINALS.get(int(n), f'{n}th')
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_mlb_time(time_str):
+    """Parse an MLB API ISO timestamp to a UTC-aware datetime."""
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return pytz.utc.localize(datetime.strptime(time_str, fmt))
+        except ValueError:
+            continue
+    raise ValueError(f"Cannot parse MLB timestamp: {time_str!r}")
+
+
+def _fetch_game_timeline(game_pk):
+    """Fetch the full live feed for one game and return a play-by-play timeline.
+
+    Returns a dict:
+      scheduled_start_utc — UTC-aware datetime of scheduled first pitch
+      first_pitch_utc     — UTC-aware datetime when first play began (or None)
+      last_play_utc       — UTC-aware datetime when last play completed (or None)
+      plays               — list of dicts sorted by end_time, each:
+                              end_time, away_score, home_score, inning,
+                              half_inning ('top'|'bottom'), outs
+    """
+    url = f'https://statsapi.mlb.com/api/v1.1/game/{game_pk}/feed/live'
+    resp = requests.get(url, timeout=20)
+    data = resp.json()
+
+    scheduled_start = None
+    dt_str = data.get('gameData', {}).get('datetime', {}).get('dateTime', '')
+    if dt_str:
+        try:
+            scheduled_start = _parse_mlb_time(dt_str)
+        except ValueError:
+            pass
+
+    all_plays = data.get('liveData', {}).get('plays', {}).get('allPlays', [])
+    timeline = []
+    first_pitch = None
+
+    for play in all_plays:
+        about  = play.get('about', {})
+        result = play.get('result', {})
+
+        if first_pitch is None:
+            st = about.get('startTime', '')
+            if st:
+                try:
+                    first_pitch = _parse_mlb_time(st)
+                except ValueError:
+                    pass
+
+        if not about.get('isComplete', False):
+            continue
+        end_str = about.get('endTime', '')
+        if not end_str:
+            continue
+        try:
+            end_time = _parse_mlb_time(end_str)
+        except ValueError:
+            continue
+
+        timeline.append({
+            'end_time':    end_time,
+            'away_score':  result.get('awayScore', 0) or 0,
+            'home_score':  result.get('homeScore', 0) or 0,
+            'inning':      about.get('inning', 1),
+            'half_inning': about.get('halfInning', 'top'),
+            'outs':        about.get('outs', 0),
+        })
+
+    timeline.sort(key=lambda p: p['end_time'])
+
+    return {
+        'scheduled_start_utc': scheduled_start,
+        'first_pitch_utc':     first_pitch,
+        'last_play_utc':       timeline[-1]['end_time'] if timeline else None,
+        'plays':               timeline,
+    }
+
+
+def _game_state_at_time(base_game, tl, target_utc):
+    """Return a copy of base_game with dynamic fields set to game state at target_utc."""
+    state = dict(base_game)
+
+    scheduled_start = tl.get('scheduled_start_utc')
+    first_pitch     = tl.get('first_pitch_utc') or scheduled_start
+    last_play_time  = tl.get('last_play_utc')
+    plays           = tl.get('plays', [])
+
+    # --- Before first pitch ---
+    if first_pitch and target_utc < first_pitch - timedelta(seconds=30):
+        state.update({
+            'detailed_state': 'Scheduled',
+            'away_runs': None, 'home_runs': None,
+            'current_inning': None, 'currentInningOrdinal': None, 'inningState': None,
+            'num_of_outs': None, 'balls': None, 'strikes': None,
+            'runner_on_first': None, 'runner_on_second': None, 'runner_on_third': None,
+            'away_win_probability': None, 'home_win_probability': None, 'last_play': None,
+        })
+        return state
+
+    # --- After last play with buffer ---
+    if last_play_time and target_utc > last_play_time + timedelta(minutes=5):
+        final = plays[-1] if plays else None
+        state['detailed_state'] = 'Final'
+        if final:
+            state['away_runs']      = final['away_score']
+            state['home_runs']      = final['home_score']
+            state['current_inning'] = final['inning']
+        state.update({
+            'num_of_outs': None, 'balls': None, 'strikes': None,
+            'runner_on_first': None, 'runner_on_second': None, 'runner_on_third': None,
+            'inningState': None, 'away_win_probability': None,
+            'home_win_probability': None, 'last_play': None,
+        })
+        return state
+
+    # --- In Progress: find last completed play before target_utc ---
+    state['detailed_state'] = 'In Progress'
+    last_play = None
+    for play in plays:
+        if play['end_time'] <= target_utc:
+            last_play = play
+        else:
+            break
+
+    if last_play:
+        state['away_runs']            = last_play['away_score']
+        state['home_runs']            = last_play['home_score']
+        state['current_inning']       = last_play['inning']
+        state['currentInningOrdinal'] = _ordinal(last_play['inning'])
+        half = last_play.get('half_inning', 'top')
+        state['inningState']          = 'Top' if half == 'top' else 'Bottom'
+        state['num_of_outs']          = last_play.get('outs', 0)
+    else:
+        state.update({
+            'away_runs': 0, 'home_runs': 0,
+            'current_inning': 1, 'currentInningOrdinal': '1st',
+            'inningState': 'Top', 'num_of_outs': 0,
+        })
+
+    # balls/strikes default to 0 so draw_box comparisons don't fail
+    state.update({
+        'balls': 0, 'strikes': 0,
+        'runner_on_first': None, 'runner_on_second': None, 'runner_on_third': None,
+        'away_win_probability': None, 'home_win_probability': None, 'last_play': None,
+    })
+    return state
+
+
+def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame_delay_ms, sport_id, config_data):
+    """Generate an animated GIF of the scoreboard for a game day.
+
+    Fetches each game's full play-by-play feed once (O(N_games) API calls),
+    then reconstructs game state at every minute in memory — no per-minute
+    API calls.  Time window is auto-detected from first pitch / last play
+    when --gif-start / --gif-end are not provided.
     """
     from generate_image import orchestrate_score_board
 
-    tz_str = config_data.get('timezone', 'America/Chicago')
+    tz_str   = config_data.get('timezone', 'America/Chicago')
     local_tz = pytz.timezone(tz_str)
 
-    start_dt = local_tz.localize(datetime.strptime(f"{date_str} {gif_start}", "%Y-%m-%d %H:%M"))
-    end_dt   = local_tz.localize(datetime.strptime(f"{date_str} {gif_end}",   "%Y-%m-%d %H:%M"))
+    # --- Step 1: Fetch base schedule (final/current state for team/game metadata) ---
+    print(f"Fetching schedule for {date_str}...")
+    fetch_scoreboard_for_date(date_str, sport_id)
+    base_games = read_json_file('data/games.json').get('games', [])
+    team_data  = read_json_file('data/teams.json') or {}
+    if 'team_abbreviation' not in team_data:
+        team_data = {'team_abbreviation': {}}
+
+    if not base_games:
+        print(f"No games found for {date_str}")
+        return
+
+    # --- Step 2: Fetch play-by-play timeline once per game ---
+    print(f"Fetching play-by-play for {len(base_games)} game(s)...")
+    game_timelines   = {}
+    all_first_pitches = []
+    all_last_plays    = []
+
+    for game in base_games:
+        game_pk = game.get('game_pk')
+        if not game_pk:
+            continue
+        print(f"  game {game_pk}...", end=' ', flush=True)
+        try:
+            tl = _fetch_game_timeline(game_pk)
+            game_timelines[str(game_pk)] = tl
+            anchor = tl.get('first_pitch_utc') or tl.get('scheduled_start_utc')
+            if anchor:
+                all_first_pitches.append(anchor)
+            if tl.get('last_play_utc'):
+                all_last_plays.append(tl['last_play_utc'])
+            print("ok")
+        except Exception as e:
+            print(f"error: {e}")
+
+    if not game_timelines:
+        print("No timeline data fetched — aborting.")
+        return
+
+    # --- Step 3: Determine time window ---
+    if gif_start and gif_end:
+        start_dt = local_tz.localize(datetime.strptime(f"{date_str} {gif_start}", "%Y-%m-%d %H:%M"))
+        end_dt   = local_tz.localize(datetime.strptime(f"{date_str} {gif_end}",   "%Y-%m-%d %H:%M"))
+    else:
+        if not all_first_pitches:
+            print("Cannot determine start time — provide --gif-start/--gif-end")
+            return
+        start_utc = min(all_first_pitches) - timedelta(minutes=5)
+        end_utc   = (max(all_last_plays) + timedelta(minutes=5)) if all_last_plays \
+                    else max(all_first_pitches) + timedelta(hours=4)
+        start_dt = start_utc.astimezone(local_tz)
+        end_dt   = end_utc.astimezone(local_tz)
+        print(f"Auto-detected window: {start_dt.strftime('%H:%M')}–{end_dt.strftime('%H:%M')} {tz_str}")
 
     if end_dt <= start_dt:
-        print("Error: --gif-end must be after --gif-start")
+        print("End time is before start time — aborting.")
         return
 
     total_steps = int((end_dt - start_dt).total_seconds() / 60 / interval_min) + 1
     print(f"Generating {total_steps}-frame GIF ({interval_min}min intervals, {frame_delay_ms}ms/frame)")
-    print(f"  Date: {date_str}  {gif_start}–{gif_end} {tz_str}")
     print(f"  Output: {output_path}")
 
+    # --- Step 4: Render each frame from in-memory timelines ---
     frames = []
     current_dt = start_dt
     step = 0
 
     while current_dt <= end_dt:
         step += 1
-        time_label = current_dt.strftime("%H:%M")
-        timecode = _local_time_to_timecode(date_str, time_label, tz_str)
+        current_utc = current_dt.astimezone(pytz.utc)
+        time_label  = current_dt.strftime("%H:%M")
 
-        print(f"  [{step:3d}/{total_steps}] {time_label} → {timecode} ET ...", end=' ', flush=True)
+        print(f"  [{step:4d}/{total_steps}] {time_label}...", end=' ', flush=True)
+
+        frame_games = []
+        for game in base_games:
+            pk_str = str(game.get('game_pk', ''))
+            tl = game_timelines.get(pk_str)
+            frame_games.append(_game_state_at_time(game, tl, current_utc) if tl else dict(game))
 
         try:
-            fetch_scoreboard_for_date(date_str, sport_id, timecode=timecode)
-            game_state_data = read_json_file('data/games.json').get('games', [])
-            team_data = read_json_file('data/teams.json') or {}
-            if 'team_abbreviation' not in team_data:
-                team_data = {'team_abbreviation': {}}
-
-            result = orchestrate_score_board(game_state_data, team_data, date_str, bypass_cache=True)
+            result = orchestrate_score_board(frame_games, team_data, date_str, bypass_cache=True)
             if result:
                 image, _ = result
-                # PIL GIF requires palette ('P') mode; convert via 'L' to preserve bilevel look
                 frames.append(image.convert('L').convert('P'))
                 print("ok")
             else:
-                print("no image")
+                print("skip")
         except Exception as e:
             print(f"error: {e}")
 
         current_dt += timedelta(minutes=interval_min)
 
+    # --- Step 5: Save GIF ---
     if not frames:
-        print("No frames were generated — GIF not saved.")
+        print("No frames generated — GIF not saved.")
         return
 
     print(f"Assembling {len(frames)}-frame GIF...")
@@ -771,11 +984,11 @@ Examples:
   # Time-travel: show scoreboard as it appeared at 7:32 PM local time
   python scoreboard_generate.py --date 2025-04-01 --time 19:32
 
-  # Generate an animated GIF of the scoreboard from 6 PM to 11 PM
-  python scoreboard_generate.py --date 2025-04-01 --gif-start 18:00 --gif-end 23:00
+  # Generate a GIF for the full game day (auto-detects first pitch to last out)
+  python scoreboard_generate.py --date 2025-04-01 --gif
 
-  # GIF with 5-minute intervals and faster playback
-  python scoreboard_generate.py --date 2025-04-01 --gif-start 19:00 --gif-end 22:30 --gif-interval 5 --gif-delay 300
+  # GIF with manual window override
+  python scoreboard_generate.py --date 2025-04-01 --gif --gif-start 18:00 --gif-end 23:00 --gif-interval 5 --gif-delay 300
 
   # World Baseball Classic game from 2023
   python scoreboard_generate.py --date 2023-03-21 --sport-id 8
@@ -796,10 +1009,15 @@ Examples:
         help='Time-travel: show the scoreboard as it appeared at this local time on --date'
     )
     parser.add_argument(
+        '--gif',
+        action='store_true',
+        help='Generate a GIF for --date (auto-detects time window from first pitch to last out)'
+    )
+    parser.add_argument(
         '--gif-start',
         type=str,
         metavar='HH:MM',
-        help='GIF start time (local, HH:MM). Requires --date and --gif-end.'
+        help='GIF start time override (local HH:MM). Auto-detected if omitted.'
     )
     parser.add_argument(
         '--gif-end',
@@ -846,17 +1064,19 @@ Examples:
 
     args = parser.parse_args()
 
-    # --gif-start and --gif-end must be used together with --date
+    # --gif-start and --gif-end must always be used together
     if bool(args.gif_start) != bool(args.gif_end):
         parser.error("--gif-start and --gif-end must be used together")
-    if (args.gif_start or args.gif_end) and not args.date:
-        parser.error("--gif-start/--gif-end require --date")
+    # --gif / --gif-start / --gif-end all require --date
+    gif_mode = args.gif or bool(args.gif_start)
+    if gif_mode and not args.date:
+        parser.error("--gif / --gif-start / --gif-end require --date")
     if args.time and not args.date:
         parser.error("--time requires --date")
 
     # Time-travel and GIF modes are treated as explicit offline requests — bypass
     # night mode, smart polling, and Discord state checks.
-    offline_mode = bool(args.time or args.gif_start or args.local)
+    offline_mode = bool(args.time or gif_mode or args.local)
 
     # Display platform information
     system_platform = platform.system()
@@ -941,9 +1161,11 @@ Examples:
         print(f"Using today's date: {date_str}")
 
     # --- GIF generation mode ---
-    if args.gif_start and args.gif_end:
+    if gif_mode:
         _generate_gif(
-            date_str, args.gif_start, args.gif_end,
+            date_str,
+            args.gif_start or None,  # None triggers auto-detection
+            args.gif_end   or None,
             args.gif_output, args.gif_interval, args.gif_delay,
             sport_id, config_data,
         )

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -707,6 +707,9 @@ def _parse_mlb_time(time_str):
     raise ValueError(f"Cannot parse MLB timestamp: {time_str!r}")
 
 
+_WP_SKIP_TYPES = ('substitution', 'timeout', 'advisory')
+
+
 def _fetch_game_timeline(game_pk):
     """Fetch the full live feed for one game and return a play-by-play timeline.
 
@@ -717,6 +720,13 @@ def _fetch_game_timeline(game_pk):
       plays               — list of dicts sorted by end_time, each:
                               end_time, away_score, home_score, inning,
                               half_inning ('top'|'bottom'), outs
+      pitch_events        — list of dicts sorted by time, one per pitch/action event:
+                              time, balls, strikes, outs, inning, half_inning,
+                              away_score, home_score
+                            Used to reconstruct mid-at-bat state minute by minute.
+      wp_events           — list of dicts sorted by time, one per completed play:
+                              time, away_wp, home_wp, last_play
+                            Win probability and last-play description at each play boundary.
     """
     url = f'https://statsapi.mlb.com/api/v1.1/game/{game_pk}/feed/live'
     resp = requests.get(url, timeout=20)
@@ -733,10 +743,35 @@ def _fetch_game_timeline(game_pk):
     all_plays = data.get('liveData', {}).get('plays', {}).get('allPlays', [])
     timeline = []
     first_pitch = None
+    pitch_events = []
+    wp_events = []
 
-    for play in all_plays:
+    # Fetch win probability timeline (one entry per completed play)
+    wp_by_index = {}
+    try:
+        wp_resp = requests.get(
+            f'https://statsapi.mlb.com/api/v1/game/{game_pk}/winProbability',
+            timeout=10,
+        )
+        wp_data = wp_resp.json()
+        if isinstance(wp_data, list):
+            for entry in wp_data:
+                idx = entry.get('atBatIndex')
+                if idx is not None:
+                    wp_by_index[idx] = entry
+    except Exception:
+        pass
+
+    # Running score: score after last completed play (used for pitch events mid-at-bat)
+    running_away = 0
+    running_home = 0
+    cumulative_last_play = None  # last non-substitution event description seen so far
+
+    for i, play in enumerate(all_plays):
         about  = play.get('about', {})
         result = play.get('result', {})
+        inning      = about.get('inning', 1)
+        half_inning = about.get('halfInning', 'top')
 
         if first_pitch is None:
             st = about.get('startTime', '')
@@ -746,6 +781,38 @@ def _fetch_game_timeline(game_pk):
                 except ValueError:
                     pass
 
+        # --- Extract pitch-level events for minute-by-minute state ---
+        # Score during this at-bat = score as of the end of the last completed play.
+        at_bat_away = running_away
+        at_bat_home = running_home
+
+        matchup = play.get('matchup', {})
+        at_bat_pitcher = matchup.get('pitcher', {}).get('fullName') or ''
+        at_bat_batter  = matchup.get('batter',  {}).get('fullName') or ''
+
+        for ev in play.get('playEvents', []):
+            ev_time_str = ev.get('startTime', '')
+            if not ev_time_str:
+                continue
+            try:
+                ev_time = _parse_mlb_time(ev_time_str)
+            except ValueError:
+                continue
+            count = ev.get('count', {})
+            pitch_events.append({
+                'time':        ev_time,
+                'balls':       count.get('balls', 0) or 0,
+                'strikes':     count.get('strikes', 0) or 0,
+                'outs':        count.get('outs', about.get('outs', 0)) or 0,
+                'inning':      inning,
+                'half_inning': half_inning,
+                'away_score':  at_bat_away,
+                'home_score':  at_bat_home,
+                'pitcher':     at_bat_pitcher,
+                'batter':      at_bat_batter,
+            })
+
+        # --- Completed-play timeline (for score/inning snapshots) ---
         if not about.get('isComplete', False):
             continue
         end_str = about.get('endTime', '')
@@ -756,28 +823,76 @@ def _fetch_game_timeline(game_pk):
         except ValueError:
             continue
 
+        away_score = result.get('awayScore', 0) or 0
+        home_score = result.get('homeScore', 0) or 0
+
         timeline.append({
             'end_time':    end_time,
-            'away_score':  result.get('awayScore', 0) or 0,
-            'home_score':  result.get('homeScore', 0) or 0,
-            'inning':      about.get('inning', 1),
-            'half_inning': about.get('halfInning', 'top'),
+            'away_score':  away_score,
+            'home_score':  home_score,
+            'inning':      inning,
+            'half_inning': half_inning,
             'outs':        about.get('outs', 0),
+            'outs_after':  play.get('count', {}).get('outs', 0) or 0,
+            'pitcher':     at_bat_pitcher,
+            'batter':      at_bat_batter,
+        })
+
+        running_away = away_score
+        running_home = home_score
+
+        # --- Win probability and last-play at this play boundary ---
+        wp_entry = wp_by_index.get(i, {})
+        away_wp = wp_entry.get('awayTeamWinProbability')
+        home_wp = wp_entry.get('homeTeamWinProbability')
+        if away_wp is not None:
+            away_wp = float(away_wp)
+            if away_wp <= 1.0:
+                away_wp *= 100
+        if home_wp is not None:
+            home_wp = float(home_wp)
+            if home_wp <= 1.0:
+                home_wp *= 100
+
+        # Advance last_play description (skip substitutions/timeouts)
+        wp_result    = wp_entry.get('result', {})
+        event        = wp_result.get('event') or result.get('event') or ''
+        event_type   = (wp_result.get('eventType') or '').lower()
+        if event and not any(s in event_type for s in _WP_SKIP_TYPES):
+            cumulative_last_play = event
+
+        wp_events.append({
+            'time':      end_time,
+            'away_wp':   away_wp,
+            'home_wp':   home_wp,
+            'last_play': cumulative_last_play,
         })
 
     timeline.sort(key=lambda p: p['end_time'])
+    pitch_events.sort(key=lambda e: e['time'])
+    wp_events.sort(key=lambda e: e['time'])
 
     return {
         'scheduled_start_utc': scheduled_start,
         'first_pitch_utc':     first_pitch,
         'last_play_utc':       timeline[-1]['end_time'] if timeline else None,
         'plays':               timeline,
+        'pitch_events':        pitch_events,
+        'wp_events':           wp_events,
     }
 
+
+_TERMINAL_GAME_STATES = {'Postponed', 'Cancelled', 'Suspended'}
 
 def _game_state_at_time(base_game, tl, target_utc):
     """Return a copy of base_game with dynamic fields set to game state at target_utc."""
     state = dict(base_game)
+
+    # Preserve terminal non-game statuses (Postponed, Cancelled, Suspended).
+    # These have no play data, so the timeline-based logic would otherwise
+    # overwrite them with 'Scheduled'.
+    if base_game.get('detailed_state') in _TERMINAL_GAME_STATES and not tl.get('plays'):
+        return state
 
     scheduled_start = tl.get('scheduled_start_utc')
     first_pitch     = tl.get('first_pitch_utc') or scheduled_start
@@ -808,12 +923,26 @@ def _game_state_at_time(base_game, tl, target_utc):
             'num_of_outs': None, 'balls': None, 'strikes': None,
             'runner_on_first': None, 'runner_on_second': None, 'runner_on_third': None,
             'inningState': None, 'away_win_probability': None,
-            'home_win_probability': None, 'last_play': None,
+            'home_win_probability': None,
         })
+        # Keep last_play from final play if available
+        wp_events = tl.get('wp_events', [])
+        state['last_play'] = wp_events[-1]['last_play'] if wp_events else None
         return state
 
-    # --- In Progress: find last completed play before target_utc ---
+    # --- In Progress: reconstruct detailed state from pitch events and completed plays ---
     state['detailed_state'] = 'In Progress'
+    pitch_events = tl.get('pitch_events', [])
+
+    # Last pitch event before target_utc
+    last_event = None
+    for ev in pitch_events:
+        if ev['time'] <= target_utc:
+            last_event = ev
+        else:
+            break
+
+    # Last completed play before target_utc
     last_play = None
     for play in plays:
         if play['end_time'] <= target_utc:
@@ -821,28 +950,112 @@ def _game_state_at_time(base_game, tl, target_utc):
         else:
             break
 
-    if last_play:
+    # Between-plays: last play resolved AFTER the most recent pitch event.
+    # This covers the inning break and the gap between plate appearances.
+    between_plays = (
+        last_play is not None and
+        (last_event is None or last_play['end_time'] > last_event['time'])
+    )
+
+    if between_plays:
+        outs_after = last_play.get('outs_after', 0)
+        half = last_play.get('half_inning', 'top')
         state['away_runs']            = last_play['away_score']
         state['home_runs']            = last_play['home_score']
         state['current_inning']       = last_play['inning']
         state['currentInningOrdinal'] = _ordinal(last_play['inning'])
-        half = last_play.get('half_inning', 'top')
+        state['num_of_outs']          = outs_after
+        state['balls']                = 0
+        state['strikes']              = 0
+        state['current_pitcher']      = last_play.get('pitcher') or None
+        state['current_hitter']       = None  # between at-bats, no batter yet
+        if outs_after >= 3:
+            # Inning break: top half done → Mid, bottom half done → End
+            state['inningState'] = 'Middle' if half == 'top' else 'End'
+        else:
+            state['inningState'] = 'Top' if half == 'top' else 'Bottom'
+    elif last_event:
+        # Mid-at-bat: pitch events are more recent than the last play completion
+        state['away_runs']            = last_event['away_score']
+        state['home_runs']            = last_event['home_score']
+        state['current_inning']       = last_event['inning']
+        state['currentInningOrdinal'] = _ordinal(last_event['inning'])
+        state['num_of_outs']          = last_event['outs']
+        state['balls']                = last_event['balls']
+        state['strikes']              = last_event['strikes']
+        state['current_pitcher']      = last_event.get('pitcher') or None
+        state['current_hitter']       = last_event.get('batter') or None
+        half = last_event.get('half_inning', 'top')
         state['inningState']          = 'Top' if half == 'top' else 'Bottom'
-        state['num_of_outs']          = last_play.get('outs', 0)
     else:
+        # No pitch events and no completed plays at this timestamp —
+        # the game hasn't officially started yet (no first pitch thrown).
         state.update({
-            'away_runs': 0, 'home_runs': 0,
-            'current_inning': 1, 'currentInningOrdinal': '1st',
-            'inningState': 'Top', 'num_of_outs': 0,
+            'detailed_state': 'Scheduled',
+            'away_runs': None, 'home_runs': None,
+            'current_inning': None, 'currentInningOrdinal': None,
+            'inningState': None, 'num_of_outs': None,
+            'balls': None, 'strikes': None,
+            'current_pitcher': None, 'current_hitter': None,
         })
 
-    # balls/strikes default to 0 so draw_box comparisons don't fail
+    # --- Win probability and last-play: find last wp_event before target_utc ---
+    wp_events = tl.get('wp_events', [])
+    last_wp = None
+    for wp in wp_events:
+        if wp['time'] <= target_utc:
+            last_wp = wp
+        else:
+            break
+
+    if last_wp:
+        state['away_win_probability'] = last_wp['away_wp']
+        state['home_win_probability'] = last_wp['home_wp']
+        state['last_play']            = last_wp['last_play']
+    else:
+        state['away_win_probability'] = None
+        state['home_win_probability'] = None
+        state['last_play']            = None
+
     state.update({
-        'balls': 0, 'strikes': 0,
         'runner_on_first': None, 'runner_on_second': None, 'runner_on_third': None,
-        'away_win_probability': None, 'home_win_probability': None, 'last_play': None,
     })
     return state
+
+
+def _any_game_active(game_timelines, current_utc):
+    """Return True if any game has had at least one pitch thrown by current_utc
+    and hasn't ended more than 5 minutes ago.
+
+    pitch_events includes pre-game advisory/action events (mound visits, lineup
+    substitutions) with count 0-0.  Use the first event where balls+strikes > 0
+    (an actual pitch registered) or the first completed play, so pre-game
+    advisory events don't count as the game start.
+    """
+    for tl in game_timelines.values():
+        last_play    = tl.get('last_play_utc')
+        pitch_events = tl.get('pitch_events', [])
+        plays        = tl.get('plays', [])
+
+        # First pitch event that registered a ball or strike
+        game_start = None
+        for ev in pitch_events:
+            if (ev.get('balls', 0) or 0) + (ev.get('strikes', 0) or 0) > 0:
+                game_start = ev['time']
+                break
+        # Fall back to first completed play (handles first-pitch-hit where count stays 0-0)
+        if game_start is None and plays:
+            game_start = plays[0]['end_time']
+        # Last resort: first_pitch_utc from the schedule
+        if game_start is None:
+            game_start = tl.get('first_pitch_utc')
+
+        if not game_start or current_utc < game_start:
+            continue
+        game_end = (last_play + timedelta(minutes=5)) if last_play else (game_start + timedelta(hours=4))
+        if current_utc <= game_end:
+            return True
+    return False
 
 
 def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame_delay_ms, sport_id, config_data):
@@ -869,6 +1082,17 @@ def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame
     if not base_games:
         print(f"No games found for {date_str}")
         return
+
+    # --- Step 1b: Fetch standings as of this date so wildcard/division data is accurate ---
+    print(f"Fetching standings for {date_str}...")
+    try:
+        from standings import get_standings
+        from datetime import datetime as _dt
+        _date_obj = _dt.strptime(date_str, '%Y-%m-%d')
+        get_standings([103, 104], season=_date_obj.year, date=_date_obj.strftime('%m/%d/%Y'))
+        print("  standings ok")
+    except Exception as _e:
+        print(f"  standings error: {_e} (using cached)")
 
     # --- Step 2: Fetch play-by-play timeline once per game ---
     print(f"Fetching play-by-play for {len(base_games)} game(s)...")
@@ -905,7 +1129,7 @@ def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame
         if not all_first_pitches:
             print("Cannot determine start time — provide --gif-start/--gif-end")
             return
-        start_utc = min(all_first_pitches) - timedelta(minutes=5)
+        start_utc = min(all_first_pitches)
         end_utc   = (max(all_last_plays) + timedelta(minutes=5)) if all_last_plays \
                     else max(all_first_pitches) + timedelta(hours=4)
         start_dt = start_utc.astimezone(local_tz)
@@ -929,6 +1153,11 @@ def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame
         step += 1
         current_utc = current_dt.astimezone(pytz.utc)
         time_label  = current_dt.strftime("%H:%M")
+
+        if not _any_game_active(game_timelines, current_utc):
+            print(f"  [    dead] {current_dt.strftime('%H:%M')} — no active games, skipping")
+            current_dt += timedelta(minutes=interval_min)
+            continue
 
         print(f"  [{step:4d}/{total_steps}] {time_label}...", end=' ', flush=True)
 

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -518,13 +518,25 @@ def check_games_for_sport(date, sport_id):
     return 0
 
 
-def fetch_scoreboard_for_date(date, sport_id=None):
+def _local_time_to_timecode(date_str, time_str, timezone_str):
+    """Convert local date+time to MLB API timecode in Eastern Time (YYYYMMDD_HHMMSS)."""
+    eastern = pytz.timezone('America/New_York')
+    local_tz = pytz.timezone(timezone_str)
+    dt = datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M")
+    dt_local = local_tz.localize(dt)
+    dt_eastern = dt_local.astimezone(eastern)
+    return dt_eastern.strftime("%Y%m%d_%H%M%S")
+
+
+def fetch_scoreboard_for_date(date, sport_id=None, timecode=None):
     """
     Fetch scoreboard for a specific date and sport.
 
     Args:
         date: Date string in format 'YYYY-MM-DD'
         sport_id: Sport ID (1=MLB, 8=WBC, 11=College, etc.). If None, reads from config.
+        timecode: Optional MLB API timecode (YYYYMMDD_HHMMSS in Eastern Time) to fetch
+                  historical game state at a specific minute.
 
     Sport IDs:
         1  = MLB (default)
@@ -563,12 +575,15 @@ def fetch_scoreboard_for_date(date, sport_id=None):
             # Fall back to single sport_id
             sport_id = config_data.get('sport_id', 1)
 
-    print(f"Fetching games for {date} (sportId={sport_id})")
+    tc_info = f" @ {timecode}" if timecode else ""
+    print(f"Fetching games for {date}{tc_info} (sportId={sport_id})")
 
     endpoint_url = (
         'https://statsapi.mlb.com/api/v1/schedule?'
         f'startDate={date}&endDate={date}&sportId={sport_id}&hydrate=decisions,probablePitcher(note),linescore,flags,team'
     )
+    if timecode:
+        endpoint_url += f'&timecode={timecode}'
     response = requests.get(endpoint_url)
     data = response.json()
 
@@ -669,6 +684,77 @@ def scoreboard_generate(date_str, game_data, sport_id=None):
         print("No display update needed - image unchanged")
 
 
+def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame_delay_ms, sport_id, config_data):
+    """Generate an animated GIF of the scoreboard between two local times on a given date.
+
+    Fetches game state at each interval step via the MLB API timecode parameter,
+    renders each frame using orchestrate_score_board(bypass_cache=True), and
+    assembles all frames into an animated GIF.
+    """
+    from generate_image import orchestrate_score_board
+
+    tz_str = config_data.get('timezone', 'America/Chicago')
+    local_tz = pytz.timezone(tz_str)
+
+    start_dt = local_tz.localize(datetime.strptime(f"{date_str} {gif_start}", "%Y-%m-%d %H:%M"))
+    end_dt   = local_tz.localize(datetime.strptime(f"{date_str} {gif_end}",   "%Y-%m-%d %H:%M"))
+
+    if end_dt <= start_dt:
+        print("Error: --gif-end must be after --gif-start")
+        return
+
+    total_steps = int((end_dt - start_dt).total_seconds() / 60 / interval_min) + 1
+    print(f"Generating {total_steps}-frame GIF ({interval_min}min intervals, {frame_delay_ms}ms/frame)")
+    print(f"  Date: {date_str}  {gif_start}–{gif_end} {tz_str}")
+    print(f"  Output: {output_path}")
+
+    frames = []
+    current_dt = start_dt
+    step = 0
+
+    while current_dt <= end_dt:
+        step += 1
+        time_label = current_dt.strftime("%H:%M")
+        timecode = _local_time_to_timecode(date_str, time_label, tz_str)
+
+        print(f"  [{step:3d}/{total_steps}] {time_label} → {timecode} ET ...", end=' ', flush=True)
+
+        try:
+            fetch_scoreboard_for_date(date_str, sport_id, timecode=timecode)
+            game_state_data = read_json_file('data/games.json').get('games', [])
+            team_data = read_json_file('data/teams.json') or {}
+            if 'team_abbreviation' not in team_data:
+                team_data = {'team_abbreviation': {}}
+
+            result = orchestrate_score_board(game_state_data, team_data, date_str, bypass_cache=True)
+            if result:
+                image, _ = result
+                # PIL GIF requires palette ('P') mode; convert via 'L' to preserve bilevel look
+                frames.append(image.convert('L').convert('P'))
+                print("ok")
+            else:
+                print("no image")
+        except Exception as e:
+            print(f"error: {e}")
+
+        current_dt += timedelta(minutes=interval_min)
+
+    if not frames:
+        print("No frames were generated — GIF not saved.")
+        return
+
+    print(f"Assembling {len(frames)}-frame GIF...")
+    frames[0].save(
+        output_path,
+        save_all=True,
+        append_images=frames[1:],
+        optimize=False,
+        duration=frame_delay_ms,
+        loop=0,
+    )
+    print(f"✓ GIF saved to {output_path}")
+
+
 def main():
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
@@ -682,6 +768,15 @@ Examples:
   # Specify a date
   python scoreboard_generate.py --date 2024-07-26
 
+  # Time-travel: show scoreboard as it appeared at 7:32 PM local time
+  python scoreboard_generate.py --date 2025-04-01 --time 19:32
+
+  # Generate an animated GIF of the scoreboard from 6 PM to 11 PM
+  python scoreboard_generate.py --date 2025-04-01 --gif-start 18:00 --gif-end 23:00
+
+  # GIF with 5-minute intervals and faster playback
+  python scoreboard_generate.py --date 2025-04-01 --gif-start 19:00 --gif-end 22:30 --gif-interval 5 --gif-delay 300
+
   # World Baseball Classic game from 2023
   python scoreboard_generate.py --date 2023-03-21 --sport-id 8
 
@@ -693,6 +788,45 @@ Examples:
         '--date',
         type=str,
         help='Date to fetch games for (format: YYYY-MM-DD). Default: today'
+    )
+    parser.add_argument(
+        '--time',
+        type=str,
+        metavar='HH:MM',
+        help='Time-travel: show the scoreboard as it appeared at this local time on --date'
+    )
+    parser.add_argument(
+        '--gif-start',
+        type=str,
+        metavar='HH:MM',
+        help='GIF start time (local, HH:MM). Requires --date and --gif-end.'
+    )
+    parser.add_argument(
+        '--gif-end',
+        type=str,
+        metavar='HH:MM',
+        help='GIF end time (local, HH:MM). Requires --date and --gif-start.'
+    )
+    parser.add_argument(
+        '--gif-output',
+        type=str,
+        metavar='FILE',
+        default='scoreboard_timelapse.gif',
+        help='Output path for the generated GIF (default: scoreboard_timelapse.gif)'
+    )
+    parser.add_argument(
+        '--gif-interval',
+        type=int,
+        metavar='MINUTES',
+        default=1,
+        help='Minutes between each GIF frame (default: 1)'
+    )
+    parser.add_argument(
+        '--gif-delay',
+        type=int,
+        metavar='MS',
+        default=500,
+        help='Delay between GIF frames in milliseconds (default: 500)'
     )
     parser.add_argument(
         '--sport-id',
@@ -711,6 +845,18 @@ Examples:
     )
 
     args = parser.parse_args()
+
+    # --gif-start and --gif-end must be used together with --date
+    if bool(args.gif_start) != bool(args.gif_end):
+        parser.error("--gif-start and --gif-end must be used together")
+    if (args.gif_start or args.gif_end) and not args.date:
+        parser.error("--gif-start/--gif-end require --date")
+    if args.time and not args.date:
+        parser.error("--time requires --date")
+
+    # Time-travel and GIF modes are treated as explicit offline requests — bypass
+    # night mode, smart polling, and Discord state checks.
+    offline_mode = bool(args.time or args.gif_start or args.local)
 
     # Display platform information
     system_platform = platform.system()
@@ -737,8 +883,8 @@ Examples:
             # Window within same day (e.g. 0 to 7): active if start <= hour < end
             in_night_window = night_start <= current_hour < night_end
         if in_night_window:
-            if args.local:
-                print(f"Night mode: bypassed for local testing ({now_local.strftime('%H:%M')})")
+            if offline_mode:
+                print(f"Night mode: bypassed for offline/local request ({now_local.strftime('%H:%M')})")
             else:
                 print(f"Night mode: skipping refresh ({now_local.strftime('%H:%M')})")
                 return
@@ -746,8 +892,8 @@ Examples:
     dark_mode = config_data.get('dark_mode', False)
 
     # --- Discord state check ---
-    # Apply any pending changes from the Discord bot before doing anything else
-    discord_state = load_discord_state()
+    # Skip Discord changes for offline/time-travel/GIF modes — they're historical queries.
+    discord_state = None if offline_mode else load_discord_state()
     if discord_state:
         user = discord_state.get('requested_by', 'unknown')
         mode_req = discord_state.get('pending_mode', '')
@@ -794,9 +940,18 @@ Examples:
         date_str = now.strftime('%Y-%m-%d')
         print(f"Using today's date: {date_str}")
 
+    # --- GIF generation mode ---
+    if args.gif_start and args.gif_end:
+        _generate_gif(
+            date_str, args.gif_start, args.gif_end,
+            args.gif_output, args.gif_interval, args.gif_delay,
+            sport_id, config_data,
+        )
+        return
+
     # --- Smart polling: rate-limit MLB API calls based on game state ---
-    # Only applies when running on today's date (not a manual --date override or --local)
-    if not args.date and not args.local:
+    # Only applies when running on today's date without any offline/explicit flags
+    if not args.date and not offline_mode:
         sched = load_schedule_state()
 
         # Skip entirely if next game is a future date
@@ -817,30 +972,37 @@ Examples:
 
         if any_live:
             # Game in progress — always fetch, no throttle
-            interval_min = 0
+            polling_interval = 0
         elif all_done:
             # All games finished — check once per hour (scores won't change)
-            interval_min = 60
+            polling_interval = 60
         elif not cached_games:
             # No cached data yet today — use hourly until we confirm games exist
-            interval_min = 60
+            polling_interval = 60
         else:
             # Pre-game / scheduled — respect update_interval from config
-            interval_min = config_data.get('update_interval', 14)
+            polling_interval = config_data.get('update_interval', 14)
 
-        if interval_min > 0:
+        if polling_interval > 0:
             last_fetch = sched.get('last_game_fetch')
             if last_fetch:
                 try:
                     elapsed = datetime.now() - datetime.fromisoformat(last_fetch)
-                    if elapsed < timedelta(minutes=interval_min):
+                    if elapsed < timedelta(minutes=polling_interval):
                         mins = int(elapsed.total_seconds() // 60)
-                        print(f"Throttled — {mins}min since last fetch (interval={interval_min}min, state={'all_done' if all_done else 'pre-game'})")
+                        print(f"Throttled — {mins}min since last fetch (interval={polling_interval}min, state={'all_done' if all_done else 'pre-game'})")
                         return
                 except Exception:
                     pass
 
-    fetch_scoreboard_for_date(date_str, sport_id)
+    # --- Time-travel: convert local HH:MM to MLB API timecode ---
+    timecode = None
+    if args.time:
+        tz_str = config_data.get('timezone', 'America/Chicago')
+        timecode = _local_time_to_timecode(date_str, args.time, tz_str)
+        print(f"Time-travel: {date_str} {args.time} ({tz_str}) → timecode {timecode} ET")
+
+    fetch_scoreboard_for_date(date_str, sport_id, timecode=timecode)
 
     game_state_data = read_json_file('data/games.json')['games']
     team_data = read_json_file('data/teams.json')
@@ -849,8 +1011,8 @@ Examples:
     if not team_data or 'team_abbreviation' not in team_data:
         team_data = {'team_abbreviation': {}}
 
-    # After fetching: update schedule state
-    if not args.date and not args.local:
+    # After fetching: update schedule state (only for normal live-polling runs)
+    if not args.date and not offline_mode:
         sched = load_schedule_state()
         sched['last_game_fetch'] = datetime.now().isoformat(timespec='seconds')
         if not game_state_data:
@@ -873,24 +1035,31 @@ Examples:
         _run_single_game_mode(mode, game_state_data, team_data, config_data)
         print(f"\n✓ {mode.title()} view generated successfully!")
         print(f"  View image at: resulting_image.bmp")
-        if args.local and platform.system() == 'Darwin':
+        if offline_mode and platform.system() == 'Darwin':
             import subprocess
             subprocess.run(['open', 'resulting_image.bmp'], check=False)
         return
 
-    result = orchestrate_score_board(game_state_data, team_data, date_str)
+    # bypass_cache=True for time-travel so the image always renders (no stale-state skip)
+    result = orchestrate_score_board(game_state_data, team_data, date_str,
+                                     bypass_cache=bool(args.time))
 
     if result:
         sccoreboard_image, changed_regions = result
-        if needs_full_refresh() or not changed_regions:
-            print("Scoreboard: full refresh")
-            display_image(sccoreboard_image)
+        if args.time:
+            # Time-travel: just save the image, no e-ink update
+            sccoreboard_image.save('resulting_image.bmp')
+            print(f"\n✓ Time-travel snapshot saved to resulting_image.bmp")
         else:
-            print(f"Scoreboard: partial refresh ({len(changed_regions)} region(s))")
-            display_partial_regions(sccoreboard_image, changed_regions)
-        print(f"\n✓ Scoreboard generated successfully!")
-        print(f"  View image at: resulting_image.bmp")
-        if args.local and platform.system() == 'Darwin':
+            if needs_full_refresh() or not changed_regions:
+                print("Scoreboard: full refresh")
+                display_image(sccoreboard_image)
+            else:
+                print(f"Scoreboard: partial refresh ({len(changed_regions)} region(s))")
+                display_partial_regions(sccoreboard_image, changed_regions)
+            print(f"\n✓ Scoreboard generated successfully!")
+            print(f"  View image at: resulting_image.bmp")
+        if offline_mode and platform.system() == 'Darwin':
             import subprocess
             subprocess.run(['open', 'resulting_image.bmp'], check=False)
     else:


### PR DESCRIPTION
## Summary
- **Time-travel mode** (`--time HH:MM`): fetch and render the scoreboard as it appeared at any past minute on a given `--date`. Converts the local config timezone to an Eastern Time MLB API timecode (`&timecode=YYYYMMDD_HHMMSS`).
- **GIF generation** (`--gif-start HH:MM --gif-end HH:MM`): renders one frame per minute (configurable via `--gif-interval`) between two local times and assembles them into an animated GIF (`--gif-output`, `--gif-delay`). Useful for replaying an entire game night.
- **Full wildcard display**: the wildcard header strip now shows all eligible teams (up to 12 per league — all non-division-leaders) instead of just the top 10. A rounded rectangle box is drawn around the top-3 wildcard leaders per league.
- **`bypass_cache` in `orchestrate_score_board`**: new parameter skips the unchanged-image comparison and state writes, enabling clean rendering for GIF frames and time-travel snapshots without corrupting normal polling state.
- **`offline_mode` flag**: `--time`, `--gif-start`, and `--local` are consolidated; they bypass night mode, smart polling, and Discord state checks since they are explicit historical queries.

## Test plan
- [ ] `python src/scoreboard_generate.py --date 2025-04-01 --time 19:30` — renders a historical snapshot, saves to `resulting_image.bmp`, auto-opens on macOS
- [ ] `python src/scoreboard_generate.py --date 2025-04-01 --gif-start 19:00 --gif-end 22:00 --gif-interval 5` — generates a `scoreboard_timelapse.gif` with ~37 frames
- [ ] `--gif-start` without `--gif-end` (or without `--date`) prints an argparse error and exits cleanly
- [ ] Wildcard header shows all non-division-leader teams; a rounded box appears around the leftmost 3 (AL) and rightmost 3 (NL) slots
- [ ] Normal live-polling run is unaffected (no regression in smart polling, night mode, or Discord state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)