### PR TITLE
fix(pitchers): batch-fetch ERA since MLB API dropped note field

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -72,6 +72,35 @@ def fetch_win_probability(game_pk):
         return None, None, None
 
 
+def _fetch_pitcher_eras(pitcher_ids, season):
+    """Batch-fetch season ERA for a list of pitcher IDs. Returns {id: 'W-L, ERA ERA'}."""
+    if not pitcher_ids:
+        return {}
+    ids_str = ','.join(str(p) for p in pitcher_ids)
+    try:
+        url = (
+            f'https://statsapi.mlb.com/api/v1/people?personIds={ids_str}'
+            f'&hydrate=stats(group=pitching,type=season,season={season})'
+        )
+        resp = requests.get(url, timeout=10)
+        data = resp.json()
+    except Exception:
+        return {}
+    result = {}
+    for person in data.get('people', []):
+        pid = person.get('id')
+        for stat_group in person.get('stats', []):
+            splits = stat_group.get('splits', [])
+            if splits:
+                stat = splits[0].get('stat', {})
+                era = stat.get('era', '')
+                wins = stat.get('wins', '')
+                losses = stat.get('losses', '')
+                if era and not str(era).startswith('-'):
+                    result[pid] = f'{wins}-{losses}, {era} ERA'
+    return result
+
+
 def fetch_all_team_abbreviations(sport_id=1):
     """Fetch all team abbreviations for a given sport and cache to data/teams.json."""
     team_abbreviations = {}
@@ -243,12 +272,14 @@ def parse_games(data, sport_id=None, config=None):
             'away_team_id': away_team_id,
             'away_team_is_winner': away_team.get('isWinner'),
             'away_probable': away_team.get('probablePitcher', {}).get('fullName'),
+            '_away_probable_id': away_team.get('probablePitcher', {}).get('id'),
             'away_probable_note': away_team.get('probablePitcher', {}).get('note'),
             'away_team_series_number': away_team.get('seriesNumber'),
             'home_team_name': home_team_info.get('name'),
             'home_team_id': home_team_id,
             'home_team_is_winner': home_team.get('isWinner'),
             'home_probable': home_team.get('probablePitcher', {}).get('fullName'),
+            '_home_probable_id': home_team.get('probablePitcher', {}).get('id'),
             'home_probable_note': home_team.get('probablePitcher', {}).get('note'),
             'home_team_series_number': home_team.get('seriesNumber'),
             'double_header': game.get('doubleHeader'),
@@ -302,6 +333,29 @@ def parse_games(data, sport_id=None, config=None):
                 game_dict['away_win_probability'] = away_wp
                 game_dict['home_win_probability'] = home_wp
         game_array.append(game_dict)
+
+    # Batch-fetch probable pitcher ERA (MLB API no longer returns note field)
+    pitcher_ids = set()
+    for gd in game_array:
+        if gd.get('_away_probable_id'):
+            pitcher_ids.add(gd['_away_probable_id'])
+        if gd.get('_home_probable_id'):
+            pitcher_ids.add(gd['_home_probable_id'])
+    if pitcher_ids:
+        from datetime import date as _date
+        season = str(_date.today().year)
+        eras = _fetch_pitcher_eras(pitcher_ids, season)
+        for gd in game_array:
+            away_id = gd.pop('_away_probable_id', None)
+            home_id = gd.pop('_home_probable_id', None)
+            if away_id and away_id in eras and not gd.get('away_probable_note'):
+                gd['away_probable_note'] = eras[away_id]
+            if home_id and home_id in eras and not gd.get('home_probable_note'):
+                gd['home_probable_note'] = eras[home_id]
+    else:
+        for gd in game_array:
+            gd.pop('_away_probable_id', None)
+            gd.pop('_home_probable_id', None)
 
     save_off_results({'games': game_array}, 'games')
     save_off_results({'team_abbreviation': team_abbreviations}, 'teams')

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -1,5 +1,5 @@
 from generate_image import orchestrate_score_board
-from fetch_games import fetch_win_probability
+from fetch_games import fetch_win_probability, _fetch_pitcher_eras
 
 from datetime import datetime, timedelta
 import json
@@ -253,12 +253,14 @@ def parse_games(data, sport_id=None):
             'away_team_id': away_team_id,
             'away_team_is_winner': away_team.get('isWinner'),
             'away_probable': away_team.get('probablePitcher', {}).get('fullName'),
+            '_away_probable_id': away_team.get('probablePitcher', {}).get('id'),
             'away_probable_note': away_team.get('probablePitcher', {}).get('note'),
             'away_team_series_number': away_team.get('seriesNumber'),
             'home_team_name': home_team_info.get('name'),
             'home_team_id': home_team_id,
             'home_team_is_winner': home_team.get('isWinner'),
             'home_probable': home_team.get('probablePitcher', {}).get('fullName'),
+            '_home_probable_id': home_team.get('probablePitcher', {}).get('id'),
             'home_probable_note': home_team.get('probablePitcher', {}).get('note'),
             'home_team_series_number': home_team.get('seriesNumber'),
             'double_header': game.get('doubleHeader'),
@@ -312,6 +314,29 @@ def parse_games(data, sport_id=None):
                 game_dict['home_win_probability'] = home_wp
 
         game_array.append(game_dict)
+
+    # Batch-fetch probable pitcher ERA (MLB API no longer returns note field)
+    pitcher_ids = set()
+    for gd in game_array:
+        if gd.get('_away_probable_id'):
+            pitcher_ids.add(gd['_away_probable_id'])
+        if gd.get('_home_probable_id'):
+            pitcher_ids.add(gd['_home_probable_id'])
+    if pitcher_ids:
+        from datetime import date as _date
+        season = str(_date.today().year)
+        eras = _fetch_pitcher_eras(pitcher_ids, season)
+        for gd in game_array:
+            away_id = gd.pop('_away_probable_id', None)
+            home_id = gd.pop('_home_probable_id', None)
+            if away_id and away_id in eras and not gd.get('away_probable_note'):
+                gd['away_probable_note'] = eras[away_id]
+            if home_id and home_id in eras and not gd.get('home_probable_note'):
+                gd['home_probable_note'] = eras[home_id]
+    else:
+        for gd in game_array:
+            gd.pop('_away_probable_id', None)
+            gd.pop('_home_probable_id', None)
 
     # Save both games and updated team abbreviations
     save_off_results({'games': game_array}, 'games')


### PR DESCRIPTION
## Summary
- The MLB Stats API `probablePitcher(note)` hydration no longer returns the ERA/record note field (returns `null`)
- Added `_fetch_pitcher_eras()` in `fetch_games.py`: after parsing all games, collects probable pitcher IDs and makes **one** batch call to `/api/v1/people?personIds=...&hydrate=stats(group=pitching,type=season,...)` 
- Backfills `away_probable_note` / `home_probable_note` as `'W-L, ERA ERA'` — same format `_pitcher_line()` already expects
- Applied to both `fetch_games.py` (live display) and `scoreboard_generate.py` (GIF/historical)

## Test plan
- [ ] Run `python src/fetch_games.py --date <today>` and verify `data/games.json` has non-null `away_probable_note` / `home_probable_note`
- [ ] Render scoreboard and confirm pitcher ERA appears next to name on scheduled games

🤖 Generated with [Claude Code](https://claude.com/claude-code)