### PR TITLE
fix(polling): prevent stale display when game stuck in mid-game state

### DIFF
--- a/main.py
+++ b/main.py
@@ -184,7 +184,13 @@ def _should_skip_poll(date_str, config, sched):
         cached_games = []
 
     _final_states = {'Final', 'Game Over', 'Final: Tied', 'Postponed', 'Delayed', 'Completed Early'}
-    any_live = any(g.get('detailed_state') == 'In Progress' for g in cached_games)
+    # Any game that has started (current_inning > 0) but isn't in a terminal state —
+    # catches 'In Progress' plus any other mid-game API state (e.g. rain delay, challenge)
+    # that would leave the display stuck showing stale inning data.
+    any_live = any(
+        g.get('detailed_state') not in _final_states and (g.get('current_inning') or 0) > 0
+        for g in cached_games
+    )
     all_done = bool(cached_games) and all(g.get('detailed_state') in _final_states for g in cached_games)
 
     if any_live:


### PR DESCRIPTION
## Summary
- `any_live` in `_should_skip_poll` previously only matched `detailed_state == 'In Progress'`, so a game in a rain delay, manager challenge, or other non-final mid-game API state would fall through to the 14-minute throttle
- If the cron had just run, the next cycle would skip the fetch entirely, leaving the display stuck showing stale inning data (e.g. stuck in the 8th inning with no active games)
- Fix expands `any_live` to catch any game where `current_inning > 0` and `detailed_state` is not in `_final_states` — this covers all mid-game states without over-fetching for pre-game scheduled games

## Test plan
- [ ] Verify normal in-progress games still poll without throttle
- [ ] Confirm all-final game days still throttle to 60 min
- [ ] Confirm pre-game/scheduled days still use `update_interval` (14 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)