### PR TITLE
feat(scoreboard): live pitch count, batter stats & speed in game boxes

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,6 +78,10 @@ small_logo_x_offset: 2
 # Left edge = 0% (certain loss), right edge = 100% (certain win). Only shown for In Progress games.
 scoreboard_win_probability: true
 
+# Live details in scoreboard boxes: pitch count, batter today stats + last AB result, last pitch speed.
+# Adds one extra API call (live feed) per in-progress game per refresh cycle.
+scoreboard_live_details: true
+
 # Discord bot configuration
 # Get token from https://discord.com/developers/applications
 # Set channel_id to restrict commands to one channel (0 = any channel)

--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -332,6 +332,10 @@ def parse_games(data, sport_id=None, config=None):
             if config.get('scoreboard_win_probability', False):
                 game_dict['away_win_probability'] = away_wp
                 game_dict['home_win_probability'] = home_wp
+            if config.get('scoreboard_live_details', False):
+                from game_detail_fetch import fetch_scoreboard_live_extras
+                extras = fetch_scoreboard_live_extras(game_id)
+                game_dict.update(extras)
         game_array.append(game_dict)
 
     # Batch-fetch probable pitcher ERA (MLB API no longer returns note field)

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -123,6 +123,62 @@ def fetch_pitch_view_data(game_pk):
     }
 
 
+def fetch_scoreboard_live_extras(game_pk):
+    """Fetch pitch count, batter game stats, last at-bat result, and last pitch speed
+    from the live feed for use in the scoreboard box.
+
+    Returns a dict with keys: pitch_count, batter_hits, batter_at_bats,
+    batter_last_result, last_pitch_speed, last_pitch_type.
+    All values default to None / '' on any failure.
+    """
+    try:
+        data = fetch_live_feed(game_pk)
+        live = data.get('liveData', {})
+        plays = live.get('plays', {})
+        linescore = live.get('linescore', {})
+        boxscore = live.get('boxscore', {})
+
+        pitcher_id = linescore.get('defense', {}).get('pitcher', {}).get('id')
+        batter_id = linescore.get('offense', {}).get('batter', {}).get('id')
+
+        pitcher_info = _get_player_info(boxscore, pitcher_id, 'pitching')
+        batter_info = _get_player_info(boxscore, batter_id, 'batting')
+
+        pitch_count = pitcher_info.get('stats', {}).get('numberOfPitches')
+        batter_hits = batter_info.get('stats', {}).get('hits')
+        batter_at_bats = batter_info.get('stats', {}).get('atBats')
+
+        # Last completed at-bat result for the current batter (e.g. HR, K, 2B)
+        batter_last_result = ''
+        for play in reversed(plays.get('allPlays', [])):
+            if play.get('matchup', {}).get('batter', {}).get('id') == batter_id:
+                event = play.get('result', {}).get('event', '')
+                batter_last_result = _EVENT_CODE_MAP.get(event, event[:3] if event else '')
+                break
+
+        # Last pitch speed and type from the most recent pitch event
+        last_speed = None
+        last_type = ''
+        for event in reversed(plays.get('currentPlay', {}).get('playEvents', [])):
+            if event.get('isPitch'):
+                pd = event.get('pitchData', {})
+                last_speed = pd.get('startSpeed')
+                raw_code = event.get('details', {}).get('type', {}).get('code', '') or ''
+                last_type = _PITCH_TYPE_ABBR.get(raw_code, raw_code)
+                break
+
+        return {
+            'pitch_count': pitch_count,
+            'batter_hits': batter_hits,
+            'batter_at_bats': batter_at_bats,
+            'batter_last_result': batter_last_result,
+            'last_pitch_speed': last_speed,
+            'last_pitch_type': last_type,
+        }
+    except Exception:
+        return {}
+
+
 def _extract_pitches(plays):
     """Extract pitch locations from the current at-bat, falling back to the last completed at-bat."""
     sources = [plays.get('currentPlay', {})]
@@ -345,6 +401,28 @@ def _get_player_info(boxscore, player_id, stat_type):
                     'season': season,
                 }
     return {'name': '', 'stats': {}, 'season': {}}
+
+
+# --- Pitch type display abbreviations (Statcast code → scoreboard label) ---
+
+_PITCH_TYPE_ABBR = {
+    'FF': 'FB',  # Four-seam fastball
+    'FA': 'FB',  # Generic fastball
+    'FT': 'FB',  # Two-seam fastball
+    'SI': 'SI',  # Sinker
+    'FC': 'CT',  # Cutter
+    'SL': 'SL',  # Slider
+    'ST': 'SW',  # Sweeper
+    'SW': 'SW',
+    'CH': 'CH',  # Changeup
+    'CU': 'CB',  # Curveball
+    'CS': 'CB',
+    'KC': 'KC',  # Knuckle-curve
+    'FS': 'SP',  # Splitter
+    'KN': 'KN',  # Knuckleball
+    'EP': 'EP',  # Eephus
+    'SC': 'SC',  # Screwball
+}
 
 
 # --- Scorecard Data ---

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1148,10 +1148,56 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             venue_ppd_txt, venue_ppd_fnt = fit_text(venue_ppd, max_text_width)
             draw.text((start_x + 7, start_y + 25 + 74), venue_ppd_txt, font=venue_ppd_fnt, fill=0)
     elif game_data['detailed_state'] == 'In Progress':
-        pitcher_str, pitcher_font = fit_text(f'P: {game_data.get("current_pitcher") or ""}', max_text_width)
-        hitter_str, hitter_font = fit_text(f'AB: {game_data.get("current_hitter") or ""}', max_text_width)
+        # Right-column pitch info: speed on count row, "TYPE (count)" on pitcher line
+        _pc = game_data.get('pitch_count')
+        _pt = game_data.get('last_pitch_type', '')   # e.g. "FB", "SL", "CH"
+        _lps = game_data.get('last_pitch_speed')
+
+        # Pitcher line right badge: "FB (87)", "(87)", "FB", or ""
+        if _pc is not None and _pt:
+            _right_str = f'{_pt} ({_pc})'
+        elif _pc is not None:
+            _right_str = f'({_pc})'
+        elif _pt:
+            _right_str = _pt
+        else:
+            _right_str = ''
+        _right_w = int(font11.getlength(_right_str)) + 2 if _right_str else 0
+
+        pitcher_str, pitcher_font = fit_text(
+            f'P: {game_data.get("current_pitcher") or ""}',
+            max_text_width - _right_w,
+        )
         draw.text((start_x + 5, start_y + 25 + 74), pitcher_str, font=pitcher_font, fill=0)
+        if _right_str:
+            draw.text((start_x + horizonta_len - _right_w, start_y + 25 + 74), _right_str, font=font11, fill=0)
+
+        # Speed right-aligned above the pitch count column on the B/S row (bold)
+        if _lps:
+            _speed_str = str(int(_lps))
+            _speed_w = int(font11.getlength(_speed_str)) + 2
+            _speed_x = start_x + horizonta_len - _speed_w
+            _speed_y = start_y + 25 + 62
+            draw.text((_speed_x,     _speed_y), _speed_str, font=font11, fill=0)
+            draw.text((_speed_x + 1, _speed_y), _speed_str, font=font11, fill=0)
+
+        # Batter stats "2-4 HR" right-anchored on hitter line
+        _bh = game_data.get('batter_hits')
+        _ba = game_data.get('batter_at_bats')
+        _blr = game_data.get('batter_last_result', '')
+        _ba_str = ''
+        if _bh is not None and _ba is not None:
+            _ba_str = f'{_bh}-{_ba}'
+            if _blr:
+                _ba_str += f' {_blr}'
+        _ba_w = int(font11.getlength(_ba_str)) + 2 if _ba_str else 0
+        hitter_str, hitter_font = fit_text(
+            f'AB: {game_data.get("current_hitter") or ""}',
+            max_text_width - _ba_w,
+        )
         draw.text((start_x + 7, start_y + 25 + 89), hitter_str, font=hitter_font, fill=0)
+        if _ba_str:
+            draw.text((start_x + horizonta_len - _ba_w, start_y + 25 + 89), _ba_str, font=font11, fill=0)
         
     if game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied', 'Postponed', 'Delayed'):
         # Normalize display labels
@@ -1407,8 +1453,8 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         Himage = draw_circle(Himage, (start_x + 34 + 63, start_y + 25 + 68), 4, strikes_list[1])
 
         if game_data.get('save_situation'):
-            sv_w = int(font11.getlength('SV'))
-            draw.text((start_x + horizonta_len - sv_w - 2, start_y + 25 + 61), 'SV', font=font11, fill=0)
+            _sv_w = int(font9.getlength('SV'))
+            draw.text((start_x + horizonta_len - _sv_w - 2, start_y + 21), 'SV', font=font9, fill=0)
     else:
 
         # Perfect game takes precedence over no-hitter display

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -312,6 +312,10 @@ def parse_games(data, sport_id=None):
             if config_data.get('scoreboard_win_probability', False):
                 game_dict['away_win_probability'] = away_wp
                 game_dict['home_win_probability'] = home_wp
+            if config_data.get('scoreboard_live_details', False):
+                from game_detail_fetch import fetch_scoreboard_live_extras
+                extras = fetch_scoreboard_live_extras(game_id)
+                game_dict.update(extras)
 
         game_array.append(game_dict)
 


### PR DESCRIPTION
## Summary
- Adds `fetch_scoreboard_live_extras()` to `game_detail_fetch.py` — fetches pitch count, batter game stats (H/AB), last AB result, and last pitch speed/type from the MLB live feed in a single call
- Adds `_PITCH_TYPE_ABBR` mapping (Statcast codes → display labels: FF→FB, SL→SL, CU→CB, etc.)
- In-progress scoreboard boxes now show:
  - **Pitcher line**: pitch type + count right-aligned, e.g. `FB (87)`
  - **Hitter line**: today's stats + last AB result right-aligned, e.g. `2-4 HR`
  - **B/S count row**: last pitch speed bold right-aligned, e.g. `100`
  - **SV badge**: repositioned to top-right corner under the header
- Wired into both `fetch_games.py` and `scoreboard_generate.py` fetch paths
- Gated behind new config flag `scoreboard_live_details: true` (defaults to on)

## Test plan
- [ ] Run `poetry run python src/scoreboard_generate.py` during a live game and confirm pitch count, batter stats, and speed appear in in-progress boxes
- [ ] Confirm graceful degradation: set `scoreboard_live_details: false` and verify boxes render identically to before with no errors
- [ ] Confirm save situation: `SV` badge appears top-right, speed still shows on count row
- [ ] Confirm Final/Scheduled boxes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)