### PR TITLE
fix(delay): display rain delays correctly and keep polling during delays

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,10 +183,10 @@ def _should_skip_poll(date_str, config, sched):
     except Exception:
         cached_games = []
 
-    _final_states = {'Final', 'Game Over', 'Final: Tied', 'Postponed', 'Delayed', 'Completed Early'}
+    _final_states = {'Final', 'Game Over', 'Final: Tied', 'Postponed', 'Completed Early'}
     # Any game that has started (current_inning > 0) but isn't in a terminal state —
-    # catches 'In Progress' plus any other mid-game API state (e.g. rain delay, challenge)
-    # that would leave the display stuck showing stale inning data.
+    # catches 'In Progress', rain delays, and any other mid-game API state.
+    # 'Delayed' is intentionally excluded from _final_states so delayed games keep polling.
     any_live = any(
         g.get('detailed_state') not in _final_states and (g.get('current_inning') or 0) > 0
         for g in cached_games

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -190,8 +190,24 @@ import time
 from PIL import Image, ImageDraw, ImageFont, ImageOps, ImageEnhance
 import traceback
 
-# Tracks when each game's inning break was first detected: (game_pk, inning, state) -> epoch
-_break_start_times: dict = {}
+_BREAK_STATE_FILE = os.path.join(os.path.dirname(__file__), '..', 'data', 'inning_break_state.json')
+
+
+def _load_break_state() -> dict:
+    try:
+        with open(_BREAK_STATE_FILE) as _f:
+            return json.load(_f)
+    except (FileNotFoundError, ValueError):
+        return {}
+
+
+def _save_break_state(state: dict) -> None:
+    try:
+        os.makedirs(os.path.dirname(_BREAK_STATE_FILE), exist_ok=True)
+        with open(_BREAK_STATE_FILE, 'w') as _f:
+            json.dump(state, _f)
+    except Exception:
+        pass
 
 # logging.basicConfig(level=logging.DEBUG)
 
@@ -484,11 +500,13 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
         
     DISPLAY_PROBS = False
     
-    if game_state in ('Scheduled', 'Pre-Game', 'Warmup'):
+    if game_state in ('Scheduled', 'Pre-Game', 'Warmup', 'Delayed Start'):
         innings = [None] * 12
         away, home = innings, innings
-        if game_state != 'Warmup':
-            game_state = start_time 
+        if game_state not in ('Warmup', 'Delayed Start'):
+            game_state = start_time
+        elif game_state == 'Delayed Start':
+            game_state = 'Delayed'
         DISPLAY_PROBS = True
 
         draw.text((25 + col_start + 82, 30 + row_start), away_probable, font = font24, fill = 0)
@@ -1049,6 +1067,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         game_data = dict(game_data)
         game_data['detailed_state'] = 'In Progress'
 
+    # Delayed Start = game hasn't begun yet; treat like Pre-Game (show pitcher probables)
+    if game_data.get('detailed_state') == 'Delayed Start':
+        game_data = dict(game_data)
+        game_data['detailed_state'] = 'Pre-Game'
+
     # Only show score once the first pitch has been thrown. Evidence of play:
     # a ball/strike in the current at-bat, any out, any hit, a runner on base,
     # an inning break, or the game past inning 1. If none of these are present
@@ -1196,6 +1219,10 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         if venue_ppd:
             venue_ppd_txt, venue_ppd_fnt = fit_text(venue_ppd, max_text_width)
             draw.text((start_x + 7, start_y + 25 + 74), venue_ppd_txt, font=venue_ppd_fnt, fill=0)
+    elif _delayed_with_score:
+        reason = game_data.get('postpone_reason') or ''
+        delay_line, delay_fnt = fit_text(f'Delay: {reason}' if reason else 'Delay', max_text_width)
+        draw.text((start_x + 7, start_y + 25 + 59), delay_line, font=delay_fnt, fill=0)
     elif game_data['detailed_state'] == 'In Progress':
         # Right-column pitch info: speed on count row, "TYPE (count)" on pitcher line
         _pc = game_data.get('pitch_count')
@@ -1335,7 +1362,12 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     away_runs = str(game_data.get('away_runs', 0) if game_data.get('away_runs', 0) is not None else 0)
     home_runs = str(game_data.get('home_runs', 0) if game_data.get('home_runs', 0) is not None else 0)
 
-    is_game_started = game_data['detailed_state'] in ['Final', 'Game Over', 'In Progress', 'Final: Tied']
+    # Mid-game delay: game started (has innings) but play is suspended
+    _delayed_with_score = (
+        game_data['detailed_state'] == 'Delayed'
+        and (game_data.get('current_inning') or 0) > 0
+    )
+    is_game_started = game_data['detailed_state'] in ['Final', 'Game Over', 'In Progress', 'Final: Tied'] or _delayed_with_score
     is_game_finished = game_data['detailed_state'] in ['Final', 'Game Over', 'Final: Tied']
 
     # Display score if game has started, otherwise show team records
@@ -1513,13 +1545,15 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         # bases — two refreshes per break: first 60s = 1B only, after 60s = 1B + 3B.
         # Elapsed time is measured from when the break was first detected for this game/inning.
         if _between_innings:
-            _bkey = (game_data.get('game_pk'), game_data.get('current_inning'), game_data.get('inningState'))
-            if _bkey not in _break_start_times:
-                _break_start_times[_bkey] = time.time()
-                # Drop stale keys for this game (previous inning breaks)
-                for _k in [k for k in _break_start_times if k[0] == _bkey[0] and k != _bkey]:
-                    del _break_start_times[_k]
-            _elapsed = time.time() - _break_start_times[_bkey]
+            _bkey = f"{game_data.get('game_pk')}_{game_data.get('current_inning')}_{game_data.get('inningState')}"
+            _brk = _load_break_state()
+            if _bkey not in _brk:
+                # New break: clear any old keys for this game, record start time
+                _brk = {k: v for k, v in _brk.items()
+                        if not k.startswith(f"{game_data.get('game_pk')}_")}
+                _brk[_bkey] = time.time()
+                _save_break_state(_brk)
+            _elapsed = time.time() - _brk.get(_bkey, time.time())
             _hi_first = True
             _hi_second = False
             _hi_third = (_elapsed >= 60)


### PR DESCRIPTION
## Summary
- **Pre-game delay (`Delayed Start`)**: normalized to `Pre-Game` in both `draw_box` and the linescore view — shows pitcher probables and start time instead of broken/empty state
- **Mid-game delay (`Delayed` with innings played)**: now shows the score, inning, and a "Delay" label in the info row so the display reflects the frozen game state
- **Polling fix**: removed `'Delayed'` from `_final_states` in `_should_skip_poll` — previously a rain-delayed game caused `any_live = False` and polling throttled to 60 min, leaving the display stale until the game resumed or ended
- **Between-inning second refresh**: replaced in-memory `_break_start_times` dict (reset every cron invocation) with a disk-backed `data/inning_break_state.json` so the 60-second elapsed time persists across process boundaries and actually triggers a different image on the second render

## Test plan
- [ ] Simulate `Delayed Start` state in a game dict — box should show pitcher probables and scheduled time
- [ ] Simulate `Delayed` state with `current_inning=9` — box should show score + "Delay" label, header should show "Delayed"
- [ ] Confirm polling doesn't throttle during a delay (check logs for "Throttled" message not appearing when a game has `Delayed` + `current_inning > 0`)
- [ ] Verify `data/inning_break_state.json` is created on first between-inning render and that `_hi_third` flips after 60 s on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)