### PR TITLE
feat(scoreboard): live play display fixes for in-progress games

### DIFF
--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -157,16 +157,32 @@ def fetch_scoreboard_live_extras(game_pk):
                 batter_last_result = _EVENT_CODE_MAP.get(event, event[:3] if event else '')
                 break
 
-        # Last pitch speed and type from the most recent pitch event
+        # Scan current at-bat: pitch count, last strike type, and whether AB is complete
         last_speed = None
         last_type = ''
-        for event in reversed(plays.get('currentPlay', {}).get('playEvents', [])):
-            if event.get('isPitch'):
-                pd = event.get('pitchData', {})
-                last_speed = pd.get('startSpeed')
-                raw_code = event.get('details', {}).get('type', {}).get('code', '') or ''
+        last_strike_call = ''
+        at_bat_pitch_count = 0
+        current_play_events = plays.get('currentPlay', {}).get('playEvents', [])
+        for ev in current_play_events:
+            if ev.get('isPitch'):
+                at_bat_pitch_count += 1
+                pd = ev.get('pitchData', {})
+                details = ev.get('details', {})
+                call_code = (details.get('call', {}).get('code', '') or '').upper()
+                if call_code in ('S', 'W', 'T', 'O', 'M'):
+                    last_strike_call = 'S'  # swinging
+                elif call_code == 'C':
+                    last_strike_call = 'L'  # looking
+                elif call_code in ('F', 'L', 'R'):
+                    last_strike_call = 'F'  # foul
+                # always overwrite so the last pitch in the AB is shown
+                raw_code = details.get('type', {}).get('code', '') or ''
                 last_type = _PITCH_TYPE_ABBR.get(raw_code, raw_code)
-                break
+                last_speed = pd.get('startSpeed')
+
+        current_at_bat_complete = bool(
+            plays.get('currentPlay', {}).get('result', {}).get('event')
+        )
 
         return {
             'pitch_count': pitch_count,
@@ -176,6 +192,9 @@ def fetch_scoreboard_live_extras(game_pk):
             'last_pitch_speed': last_speed,
             'last_pitch_type': last_type,
             'due_up': on_deck_name,
+            'last_strike_call': last_strike_call,
+            'at_bat_pitch_count': at_bat_pitch_count,
+            'current_at_bat_complete': current_at_bat_complete,
         }
     except Exception:
         return {}
@@ -311,13 +330,19 @@ def fetch_field_view_data(game_pk):
     last_hit = all_hits[-1] if all_hits else None
     hit_coords = (last_hit['x'], last_hit['y']) if last_hit else None
 
-    # Last play description
+    # Last play description — only show plays from the current half inning so the
+    # previous half inning's last play doesn't bleed into the new half inning header.
     current_play = plays.get('currentPlay', {})
     last_play_desc = current_play.get('result', {}).get('description', '')
     if not last_play_desc:
         all_plays = plays.get('allPlays', [])
         if all_plays:
-            last_play_desc = all_plays[-1].get('result', {}).get('description', '')
+            last_completed = all_plays[-1]
+            cur_half = 'bottom' if inning_state == 'Bottom' else 'top'
+            play_inning = last_completed.get('about', {}).get('inning')
+            play_half = last_completed.get('about', {}).get('halfInning', '')
+            if play_inning == current_inning and play_half == cur_half:
+                last_play_desc = last_completed.get('result', {}).get('description', '')
 
     # Linescore innings for mini table
     innings_list = linescore.get('innings', [])
@@ -435,6 +460,7 @@ _EVENT_CODE_MAP = {
     'Strikeout Double Play': 'K',
     'Walk': 'BB',
     'Intent Walk': 'IBB',
+    'Runner Placed On Base': 'PR',
     'Hit By Pitch': 'HBP',
     'Single': '1B',
     'Double': '2B',

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1408,14 +1408,22 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 _ba_str = f'{_bh}-{_ba}'
                 if _blr:
                     _ba_str += f' {_blr}'
-            _ba_w = int(font11.getlength(_ba_str)) + 2 if _ba_str else 0
-            hitter_str, hitter_font = fit_text(
-                f'AB: {game_data.get("current_hitter") or ""}',
-                max_text_width - _ba_w,
-            )
-            draw.text((start_x + 7, start_y + 25 + 89), hitter_str, font=hitter_font, fill=0)
-            if _ba_str:
-                draw.text((start_x + horizonta_len - _ba_w, start_y + 25 + 89), _ba_str, font=font11, fill=0)
+            _ba_w = min(int(font11.getlength(_ba_str)) + 2, horizonta_len - 8) if _ba_str else 0
+            _ab_done = game_data.get('current_at_bat_complete', False)
+            if _ab_done:
+                # Play resolved — show the on-deck player as the next batter while API catches up
+                _next = _format_player_name(game_data.get('due_up') or '')
+                if _next:
+                    _next_str, _next_font = fit_text(f'AB: {_next}', max_text_width)
+                    draw.text((start_x + 7, start_y + 25 + 89), _next_str, font=_next_font, fill=0)
+            else:
+                hitter_str, hitter_font = fit_text(
+                    f'AB: {game_data.get("current_hitter") or ""}',
+                    max(1, max_text_width - _ba_w),
+                )
+                draw.text((start_x + 7, start_y + 25 + 89), hitter_str, font=hitter_font, fill=0)
+                if _ba_str:
+                    draw.text((start_x + horizonta_len - _ba_w, start_y + 25 + 89), _ba_str, font=font11, fill=0)
         
     if game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied', 'Postponed', 'Delayed'):
         # Normalize display labels
@@ -1502,14 +1510,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                     draw.text((_due_x,     start_y + 5), _due_str, font=_due_fnt, fill=0)
                     draw.text((_due_x + 1, start_y + 5), _due_str, font=_due_fnt, fill=0)
         else:
-            raw_play = game_data.get('last_play') or ''
+            raw_play = (game_data.get('last_play') or '').replace('**', '').strip()
             if raw_play:
-                max_play_w = horizonta_len - _total_time_w - 10
+                max_play_w = max(horizonta_len - _total_time_w - 10, 0)
                 play_text = raw_play
                 _play_font = _get_font(12)
-                while play_text and int(_play_font.getlength(play_text)) > max_play_w:
-                    play_text = play_text[:-2] + '…'
-                if play_text:
+                while len(play_text) > 1 and int(_play_font.getlength(play_text)) > max_play_w:
+                    play_text = play_text[:-2] + '.'
+                if play_text and int(_play_font.getlength(play_text)) <= max_play_w:
                     pw = int(_play_font.getlength(play_text))
                     px = start_x + horizonta_len - pw - 2
                     draw.text((px, start_y + 4), play_text, font=_play_font, fill=0)
@@ -1742,13 +1750,24 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             Himage = draw_circle(Himage, (start_x + 34, start_y + 25 + 68), 4, balls_list[1])
             Himage = draw_circle(Himage, (start_x + 46, start_y + 25 + 68), 4, balls_list[2])
 
-            strikes_list = [None] * 3
-            for i in range(1, 3):
-                strikes_list[i-1] = i <= game_data['strikes']
+            _num_strikes = game_data.get('strikes') or 0
+            strikes_list = [i + 1 <= _num_strikes for i in range(2)]
+
+            _lsc = game_data.get('last_strike_call', '')
+            _show_k = _lsc == 'S' or (_lsc == 'F' and _num_strikes >= 2)
 
             draw.text((start_x + 22 + 47, start_y + 25 + 59), 'S', font=font14, fill=0)
-            Himage = draw_circle(Himage, (start_x + 22 + 63, start_y + 25 + 68), 4, strikes_list[0])
-            Himage = draw_circle(Himage, (start_x + 34 + 63, start_y + 25 + 68), 4, strikes_list[1])
+            for _si, (_scx, _scy) in enumerate([
+                (start_x + 22 + 63, start_y + 25 + 68),
+                (start_x + 34 + 63, start_y + 25 + 68),
+            ]):
+                Himage = draw_circle(Himage, (_scx, _scy), 4, strikes_list[_si])
+                if strikes_list[_si] and _si == _num_strikes - 1 and _show_k:
+                    _kfont = _get_font(7)
+                    _kw = int(_kfont.getlength('K'))
+                    _kx, _ky = _scx - _kw // 2, _scy - 4
+                    draw.text((_kx,     _ky), 'K', font=_kfont, fill=255)
+                    draw.text((_kx + 1, _ky), 'K', font=_kfont, fill=255)
 
         # SV badge — keep visible during inning breaks too
         if game_data.get('save_situation'):


### PR DESCRIPTION
## Summary
- **Strike circles**: bold white K overlay on last filled circle for swinging strikes and fouls with 2 strikes; looking strikes stay plain filled circles
- **AB row**: when current at-bat resolves, shows on-deck player as next-up during API lag; automatically switches to correct batter with stats once API catches up
- **last_play header**: scoped to current half inning — `allPlays[-1]` fallback only used when the play matches current inning + half, so previous half inning's final play no longer bleeds into the new half inning header
- **last_play**: strips MLB API `**` placeholders from automatic runner descriptions; truncation loop fixed (potential infinite loop on single-char string, `'.'` replaces `…` for font compatibility)
- **Fetch refactor**: single forward pass through `currentPlay.playEvents` now tracks pitch count, last strike call type (`L`/`S`/`F`), at-bat completion state, speed, and pitch type — replaces separate reversed loop
- **EVENT_CODE_MAP**: `'Runner Placed On Base'` → `'PR'`

## Test plan
- [ ] Swinging strike shows bold K inside last filled strike circle
- [ ] Called strike shows plain filled circle (no K)
- [ ] Foul with 2 strikes shows bold K; foul with 0-1 strikes shows plain circle
- [ ] After a HR/single/out resolves, AB row shows on-deck player, then correct next batter once API updates
- [ ] New half inning header is clean — no bleed from previous half inning's last play
- [ ] Games with automatic extra-inning runners don't show `**` in last_play

🤖 Generated with [Claude Code](https://claude.com/claude-code)