### PR TITLE
fix(standings): movement indicators work on live runs, no false positives for ties

### DIFF
--- a/main.py
+++ b/main.py
@@ -357,7 +357,11 @@ Examples:
         if _should_refresh_standings(sched):
             print("Refreshing standings (new Finals detected or no cache)...")
             try:
-                get_standings([103, 104], season=datetime.now().year)
+                today = datetime.now()
+                get_standings([103, 104], season=today.year)
+                prev_day = today - timedelta(days=1)
+                get_standings([103, 104], season=prev_day.year,
+                              date=prev_day.strftime('%m/%d/%Y'), save_as='standings_prev')
                 games = load_json_file('games.json').get('games', [])
                 sched['standings_final_pks'] = [
                     str(g['game_pk']) for g in games

--- a/poetry.lock
+++ b/poetry.lock
@@ -154,6 +154,61 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "imageio"
+version = "2.37.3"
+description = "Read and write images and video across all major formats. Supports scientific and volumetric data."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\") and python_version >= \"3.10\""
+files = [
+    {file = "imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0"},
+    {file = "imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451"},
+]
+
+[package.dependencies]
+imageio-ffmpeg = {version = "*", optional = true, markers = "extra == \"ffmpeg\""}
+numpy = "*"
+pillow = ">=8.3.2"
+psutil = {version = "*", optional = true, markers = "extra == \"ffmpeg\""}
+
+[package.extras]
+all-plugins = ["astropy", "av", "fsspec[http]", "imageio-ffmpeg", "numpy (>2)", "pillow-heif", "psutil", "rawpy", "tifffile"]
+all-plugins-pypy = ["fsspec[http]", "imageio-ffmpeg", "pillow-heif", "psutil", "tifffile"]
+dev = ["black", "flake8", "fsspec[github]", "pytest", "pytest-cov"]
+docs = ["numpydoc", "pydata-sphinx-theme", "sphinx (<6)"]
+ffmpeg = ["imageio-ffmpeg", "psutil"]
+fits = ["astropy"]
+freeimage = ["fsspec[http]"]
+full = ["astropy", "av", "black", "flake8", "fsspec[github,http]", "imageio-ffmpeg", "numpy (>2)", "numpydoc", "pillow-heif", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "rawpy", "sphinx (<6)", "tifffile"]
+gdal = ["gdal"]
+itk = ["itk"]
+linting = ["black", "flake8"]
+pillow-heif = ["pillow-heif"]
+pyav = ["av"]
+rawpy = ["numpy (>2)", "rawpy"]
+test = ["fsspec[github]", "pytest", "pytest-cov"]
+tifffile = ["tifffile"]
+
+[[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+description = "FFMPEG wrapper for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\") and python_version >= \"3.10\""
+files = [
+    {file = "imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61"},
+    {file = "imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742"},
+    {file = "imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc"},
+    {file = "imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282"},
+    {file = "imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2"},
+    {file = "imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a"},
+    {file = "imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755"},
+]
+
+[[package]]
 name = "numpy"
 version = "2.0.2"
 description = "Fundamental package for array computing in Python"
@@ -609,6 +664,42 @@ typing = ["typing-extensions ; python_version < \"3.10\""]
 xmp = ["defusedxml"]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+description = "Cross-platform lib for process and system monitoring."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "(sys_platform == \"win32\" or sys_platform == \"emscripten\" or sys_platform != \"win32\" and sys_platform != \"emscripten\") and python_version >= \"3.10\""
+files = [
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc"},
+    {file = "psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988"},
+    {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
+    {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "setuptools", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+
+[[package]]
 name = "pyreadr"
 version = "0.5.4"
 description = "Reads/writes R RData and Rds files into/from pandas data frames."
@@ -974,4 +1065,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "f84f1d560d2dadb929fe75948eadc0e6f6ac7790846c24dddf138ddf47ceed5c"
+content-hash = "90a4c077ec4507fe1668f9bf4adb11273a9f2b4e2923b925f4a257625ab9012d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pytz = "^2024.1"
 regex = "^2026.1.15"
 pyyaml = "^6.0.0"
 pyreadr = "^0.5.4"
+imageio = {extras = ["ffmpeg"], version = "^2.37.3", python = ">=3.10"}
 
 
 [build-system]

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1059,8 +1059,31 @@ def draw_standings_sidebar(Himage, standings_data, team_data, side='left'):
 
     logo_x = 3 if side == 'left' else (800 - 3 - _SIDEBAR_LOGO_SIZE)
     sep_x0, sep_x1 = (0, 31) if side == 'left' else (768, 800)
+    # Line drawn on the inner edge of the logo (between logo and scoreboard grid)
+    line_x = logo_x + _SIDEBAR_LOGO_SIZE + 1 if side == 'left' else logo_x - 2
 
     draw = ImageDraw.Draw(Himage)
+
+    # Build previous-rank lookup from standings_prev.json for movement indicators
+    # Stores (rank, wins, losses) so tied teams that didn't change record are not flagged.
+    prev_rank = {}
+    try:
+        prev_data = load_json_file('standings_prev.json')
+        for _teams in prev_data.get('standings', {}).values():
+            for _t in _teams:
+                _tid = str(_t.get('team_id', ''))
+                _r = _t.get('divisionRank')
+                if _tid and _r is not None:
+                    try:
+                        prev_rank[_tid] = (
+                            int(_r),
+                            int(_t.get('league_record_wins') or 0),
+                            int(_t.get('league_record_losses') or 0),
+                        )
+                    except (ValueError, TypeError):
+                        pass
+    except Exception:
+        pass
 
     for row_idx, div_name in enumerate(divisions):
         teams = standings_data.get('standings', {}).get(div_name, [])
@@ -1079,6 +1102,19 @@ def draw_standings_sidebar(Himage, standings_data, team_data, side='left'):
             else:
                 font = _get_font(9)
                 draw.text((logo_x, logo_y + 8), abbr[:3], font=font, fill=0)
+
+            # Draw movement indicator only when rank changed AND the team's record
+            # changed — this prevents false positives when tied teams swap API order.
+            if team_id in prev_rank:
+                cur_rank = int(team.get('divisionRank', 99))
+                prev_r, prev_w, prev_l = prev_rank[team_id]
+                cur_w = int(team.get('league_record_wins') or 0)
+                cur_l = int(team.get('league_record_losses') or 0)
+                if cur_rank != prev_r and (cur_w != prev_w or cur_l != prev_l):
+                    draw.line(
+                        (line_x, logo_y, line_x, logo_y + _SIDEBAR_LOGO_SIZE - 1),
+                        fill=0, width=2,
+                    )
 
         # Removed separator lines between division sections
 

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -913,6 +913,49 @@ def _fetch_game_timeline(game_pk):
 
 _TERMINAL_GAME_STATES = {'Postponed', 'Cancelled', 'Suspended'}
 
+
+def _inning_runs_at_time(plays, target_utc):
+    """Return (away_inning_runs, home_inning_runs) lists reconstructed from plays up to target_utc.
+
+    Away team scores in 'top' halves; home team scores in 'bottom' halves.
+    A None value in home_inning_runs means the bottom half hasn't been played yet.
+    """
+    half_final = {}
+    for play in plays:
+        if play['end_time'] > target_utc:
+            break
+        key = (play['inning'], play['half_inning'])
+        half_final[key] = (play['away_score'], play['home_score'])
+
+    if not half_final:
+        return [], []
+
+    max_inning = max(k[0] for k in half_final)
+    away_runs = []
+    home_runs = []
+    prev_away = 0
+    prev_home = 0
+
+    for inn in range(1, max_inning + 1):
+        top_key = (inn, 'top')
+        bot_key = (inn, 'bottom')
+
+        if top_key not in half_final:
+            break
+        top_away, _ = half_final[top_key]
+        away_runs.append(top_away - prev_away)
+        prev_away = top_away
+
+        if bot_key in half_final:
+            _, bot_home = half_final[bot_key]
+            home_runs.append(bot_home - prev_home)
+            prev_home = bot_home
+        else:
+            home_runs.append(None)
+
+    return away_runs, home_runs
+
+
 def _game_state_at_time(base_game, tl, target_utc):
     """Return a copy of base_game with dynamic fields set to game state at target_utc."""
     state = dict(base_game)
@@ -997,7 +1040,12 @@ def _game_state_at_time(base_game, tl, target_utc):
         state['balls']                = 0
         state['strikes']              = 0
         state['current_pitcher']      = last_play.get('pitcher') or None
-        state['current_hitter']       = None  # between at-bats, no batter yet
+        # Find the first batter of the next half inning so "Due:" can be shown
+        _next_event = next(
+            (ev for ev in pitch_events if ev['time'] > last_play['end_time']),
+            None,
+        )
+        state['current_hitter'] = _next_event.get('batter') if _next_event else None
         if outs_after >= 3:
             # Inning break: top half done → Mid, bottom half done → End
             state['inningState'] = 'Middle' if half == 'top' else 'End'
@@ -1027,6 +1075,11 @@ def _game_state_at_time(base_game, tl, target_utc):
             'balls': None, 'strikes': None,
             'current_pitcher': None, 'current_hitter': None,
         })
+
+    # Reconstruct per-inning run lists from play history so linescore grid shows correct data.
+    away_inn, home_inn = _inning_runs_at_time(plays, target_utc)
+    state['away_inning_runs'] = away_inn
+    state['home_inning_runs'] = home_inn
 
     # --- Win probability and last-play: find last wp_event before target_utc ---
     wp_events = tl.get('wp_events', [])
@@ -1116,10 +1169,14 @@ def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame
     print(f"Fetching standings for {date_str}...")
     try:
         from standings import get_standings
-        from datetime import datetime as _dt
+        from datetime import datetime as _dt, timedelta as _td
         _date_obj = _dt.strptime(date_str, '%Y-%m-%d')
         get_standings([103, 104], season=_date_obj.year, date=_date_obj.strftime('%m/%d/%Y'))
         print("  standings ok")
+        _prev_date = _date_obj - _td(days=1)
+        get_standings([103, 104], season=_prev_date.year,
+                      date=_prev_date.strftime('%m/%d/%Y'), save_as='standings_prev')
+        print("  prev standings ok")
     except Exception as _e:
         print(f"  standings error: {_e} (using cached)")
 
@@ -1224,6 +1281,19 @@ def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame
         loop=0,
     )
     print(f"✓ GIF saved to {output_path}")
+
+    mp4_path = os.path.splitext(output_path)[0] + '.mp4'
+    try:
+        import imageio
+        import numpy as np
+        fps = 1000 / frame_delay_ms
+        writer = imageio.get_writer(mp4_path, fps=fps, codec='libx264', quality=8)
+        for frame in frames:
+            writer.append_data(np.array(frame.convert('RGB')))
+        writer.close()
+        print(f"✓ MP4 saved to {mp4_path}")
+    except ImportError:
+        print("imageio not installed — skipping MP4 (pip install imageio[ffmpeg])")
 
 
 def main():
@@ -1420,11 +1490,14 @@ Examples:
 
     # --- GIF generation mode ---
     if gif_mode:
+        gif_output = args.gif_output
+        if gif_output == 'scoreboard_timelapse.gif':
+            gif_output = f'scoreboard_{date_str}.gif'
         _generate_gif(
             date_str,
             args.gif_start or None,  # None triggers auto-detection
             args.gif_end   or None,
-            args.gif_output, args.gif_interval, args.gif_delay,
+            gif_output, args.gif_interval, args.gif_delay,
             sport_id, config_data,
         )
         return

--- a/src/standings.py
+++ b/src/standings.py
@@ -43,7 +43,7 @@ def get_teams(team_id):
 
         
 
-def get_standings(league_id_list, season=2025, date=None):
+def get_standings(league_id_list, season=2025, date=None, save_as='standings'):
     division_standings_list = {}
     for league_id in league_id_list:
         # Build the API URL with optional date parameter
@@ -117,7 +117,7 @@ def get_standings(league_id_list, season=2025, date=None):
     
     standings = {'standings': division_standings_list, 'team_abbreviation': team_abbreviation_list, 'last_updated': last_updated}
 
-    save_off_results(standings, 'standings')
+    save_off_results(standings, save_as)
 
     # Also update the teams.json file to include these abbreviations
     from util import load_json_file


### PR DESCRIPTION
## Summary
- `main.py` now fetches yesterday's standings into `standings_prev.json` on every standings refresh, so the sidebar rank-change indicators work on normal display runs (previously only populated during GIF generation)
- Movement indicator in `draw_standings_sidebar` now requires **both** a rank change and a W-L record change — prevents false positives when tied teams swap API ordering without either team actually winning or losing

## Test plan
- [ ] Run `main.py` with `show_standings_sidebar: true` and confirm `standings_prev.json` is written to `data/`
- [ ] Verify a team that moved in standings shows the indicator line
- [ ] Verify two tied teams with identical records do not show indicator after a day where they didn't play

🤖 Generated with [Claude Code](https://claude.com/claude-code)