### PR TITLE
Fix GIF weather display and pre-game score zeros

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1276,12 +1276,22 @@ def _draw_weather_footer(draw, start_x, start_y, horiz_len, game_data, fnt):
     if not parts:
         return
     text = ' · '.join(parts)
-    try:
-        tw = int(fnt.getlength(text))
-    except AttributeError:
-        tw = len(text) * 5
+    use_fnt = fnt
+    for try_fnt in (fnt, _get_font(11), _get_font(9)):
+        try:
+            tw = int(try_fnt.getlength(text))
+        except AttributeError:
+            tw = len(text) * 5
+        use_fnt = try_fnt
+        if tw <= horiz_len - 4:
+            break
+    else:
+        try:
+            tw = int(use_fnt.getlength(text))
+        except AttributeError:
+            tw = len(text) * 5
     tx = start_x + max(0, (horiz_len - tw) // 2)
-    draw.text((tx, start_y + 112), text, font=fnt, fill=0)
+    draw.text((tx, start_y + 112), text, font=use_fnt, fill=0)
 
 
 def _is_game_effectively_over(game_data):
@@ -1729,7 +1739,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             start_y + 55,
         )
 
-        _draw_weather_footer(draw, start_x, start_y, horizonta_len, game_data, font9)
+        _draw_weather_footer(draw, start_x, start_y, horizonta_len, game_data, font14)
 
     # ABS challenges remaining — small stacked dots to the left of each team's logo
     if game_data['detailed_state'] == 'In Progress':

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -1095,6 +1095,7 @@ def _game_state_at_time(base_game, tl, target_utc):
             'num_of_outs': None, 'balls': None, 'strikes': None,
             'runner_on_first': None, 'runner_on_second': None, 'runner_on_third': None,
             'away_win_probability': None, 'home_win_probability': None, 'last_play': None,
+            'away_team_is_winner': False, 'home_team_is_winner': False,
         })
         return state
 
@@ -1312,6 +1313,38 @@ def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame
     if not base_games:
         print(f"No games found for {date_str}")
         return
+
+    # --- Step 1a: Attach pre-game weather to every game for Scheduled frames ---
+    print("Attaching weather data...")
+    try:
+        from fetch_games import _lookup_stadium
+        from weather import get_forecast
+        _weather_cfg = config_data.get('weather') or {}
+        if _weather_cfg.get('enabled', True):
+            for _g in base_games:
+                _venue = _g.get('venue')
+                _gdate = _g.get('game_date')
+                if not _venue or not _gdate:
+                    continue
+                _stadium = _lookup_stadium(None, _venue)
+                if _stadium is None:
+                    continue
+                if _stadium.get('roof') == 'fixed':
+                    _g['roof_state'] = 'fixed'
+                _fc = get_forecast(
+                    _venue,
+                    _stadium.get('lat'),
+                    _stadium.get('lon'),
+                    _gdate,
+                    cache_ttl_minutes=_weather_cfg.get('cache_ttl_minutes', 60),
+                )
+                if _fc:
+                    _g['weather_temp_f']    = _fc.get('temp_f')
+                    _g['weather_wind_mph']  = _fc.get('wind_mph')
+                    _g['weather_wind_dir']  = _fc.get('wind_dir')
+                    _g['weather_precip_pct'] = _fc.get('precip_pct')
+    except Exception as _we:
+        print(f"  weather attach error: {_we}")
 
     # --- Step 1b: Fetch standings as of this date so wildcard/division data is accurate ---
     print(f"Fetching standings for {date_str}...")


### PR DESCRIPTION
## Summary
- Attach weather forecast (temp/wind/precip) to all games during GIF generation — previously only pre-game live games got weather, so GIFs of past dates never showed it
- Clear `away_team_is_winner` / `home_team_is_winner` in the pre-first-pitch state reconstruction so the winner bold-draw no longer renders a phantom '0' score before a game starts
- Render the weather footer at `font14` (same size as pitcher ERA text), falling back to `font11` / `font9` if the text is too wide for the box

Also includes earlier commits on this branch:
- Mark displaced teams in standings movement indicator
- Suppress score display until first actual pitch in GIF
- ABS challenges + next batters in GIF; sidebar centering fix

## Test plan
- [ ] Generate a GIF for a recent date and confirm weather (temp/wind) appears in pre-game frames for outdoor stadiums
- [ ] Confirm domed stadiums show "Dome" instead of weather
- [ ] Confirm pre-game frames no longer show a '0' score in the score position
- [ ] Confirm weather text is visually the same size as pitcher name text

🤖 Generated with [Claude Code](https://claude.com/claude-code)