### PR TITLE
Add TV channel to pre-game footer

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -41,6 +41,41 @@ def convert_time_z_to(utc_time_str, time_zone='America/Chicago'):
 _SUBSTITUTION_TYPES = ('substitution', 'timeout', 'advisory')
 _PRE_GAME_STATES = ('Scheduled', 'Pre-Game', 'Warmup', 'Delayed Start')
 
+
+def _pick_tv_channel(broadcasts, favorite_abbr, away_abbr, home_abbr):
+    """Return one TV callSign/name to display, or None.
+
+    Priority: favorite-team local TV > home-team local TV > first TV found.
+    National broadcasts (ESPN, Peacock, etc.) are treated as home-side for
+    this purpose and will appear if no local home/favorite broadcast exists.
+    """
+    tv = [b for b in (broadcasts or []) if b.get('type') == 'TV']
+    if not tv:
+        return None
+
+    def _label(b):
+        return b.get('callSign') or b.get('name') or ''
+
+    # Favorite team override
+    if favorite_abbr:
+        fav_side = None
+        if away_abbr and away_abbr.upper() == favorite_abbr.upper():
+            fav_side = 'away'
+        elif home_abbr and home_abbr.upper() == favorite_abbr.upper():
+            fav_side = 'home'
+        if fav_side:
+            fav = [b for b in tv if b.get('homeAway') == fav_side]
+            if fav:
+                return _label(fav[0])
+
+    # Home team local
+    home_tv = [b for b in tv if b.get('homeAway') == 'home']
+    if home_tv:
+        return _label(home_tv[0])
+
+    # National or first available
+    return _label(tv[0])
+
 _STADIUM_WEATHER_CACHE = None
 
 
@@ -425,6 +460,12 @@ def parse_games(data, sport_id=None, config=None):
             'last_play': last_play_result,
             'save_situation': save_situation,
             'game_pk': game_id,
+            'tv_channel': _pick_tv_channel(
+                game.get('broadcasts', []),
+                config.get('primary'),
+                away_abbreviation,
+                home_abbreviation,
+            ),
         }
         if game_dict.get('detailed_state') == 'In Progress' and live_calls_made < max_live_calls:
             away_wp, home_wp, last_play = fetch_win_probability(game_id)
@@ -527,7 +568,7 @@ def fetch_scoreboard_for_date(date, sport_id=None, config=None):
     endpoint_url = (
         'https://statsapi.mlb.com/api/v1/schedule?'
         f'startDate={date}&endDate={date}&sportId={sport_id}'
-        '&hydrate=decisions,probablePitcher(note),linescore,flags,team'
+        '&hydrate=decisions,probablePitcher(note),linescore,flags,team,broadcasts(all)'
     )
     response = requests.get(endpoint_url)
     data = response.json()

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1258,7 +1258,20 @@ def _draw_challenge_dots(draw, start_x, start_y, game_data, use_logos=False, log
 
 
 def _draw_weather_footer(draw, start_x, start_y, horiz_len, game_data, fnt):
-    """Pre-game weather line (temp / wind / precip, plus dome marker) in the inter-row gap."""
+    """Pre-game footer: weather left-aligned, TV channel right-aligned, in the inter-row gap."""
+    y = start_y + 112
+
+    # TV channel: right-aligned
+    tv = game_data.get('tv_channel') or ''
+    tv_w = 0
+    if tv:
+        try:
+            tv_w = int(fnt.getlength(tv)) + 2
+        except AttributeError:
+            tv_w = len(tv) * 5 + 2
+        draw.text((start_x + horiz_len - tv_w, y), tv, font=fnt, fill=0)
+
+    # Weather: left-aligned, using width not taken by TV
     parts = []
     roof = game_data.get('roof_state')
     if roof == 'fixed':
@@ -1276,6 +1289,7 @@ def _draw_weather_footer(draw, start_x, start_y, horiz_len, game_data, fnt):
     if not parts:
         return
     text = ' · '.join(parts)
+    avail_w = horiz_len - tv_w - 6
     use_fnt = fnt
     for try_fnt in (fnt, _get_font(11), _get_font(9)):
         try:
@@ -1283,15 +1297,9 @@ def _draw_weather_footer(draw, start_x, start_y, horiz_len, game_data, fnt):
         except AttributeError:
             tw = len(text) * 5
         use_fnt = try_fnt
-        if tw <= horiz_len - 4:
+        if tw <= avail_w:
             break
-    else:
-        try:
-            tw = int(use_fnt.getlength(text))
-        except AttributeError:
-            tw = len(text) * 5
-    tx = start_x + max(0, (horiz_len - tw) // 2)
-    draw.text((tx, start_y + 112), text, font=use_fnt, fill=0)
+    draw.text((start_x + 2, y), text, font=use_fnt, fill=0)
 
 
 def _is_game_effectively_over(game_data):


### PR DESCRIPTION
## Summary
- Fetches TV broadcast data from the MLB schedule API (`hydrate=broadcasts(all)`)
- Picks one TV channel per game: shows the favorite team's RSN when they're playing (using `config.primary`), otherwise the home team's local broadcast
- Displays the TV callSign right-aligned in the pre-game inter-row footer
- Weather moves to left-aligned in the same footer row (font14, falls back smaller if needed)

## Test plan
- [ ] Generate the scoreboard and confirm TV callSign appears bottom-right of pre-game boxes (e.g. "NYY" games show Yankees RSN, all others show home team's channel)
- [ ] Verify weather still shows bottom-left
- [ ] Confirm domed stadiums show "Dome" on the left with TV on the right
- [ ] Check a nationally broadcast game (Sunday/holiday) shows the national channel name

🤖 Generated with [Claude Code](https://claude.com/claude-code)