### PR TITLE
Delayed game display, replay challenges, and cache redundant API calls

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -162,10 +162,53 @@ def fetch_win_probability(game_pk):
         return None, None, None
 
 
+_PITCHER_CACHE_TTL_MINUTES = 30
+
+
+def _pitcher_cache_key(pitcher_ids):
+    return ','.join(str(p) for p in sorted(pitcher_ids))
+
+
+def _load_pitcher_cache():
+    return load_json_file('pitcher_cache.json')
+
+
+def _save_pitcher_cache(cache):
+    save_off_results(cache, 'pitcher_cache')
+
+
+def _cache_get(cache, bucket, key, season):
+    entry = cache.get(bucket, {}).get(key)
+    if not entry or entry.get('season') != season:
+        return None
+    try:
+        age = datetime.now() - datetime.fromisoformat(entry['fetched_at'])
+        if age.total_seconds() < _PITCHER_CACHE_TTL_MINUTES * 60:
+            return entry['data']
+    except Exception:
+        pass
+    return None
+
+
+def _cache_set(cache, bucket, key, season, data):
+    if bucket not in cache:
+        cache[bucket] = {}
+    cache[bucket][key] = {
+        'season': season,
+        'data': data,
+        'fetched_at': datetime.now().isoformat(timespec='seconds'),
+    }
+
+
 def _fetch_pitcher_eras(pitcher_ids, season):
     """Batch-fetch season ERA for a list of pitcher IDs. Returns {id: 'W-L, ERA ERA'}."""
     if not pitcher_ids:
         return {}
+    key = _pitcher_cache_key(pitcher_ids)
+    cache = _load_pitcher_cache()
+    cached = _cache_get(cache, 'era', key, season)
+    if cached is not None:
+        return {int(k): v for k, v in cached.items()}
     ids_str = ','.join(str(p) for p in pitcher_ids)
     try:
         url = (
@@ -188,6 +231,8 @@ def _fetch_pitcher_eras(pitcher_ids, season):
                 losses = stat.get('losses', '')
                 if era and not str(era).startswith('-'):
                     result[pid] = f'{wins}-{losses}, {era} ERA'
+    _cache_set(cache, 'era', key, season, {str(k): v for k, v in result.items()})
+    _save_pitcher_cache(cache)
     return result
 
 
@@ -199,6 +244,11 @@ def _fetch_decision_pitcher_stats(pitcher_ids, season):
     ids = [p for p in pitcher_ids if p]
     if not ids:
         return {}
+    key = _pitcher_cache_key(ids)
+    cache = _load_pitcher_cache()
+    cached = _cache_get(cache, 'decision', key, season)
+    if cached is not None:
+        return {int(k): v for k, v in cached.items()}
     ids_str = ','.join(str(p) for p in ids)
     try:
         url = (
@@ -224,6 +274,8 @@ def _fetch_decision_pitcher_stats(pitcher_ids, season):
                         'record': f'{wins}-{losses}',
                         'saves': int(saves) if saves else 0,
                     }
+    _cache_set(cache, 'decision', key, season, {str(k): v for k, v in result.items()})
+    _save_pitcher_cache(cache)
     return result
 
 
@@ -483,6 +535,14 @@ def parse_games(data, sport_id=None, config=None):
                 bi_info = fetch_between_inning_info(game_id, game_dict['inningState'])
                 live_calls_made += 1
                 game_dict.update(bi_info)
+        elif game_dict.get('detailed_state') == 'Delayed' and (game_dict.get('current_inning') or 0) > 0 and live_calls_made < max_live_calls:
+            # Fetch upcoming batters/pitcher so the delay screen can show who's due up
+            from game_detail_fetch import fetch_between_inning_info
+            _inning_state = game_dict.get('inningState') or ''
+            _bi_state = 'Middle' if _inning_state in ('Bottom', 'Middle') else 'End'
+            bi_info = fetch_between_inning_info(game_id, _bi_state)
+            live_calls_made += 1
+            game_dict.update(bi_info)
         elif game_dict.get('detailed_state') in _PRE_GAME_STATES:
             _attach_pregame_weather(game_dict, game, config)
         game_array.append(game_dict)

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -124,10 +124,11 @@ def fetch_pitch_view_data(game_pk):
 
 
 _ABS_CHALLENGE_MAX = 2
+_REPLAY_CHALLENGE_MAX = 1
 
 
 def _count_abs_challenges_used(plays, away_id, home_id):
-    """Count unsuccessful ABS challenges per team. Successful ones are retained."""
+    """Count unsuccessful ABS challenges (on pitch events) per team."""
     away_used, home_used = 0, 0
     if not (away_id and home_id):
         return away_used, home_used
@@ -135,6 +136,26 @@ def _count_abs_challenges_used(plays, away_id, home_id):
         for ev in play.get('playEvents', []):
             rd = ev.get('reviewDetails')
             if not rd or ev.get('type') != 'pitch':
+                continue
+            if rd.get('inProgress') or rd.get('isOverturned'):
+                continue
+            team = rd.get('challengeTeamId')
+            if team == away_id:
+                away_used += 1
+            elif team == home_id:
+                home_used += 1
+    return away_used, home_used
+
+
+def _count_replay_challenges_used(plays, away_id, home_id):
+    """Count unsuccessful replay challenges (on non-pitch events) per team."""
+    away_used, home_used = 0, 0
+    if not (away_id and home_id):
+        return away_used, home_used
+    for play in plays.get('allPlays', []):
+        for ev in play.get('playEvents', []):
+            rd = ev.get('reviewDetails')
+            if not rd or ev.get('type') == 'pitch':
                 continue
             if rd.get('inProgress') or rd.get('isOverturned'):
                 continue
@@ -186,6 +207,7 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
         last_type = ''
         last_strike_call = ''
         at_bat_pitch_count = 0
+        strike_calls = []  # per-strike call type: 'S' swinging, 'C' called, 'F' foul
         current_play_events = plays.get('currentPlay', {}).get('playEvents', [])
         for ev in current_play_events:
             if ev.get('isPitch'):
@@ -195,10 +217,16 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
                 call_code = (details.get('call', {}).get('code', '') or '').upper()
                 if call_code in ('S', 'W', 'T', 'O', 'M'):
                     last_strike_call = 'S'  # swinging
+                    if len(strike_calls) < 2:
+                        strike_calls.append('S')
                 elif call_code == 'C':
                     last_strike_call = 'L'  # looking
+                    if len(strike_calls) < 2:
+                        strike_calls.append('C')
                 elif call_code in ('F', 'L', 'R'):
                     last_strike_call = 'F'  # foul
+                    if len(strike_calls) < 2:
+                        strike_calls.append('F')
                 # always overwrite so the last pitch in the AB is shown
                 raw_code = details.get('type', {}).get('code', '') or ''
                 last_type = _PITCH_TYPE_ABBR.get(raw_code, raw_code)
@@ -208,9 +236,16 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             plays.get('currentPlay', {}).get('result', {}).get('event')
         )
 
+        # ABS max grows by 1 per extra inning (10th = 3 total, 11th = 4, ...)
+        current_inning = linescore.get('currentInning') or 9
+        abs_max = _ABS_CHALLENGE_MAX + max(0, int(current_inning) - 9)
+
         away_used, home_used = _count_abs_challenges_used(plays, away_id, home_id)
-        away_remaining = max(0, _ABS_CHALLENGE_MAX - away_used)
-        home_remaining = max(0, _ABS_CHALLENGE_MAX - home_used)
+        away_remaining = max(0, abs_max - away_used)
+        home_remaining = max(0, abs_max - home_used)
+        away_replay_used, home_replay_used = _count_replay_challenges_used(plays, away_id, home_id)
+        away_replay_remaining = max(0, _REPLAY_CHALLENGE_MAX - away_replay_used)
+        home_replay_remaining = max(0, _REPLAY_CHALLENGE_MAX - home_replay_used)
 
         return {
             'pitch_count': pitch_count,
@@ -222,10 +257,14 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             'due_up': on_deck_name,
             'in_hole': in_hole_name,
             'last_strike_call': last_strike_call,
+            'strike_calls': strike_calls,
             'at_bat_pitch_count': at_bat_pitch_count,
             'current_at_bat_complete': current_at_bat_complete,
+            'abs_challenge_max': abs_max,
             'away_challenges_remaining': away_remaining,
             'home_challenges_remaining': home_remaining,
+            'away_replay_remaining': away_replay_remaining,
+            'home_replay_remaining': home_replay_remaining,
         }
     except Exception:
         return {}

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1236,22 +1236,54 @@ _ABS_CHALLENGE_MAX = 2
 
 
 def _draw_challenge_dots(draw, start_x, start_y, game_data, use_logos=False, logo_x_offset=2):
-    """Two side-by-side dots per team: filled = remaining, outlined = used."""
+    """ABS dots at original position beside the team row; replay dot below the abbreviation."""
     _LOGO_SIZE = 28
+    r = 3
+    dot_spacing = 8
+
     if use_logos:
+        # x: immediately right of logo + abbr (original position)
         dot_x = start_x + logo_x_offset + _LOGO_SIZE + 2 + 3
+        # ABS y: original positions, vertically centred in each team row
+        away_abs_y    = start_y + 30
+        home_abs_y    = start_y + 60
+        # Replay y: below the abbr text (abbr at row_base+7, font14 14px tall → bottom at row_base+21)
+        # Add a small gap so it doesn't touch the text
+        away_replay_y = start_y + 25 + 7 + 14 + 4   # = start_y + 50
+        home_replay_y = start_y + 55 + 7 + 14 + 4   # = start_y + 80
     else:
         dot_x = start_x + 5 + 3
-    r = 3
-    for side, row_y in (('away', start_y + 30), ('home', start_y + 60)):
-        remaining = game_data.get(f'{side}_challenges_remaining')
-        if remaining is None:
-            continue
-        remaining = max(0, min(_ABS_CHALLENGE_MAX, int(remaining)))
-        for i in range(_ABS_CHALLENGE_MAX):
-            cx = dot_x + i * 9
-            box = (cx - r, row_y - r, cx + r, row_y + r)
-            if i < remaining:
+        away_abs_y    = start_y + 30
+        home_abs_y    = start_y + 60
+        # font24 glyph height ~17px, top offset ~6px → bottom at row_base + 23
+        away_replay_y = start_y + 25 + 23 + 4        # = start_y + 52
+        home_replay_y = start_y + 55 + 23 + 4        # = start_y + 82
+
+    abs_max = game_data.get('abs_challenge_max') or _ABS_CHALLENGE_MAX
+
+    for side, abs_y, replay_y in (
+        ('away', away_abs_y, away_replay_y),
+        ('home', home_abs_y, home_replay_y),
+    ):
+        abs_remaining = game_data.get(f'{side}_challenges_remaining')
+        replay_remaining = game_data.get(f'{side}_replay_remaining')
+
+        # ABS dots (original position, max grows +1 per extra inning)
+        if abs_remaining is not None:
+            abs_remaining = max(0, min(abs_max, int(abs_remaining)))
+            for i in range(abs_max):
+                cx = dot_x + i * dot_spacing
+                box = (cx - r, abs_y - r, cx + r, abs_y + r)
+                if i < abs_remaining:
+                    draw.ellipse(box, fill=0, outline=0)
+                else:
+                    draw.ellipse(box, fill=255, outline=0)
+
+        # Replay dot below the abbreviation (max 1)
+        if replay_remaining is not None:
+            replay_remaining = max(0, min(1, int(replay_remaining)))
+            box = (dot_x - r, replay_y - r, dot_x + r, replay_y + r)
+            if replay_remaining > 0:
                 draw.ellipse(box, fill=0, outline=0)
             else:
                 draw.ellipse(box, fill=255, outline=0)
@@ -1503,6 +1535,34 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             draw.text((start_x + 7, start_y + 25 + 74), venue_ppd_txt, font=venue_ppd_fnt, fill=0)
     elif _delayed_with_score:
         draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos)
+        # Next 3 batters + pitcher — same panel used for between-innings
+        _right_x = start_x + horizonta_len - 2
+        _max_name_w = 46
+        _batter_names = [
+            _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
+            _last_name(game_data.get('next_batter_2') or game_data.get('due_up') or ''),
+            _last_name(game_data.get('next_batter_3') or game_data.get('in_hole') or ''),
+        ]
+        _name_y = start_y + 21
+        for _nm in _batter_names:
+            if _nm:
+                _nm_disp = _nm
+                while _nm_disp and int(font14.getlength(_nm_disp)) > _max_name_w:
+                    _nm_disp = _nm_disp[:-1]
+                _nw = int(font14.getlength(_nm_disp))
+                draw.text((_right_x - _nw, _name_y), _nm_disp, font=font14, fill=0)
+            _name_y += 16
+        _sep_y = _name_y + 1
+        draw.line((start_x + 87, _sep_y, _right_x, _sep_y), fill=0)
+        _pit_name = _last_name(game_data.get('next_pitcher') or game_data.get('current_pitcher') or '')
+        if _pit_name:
+            _pit_fnt = font11
+            if int(font11.getlength(_pit_name)) > _max_name_w:
+                _pit_fnt = font9
+                while _pit_name and int(font9.getlength(_pit_name)) > _max_name_w:
+                    _pit_name = _pit_name[:-1]
+            _pit_w = int(_pit_fnt.getlength(_pit_name))
+            draw.text((_right_x - _pit_w, _sep_y + 1), _pit_name, font=_pit_fnt, fill=0)
     elif game_data['detailed_state'] == 'In Progress':
         if _between_innings:
             draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos)
@@ -1877,21 +1937,24 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             ]
             _name_y = start_y + 21
             for _nm in _batter_names:
-                _nm_disp = _nm
-                while _nm_disp and int(font11.getlength(_nm_disp)) > _max_name_w:
-                    _nm_disp = _nm_disp[:-1]
-                if _nm_disp:
-                    _nw = int(font11.getlength(_nm_disp))
-                    draw.text((_right_x - _nw, _name_y), _nm_disp, font=font11, fill=0)
-                _name_y += 13
+                if _nm:
+                    _nm_disp = _nm
+                    while _nm_disp and int(font14.getlength(_nm_disp)) > _max_name_w:
+                        _nm_disp = _nm_disp[:-1]
+                    _nw = int(font14.getlength(_nm_disp))
+                    draw.text((_right_x - _nw, _name_y), _nm_disp, font=font14, fill=0)
+                _name_y += 16
             _sep_y = _name_y + 1
             draw.line((start_x + 87, _sep_y, _right_x, _sep_y), fill=0)
             _pit_name = _last_name(game_data.get('next_pitcher') or game_data.get('current_pitcher') or '')
-            while _pit_name and int(font9.getlength(_pit_name)) > _max_name_w:
-                _pit_name = _pit_name[:-1]
             if _pit_name:
-                _pit_w = int(font9.getlength(_pit_name))
-                draw.text((_right_x - _pit_w, _sep_y + 2), _pit_name, font=font9, fill=0)
+                _pit_fnt = font11
+                if int(font11.getlength(_pit_name)) > _max_name_w:
+                    _pit_fnt = font9
+                    while _pit_name and int(font9.getlength(_pit_name)) > _max_name_w:
+                        _pit_name = _pit_name[:-1]
+                _pit_w = int(_pit_fnt.getlength(_pit_name))
+                draw.text((_right_x - _pit_w, _sep_y + 1), _pit_name, font=_pit_fnt, fill=0)
         else:
             _hi_third = isinstance(game_data['runner_on_third'], str)
             _hi_second = isinstance(game_data['runner_on_second'], str)
@@ -1919,22 +1982,27 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
 
             _num_strikes = game_data.get('strikes') or 0
             strikes_list = [i + 1 <= _num_strikes for i in range(2)]
-
-            _lsc = game_data.get('last_strike_call', '')
-            _show_k = _lsc == 'S' or (_lsc == 'F' and _num_strikes >= 2)
+            _strike_calls = game_data.get('strike_calls', [])
 
             draw.text((start_x + 22 + 47, start_y + 25 + 59), 'S', font=font14, fill=0)
+            _kfont = _get_font(7)
             for _si, (_scx, _scy) in enumerate([
                 (start_x + 22 + 63, start_y + 25 + 68),
                 (start_x + 34 + 63, start_y + 25 + 68),
             ]):
-                Himage = draw_circle(Himage, (_scx, _scy), 4, strikes_list[_si])
-                if strikes_list[_si] and _si == _num_strikes - 1 and _show_k:
-                    _kfont = _get_font(7)
+                _call = _strike_calls[_si] if _si < len(_strike_calls) else None
+                if strikes_list[_si] and _call in ('S', 'F'):
+                    # Swinging or foul: outline circle + K inside
+                    Himage = draw_circle(Himage, (_scx, _scy), 4, False)
+                    draw = ImageDraw.Draw(Himage)
                     _kw = int(_kfont.getlength('K'))
                     _kx, _ky = _scx - _kw // 2, _scy - 4
-                    draw.text((_kx,     _ky), 'K', font=_kfont, fill=255)
-                    draw.text((_kx + 1, _ky), 'K', font=_kfont, fill=255)
+                    draw.text((_kx,     _ky), 'K', font=_kfont, fill=0)
+                    draw.text((_kx + 1, _ky), 'K', font=_kfont, fill=0)
+                else:
+                    # Looking / foul / empty: solid filled circle
+                    Himage = draw_circle(Himage, (_scx, _scy), 4, strikes_list[_si])
+                    draw = ImageDraw.Draw(Himage)
 
         # SV badge — keep visible during inning breaks too
         if game_data.get('save_situation'):
@@ -2167,11 +2235,23 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         Himage = ImageOps.invert(Himage.convert('L')).convert('1')
 
     # --- Compute changed regions from changed_game_ids ---
+    # Must use the same game ordering that draw_out_of_town_score_board used,
+    # otherwise the favorite-team-first reorder causes grid positions to mismatch.
     x_start = 32
     y_start = 30
+    _ordered = list(game_state_data)
+    if config.get('favorite_team_first', False):
+        _primary = config.get('primary', '')
+        if _primary:
+            _abbr_map = team_data.get('team_abbreviation', {})
+            for _i, _g in enumerate(_ordered):
+                _away = _abbr_map.get(str(_g.get('away_team_id', '')), '')
+                _home = _abbr_map.get(str(_g.get('home_team_id', '')), '')
+                if _primary in (_away, _home):
+                    _ordered.insert(0, _ordered.pop(_i))
+                    break
     changed_regions = []
-    # Build map of game_pk -> grid index
-    for i, game in enumerate(game_state_data):
+    for i, game in enumerate(_ordered):
         if i >= 15:  # 5x3 grid max
             break
         pk = str(game.get('game_pk', ''))

--- a/src/standings.py
+++ b/src/standings.py
@@ -4,23 +4,26 @@ import argparse
 from datetime import datetime
 
 
-from util import save_off_results
+from util import save_off_results, load_json_file
 
-    
+
 
 leauge_dict = {
     201:'American League East',
     202:'American League Central',
     200:'American League West',
-    
+
     204:'National League East',
     205:'National League Central',
     203:'National League West',
-    
+
 }
 team_abbreviation_list = {}
 
 def get_teams(team_id):
+    tid = str(team_id)
+    if tid in team_abbreviation_list:
+        return
     try:
         response = requests.get(f'https://statsapi.mlb.com/api/v1/teams/{team_id}')
         if response.status_code == 200:
@@ -29,21 +32,24 @@ def get_teams(team_id):
             team_abbreviation = data.get('teams', [{}])[0].get('abbreviation')
 
             if fetched_team_id and team_abbreviation:
-                print(f'Adding team: {fetched_team_id} => {team_abbreviation}')
                 team_abbreviation_list[str(fetched_team_id)] = team_abbreviation
             else:
                 print(f'Warning: Could not get abbreviation for team {team_id}, using fallback')
-                team_abbreviation_list[str(team_id)] = f'T{team_id}'
+                team_abbreviation_list[tid] = f'T{team_id}'
         else:
             print(f'Warning: API returned status {response.status_code} for team {team_id}')
-            team_abbreviation_list[str(team_id)] = f'T{team_id}'
+            team_abbreviation_list[tid] = f'T{team_id}'
     except Exception as e:
         print(f'Error fetching team {team_id}: {e}')
-        team_abbreviation_list[str(team_id)] = f'T{team_id}'
+        team_abbreviation_list[tid] = f'T{team_id}'
 
-        
+
 
 def get_standings(league_id_list, season=2025, date=None, save_as='standings'):
+    # Pre-populate from teams.json so we avoid per-team API calls for known teams
+    cached_teams = load_json_file('teams.json').get('team_abbreviation', {})
+    team_abbreviation_list.update(cached_teams)
+
     division_standings_list = {}
     for league_id in league_id_list:
         # Build the API URL with optional date parameter
@@ -52,40 +58,50 @@ def get_standings(league_id_list, season=2025, date=None, save_as='standings'):
             url += f'&date={date}'
 
         response = requests.get(url)
-        
+
         data = response.json()
-        
+
         for record in data['records']:
             last_updated = record.get('lastUpdated')
-            
 
-            
+
+
             division_id = leauge_dict.get(record.get('division', {}).get('id'))
             division_team_list = []
             for division in record['teamRecords']:
-                
-                
-                    
-                
+
+
+
+
                 for item in division.get("records", {}).get("splitRecords"):
                     if item.get('type') == 'lastTen':
                         last_ten_wins = item.get('wins')
                         last_ten_losses = item.get('losses')
-                        
+
                     if item.get('type') == 'home':
                         home_wins = item.get('wins')
                         home_losses = item.get('losses')
-                        
+
                     if item.get('type') == 'away':
                         away_wins = item.get('wins')
                         away_losses = item.get('losses')
-                        
-                get_teams(division.get("team", {}).get('id'))
+
+                # Use abbreviation from the API response directly; only fetch if missing
+                team_obj = division.get("team", {})
+                team_id = team_obj.get('id')
+                tid = str(team_id) if team_id else None
+                if tid and tid not in team_abbreviation_list:
+                    abbr = team_obj.get('abbreviation')
+                    if abbr:
+                        team_abbreviation_list[tid] = abbr
+                    else:
+                        get_teams(team_id)
+
                 team_standings = {
                 # 'division_id': division_id,
-                
-                'team_name': division.get("team", {}).get('name'),
-                'team_id': division.get("team", {}).get('id'),
+
+                'team_name': team_obj.get('name'),
+                'team_id': team_id,
 
                 'divisionRank': division.get("divisionRank"),
                 'league_record_wins': division.get("leagueRecord", {}).get('wins'),
@@ -99,8 +115,8 @@ def get_standings(league_id_list, season=2025, date=None, save_as='standings'):
                 'home_losses': home_losses,
                 'away_wins':away_wins,
                 'away_losses':away_losses,
-                
-                            
+
+
 
                 'league_rank': division.get("leagueRank"),
                 'sport_rank': division.get("sportRank"),
@@ -108,26 +124,25 @@ def get_standings(league_id_list, season=2025, date=None, save_as='standings'):
                 'wild_card_games_back': division.get("wildCardGamesBack"),
                 'league_games_back': division.get("leagueGamesBack"),
                 }
-                
-                # print(team_standings)
-                division_team_list.append(team_standings) 
-           
-            division_standings_list[ division_id] = division_team_list 
 
-    
+                # print(team_standings)
+                division_team_list.append(team_standings)
+
+            division_standings_list[ division_id] = division_team_list
+
+
     standings = {'standings': division_standings_list, 'team_abbreviation': team_abbreviation_list, 'last_updated': last_updated}
 
     save_off_results(standings, save_as)
 
     # Also update the teams.json file to include these abbreviations
-    from util import load_json_file
     teams_data = load_json_file('teams.json')
     existing_abbreviations = teams_data.get('team_abbreviation', {})
     existing_abbreviations.update(team_abbreviation_list)
     save_off_results({'team_abbreviation': existing_abbreviations}, 'teams')
-    
-    
-    
+
+
+
 def fetch_wildcard_standings(season=None, date=None):
     """Fetch wildcard standings for AL (103) and NL (104), save data/wildcard_standings.json.
 
@@ -225,5 +240,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-


### PR DESCRIPTION
## Summary
- **Cache team abbreviations in standings**: pre-populate from `teams.json` and read directly from the standings API response — eliminates ~30 per-team HTTP calls per standings refresh
- **Cache pitcher ERA/decision stats**: results stored in `data/pitcher_cache.json` with a 30-min TTL so repeated polls skip both batch API calls when data hasn't changed
- **Delayed game panel**: show linescore grid + upcoming batters/pitcher for in-progress delayed games
- **Replay challenge tracking**: separate dot below abbreviation for manager replay challenges (max 1), distinct from ABS robot-ump challenges
- **ABS max grows in extra innings**: +1 per inning past the 9th
- **Per-pitch strike type**: K-inside-circle for swinging strikes, solid circle for called/foul
- **Fix favorite_team_first grid ordering**: changed-region computation now uses the same game order as rendering

## Test plan
- [ ] Run `python main.py` — confirm no "Adding team: X => Y" spam during standings refresh
- [ ] Run twice in quick succession — confirm pitcher ERA fetch is skipped on second run (check `data/pitcher_cache.json`)
- [ ] Verify standings render correctly with team abbreviations populated
- [ ] Check delayed game box shows linescore + batter/pitcher panel
- [ ] Verify ABS dots and replay dot display correctly for a live game

🤖 Generated with [Claude Code](https://claude.com/claude-code)