### PR TITLE
Walk-off badge, pitch count, last play, jersey numbers, betting odds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your values.
+# .env is gitignored — never commit real keys.
+
+# Betting odds (moneylines on pre-game tiles)
+# Free API key from https://the-odds-api.com — 500 requests/month free tier.
+# Odds are cached in data/odds_cache.json and only re-fetched once per calendar day.
+ODDS_API_KEY=your_key_here

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -4,6 +4,26 @@ import yaml
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _DEFAULT_CONFIG = os.path.join(_REPO_ROOT, 'config', 'config.yaml')
+_ENV_FILE = os.path.join(_REPO_ROOT, '.env')
+
+
+def _load_dotenv():
+    """Load key=value pairs from .env into os.environ (existing vars are not overwritten)."""
+    if not os.path.exists(_ENV_FILE):
+        return
+    with open(_ENV_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key and key not in os.environ:
+                os.environ[key] = value
+
+
+_load_dotenv()
 
 
 def load_config(config_path=None):

--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -167,7 +167,7 @@ def fetch_win_probability(game_pk):
 def _fetch_mlb_odds(api_key):
     """Return {(home_name_lower, away_name_lower): (home_ml, away_ml)} from The Odds API.
 
-    Requires a free API key from https://the-odds-api.com — set odds_api_key in config.yaml.
+    Set ODDS_API_KEY in .env — free key at https://the-odds-api.com (500 req/month).
     """
     try:
         resp = requests.get(
@@ -201,6 +201,22 @@ def _fetch_mlb_odds(api_key):
         return result
     except Exception:
         return {}
+
+
+def _get_odds_cached(api_key):
+    """Return today's odds from cache, fetching once per calendar day if stale."""
+    from datetime import date
+    today = str(date.today())
+    cache = load_json_file('odds_cache.json') or {}
+    if cache.get('date') == today and cache.get('odds'):
+        return {tuple(k.split('|', 1)): tuple(v) for k, v in cache['odds'].items()}
+    odds = _fetch_mlb_odds(api_key)
+    if odds:
+        save_off_results(
+            {'date': today, 'odds': {f'{h}|{a}': list(v) for (h, a), v in odds.items()}},
+            'odds_cache',
+        )
+    return odds
 
 
 _PITCHER_CACHE_TTL_MINUTES = 30
@@ -646,10 +662,10 @@ def parse_games(data, sport_id=None, config=None):
             gd.pop('_loser_id', None)
             gd.pop('_saver_id', None)
 
-    # Attach betting moneylines to pre-game games if odds_api_key is configured
-    _odds_key = config.get('odds_api_key') if config else None
+    # Attach betting moneylines to pre-game games (key from ODDS_API_KEY env var)
+    _odds_key = os.environ.get('ODDS_API_KEY')
     if _odds_key and any(gd.get('detailed_state') in _PRE_GAME_STATES for gd in game_array):
-        _odds_map = _fetch_mlb_odds(_odds_key)
+        _odds_map = _get_odds_cached(_odds_key)
         if _odds_map:
             for gd in game_array:
                 if gd.get('detailed_state') not in _PRE_GAME_STATES:

--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -164,6 +164,45 @@ def fetch_win_probability(game_pk):
         return None, None, None
 
 
+def _fetch_mlb_odds(api_key):
+    """Return {(home_name_lower, away_name_lower): (home_ml, away_ml)} from The Odds API.
+
+    Requires a free API key from https://the-odds-api.com — set odds_api_key in config.yaml.
+    """
+    try:
+        resp = requests.get(
+            'https://api.the-odds-api.com/v4/sports/baseball_mlb/odds/',
+            params={
+                'apiKey': api_key,
+                'regions': 'us',
+                'markets': 'h2h',
+                'oddsFormat': 'american',
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        result = {}
+        for event in resp.json():
+            home = event.get('home_team', '')
+            away = event.get('away_team', '')
+            key = (home.lower(), away.lower())
+            for book in event.get('bookmakers', []):
+                for market in book.get('markets', []):
+                    if market.get('key') != 'h2h':
+                        continue
+                    prices = {o['name']: o['price'] for o in market.get('outcomes', [])}
+                    home_ml = prices.get(home)
+                    away_ml = prices.get(away)
+                    if home_ml is not None and away_ml is not None:
+                        result[key] = (int(home_ml), int(away_ml))
+                        break
+                if key in result:
+                    break
+        return result
+    except Exception:
+        return {}
+
+
 _PITCHER_CACHE_TTL_MINUTES = 30
 
 
@@ -521,6 +560,14 @@ def parse_games(data, sport_id=None, config=None):
                 home_abbreviation,
             ),
         }
+        _h_inn = game_dict.get('home_inning_runs') or []
+        _a_inn = game_dict.get('away_inning_runs') or []
+        game_dict['walk_off'] = bool(
+            game_dict.get('home_team_is_winner') and
+            _h_inn and _a_inn and
+            len(_h_inn) == len(_a_inn) and
+            _h_inn[-1] is not None and _h_inn[-1] > 0
+        )
         if game_dict.get('detailed_state') == 'In Progress' and live_calls_made < max_live_calls:
             away_wp, home_wp, last_play = fetch_win_probability(game_id)
             live_calls_made += 1
@@ -598,6 +645,20 @@ def parse_games(data, sport_id=None, config=None):
             gd.pop('_winner_id', None)
             gd.pop('_loser_id', None)
             gd.pop('_saver_id', None)
+
+    # Attach betting moneylines to pre-game games if odds_api_key is configured
+    _odds_key = config.get('odds_api_key') if config else None
+    if _odds_key and any(gd.get('detailed_state') in _PRE_GAME_STATES for gd in game_array):
+        _odds_map = _fetch_mlb_odds(_odds_key)
+        if _odds_map:
+            for gd in game_array:
+                if gd.get('detailed_state') not in _PRE_GAME_STATES:
+                    continue
+                _home_n = (gd.get('home_team_name') or '').lower()
+                _away_n = (gd.get('away_team_name') or '').lower()
+                _match = _odds_map.get((_home_n, _away_n))
+                if _match:
+                    gd['home_ml'], gd['away_ml'] = _match
 
     save_off_results({'games': game_array}, 'games')
     save_off_results({'team_abbreviation': team_abbreviations}, 'teams')

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -183,9 +183,25 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
         boxscore = live.get('boxscore', {})
 
         pitcher_id = linescore.get('defense', {}).get('pitcher', {}).get('id')
-        batter_id = linescore.get('offense', {}).get('batter', {}).get('id')
-        on_deck_name = linescore.get('offense', {}).get('onDeck', {}).get('fullName') or None
-        in_hole_name = linescore.get('offense', {}).get('inHole', {}).get('fullName') or None
+        offense = linescore.get('offense', {})
+        batter_id = offense.get('batter', {}).get('id')
+        on_deck_name = offense.get('onDeck', {}).get('fullName') or None
+        in_hole_name = offense.get('inHole', {}).get('fullName') or None
+
+        def _runner_jersey(base_key):
+            rid = offense.get(base_key, {}).get('id')
+            if not rid:
+                return None
+            pid_str = f'ID{rid}'
+            for side in ('away', 'home'):
+                pdata = boxscore.get('teams', {}).get(side, {}).get('players', {}).get(pid_str, {})
+                if pdata:
+                    return pdata.get('jerseyNumber')
+            return None
+
+        runner_first_number = _runner_jersey('first')
+        runner_second_number = _runner_jersey('second')
+        runner_third_number = _runner_jersey('third')
 
         pitcher_info = _get_player_info(boxscore, pitcher_id, 'pitching')
         batter_info = _get_player_info(boxscore, batter_id, 'batting')
@@ -265,6 +281,9 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             'home_challenges_remaining': home_remaining,
             'away_replay_remaining': away_replay_remaining,
             'home_replay_remaining': home_replay_remaining,
+            'runner_first_number': runner_first_number,
+            'runner_second_number': runner_second_number,
+            'runner_third_number': runner_third_number,
         }
     except Exception:
         return {}

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1581,19 +1581,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _pt = game_data.get('last_pitch_type', '')   # e.g. "FB", "SL", "CH"
             _lps = game_data.get('last_pitch_speed')
 
-            # Pitcher line right badge: "FB (87)", "(87)", "FB", or ""
-            if _pc is not None and _pt:
-                _right_str = f'{_pt} ({_pc})'
-            elif _pc is not None:
-                _right_str = f'({_pc})'
-            elif _pt:
-                _right_str = _pt
-            else:
-                _right_str = ''
+            # Pitcher line right badge: pitch type only; count moves into the label
+            _right_str = _pt if _pt else ''
             _right_w = int(font11.getlength(_right_str)) + 2 if _right_str else 0
 
+            _pc_label = f' ({_pc}P)' if _pc is not None else ''
             pitcher_str, pitcher_font = fit_text(
-                f'P: {game_data.get("current_pitcher") or ""}',
+                f'P: {game_data.get("current_pitcher") or ""}{_pc_label}',
                 max_text_width - _right_w,
             )
             draw.text((start_x + 2, start_y + 25 + 74), pitcher_str, font=pitcher_font, fill=0)
@@ -1621,11 +1615,17 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _ba_w = min(int(font11.getlength(_ba_str)) + 2, horizonta_len - 8) if _ba_str else 0
             _ab_done = game_data.get('current_at_bat_complete', False)
             if _ab_done and not _is_game_effectively_over(game_data):
-                # Play resolved — show the on-deck player as the next batter while API catches up
-                _next = _format_player_name(game_data.get('due_up') or '')
-                if _next:
-                    _next_str, _next_font = fit_text(f'AB: {_next}', max_text_width)
-                    draw.text((start_x + 2, start_y + 25 + 89), _next_str, font=_next_font, fill=0)
+                # Play resolved — show result and batter name, fall back to on-deck
+                _blr_done = game_data.get('batter_last_result', '')
+                _prev_name = _last_name(game_data.get('current_hitter') or '')
+                if _blr_done and _prev_name:
+                    _play_disp, _play_fnt = fit_text(f'{_blr_done} - {_prev_name}', max_text_width)
+                    draw.text((start_x + 2, start_y + 25 + 89), _play_disp, font=_play_fnt, fill=0)
+                else:
+                    _next = _format_player_name(game_data.get('due_up') or '')
+                    if _next:
+                        _next_str, _next_font = fit_text(f'AB: {_next}', max_text_width)
+                        draw.text((start_x + 2, start_y + 25 + 89), _next_str, font=_next_font, fill=0)
             else:
                 hitter_str, hitter_font = fit_text(
                     f'AB: {game_data.get("current_hitter") or ""}',
@@ -1688,6 +1688,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         draw.text((start_x + 2, start_y + 3), game_state_str, font=font14, fill=0)
         draw.text((start_x + 3, start_y + 3), game_state_str, font=font14, fill=0)
         _total_time_w = int(font14.getlength(game_state_str))
+
+    if game_data.get('walk_off'):
+        _wo_x = start_x + 3 + _total_time_w + 2
+        draw.text((_wo_x,     start_y + 4), 'W/O', font=font9, fill=0)
+        draw.text((_wo_x + 1, start_y + 4), 'W/O', font=font9, fill=0)
 
     # Venue — right-anchored in header, as large as possible without overlapping the time
     if game_data['detailed_state'] in ('Scheduled', 'Pre-Game', 'Warmup', 'Postponed'):
@@ -1815,18 +1820,29 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 sx = start_x + horizonta_len - sub_w - 1
                 draw.text((sx, y_pos + 15), sub_txt, font=font11, fill=0)
 
-        _draw_record(
-            game_data.get("away_team_record_wins", "0"),
-            game_data.get("away_team_record_losses", "0"),
-            game_data.get("away_team_id"),
-            start_y + 25,
-        )
-        _draw_record(
-            game_data.get("home_team_record_wins", "0"),
-            game_data.get("home_team_record_losses", "0"),
-            game_data.get("home_team_id"),
-            start_y + 55,
-        )
+        _away_wins  = game_data.get("away_team_record_wins", "0")
+        _away_losses = game_data.get("away_team_record_losses", "0")
+        _home_wins  = game_data.get("home_team_record_wins", "0")
+        _home_losses = game_data.get("home_team_record_losses", "0")
+
+        _draw_record(_away_wins, _away_losses, game_data.get("away_team_id"), start_y + 25)
+        _draw_record(_home_wins, _home_losses, game_data.get("home_team_id"), start_y + 55)
+
+        # Betting moneylines — right-aligned just left of each team's record
+        _away_ml = game_data.get('away_ml')
+        _home_ml = game_data.get('home_ml')
+        if _away_ml is not None and _home_ml is not None:
+            _away_rec_left = start_x + horizonta_len - int(font14.getlength(f'{_away_wins}-{_away_losses}')) - 5
+            _home_rec_left = start_x + horizonta_len - int(font14.getlength(f'{_home_wins}-{_home_losses}')) - 5
+            _odds_right = min(_away_rec_left, _home_rec_left) - 4
+
+            def _ml_str(v):
+                return f'+{v}' if v > 0 else str(v)
+
+            _aml_s = _ml_str(_away_ml)
+            _hml_s = _ml_str(_home_ml)
+            draw.text((_odds_right - int(font11.getlength(_aml_s)), start_y + 27), _aml_s, font=font11, fill=0)
+            draw.text((_odds_right - int(font11.getlength(_hml_s)), start_y + 57), _hml_s, font=font11, fill=0)
 
         _draw_weather_footer(draw, start_x, start_y, horizonta_len, game_data, font14)
 
@@ -1972,6 +1988,17 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             Himage = draw_diamond(Himage, (start_x + 97,  start_y + 52), 10, _hi_third)
             Himage = draw_diamond(Himage, (start_x + 109, start_y + 40), 10, _hi_second)
             Himage = draw_diamond(Himage, (start_x + 121, start_y + 52), 10, _hi_first)
+            draw = ImageDraw.Draw(Himage)
+            for _bfill, _bcx, _bcy, _bkey in (
+                (_hi_third,  start_x + 97,  start_y + 52, 'runner_third_number'),
+                (_hi_second, start_x + 109, start_y + 40, 'runner_second_number'),
+                (_hi_first,  start_x + 121, start_y + 52, 'runner_first_number'),
+            ):
+                if _bfill:
+                    _bnum = str(game_data.get(_bkey) or '')
+                    if _bnum:
+                        _bnw = int(font9.getlength(_bnum))
+                        draw.text((_bcx - _bnw // 2, _bcy - 5), _bnum, font=font9, fill=255)
 
             outs_list = [None] * 3
             for i in range(1, 4):


### PR DESCRIPTION
## Summary
- **Walk-off badge** — `W/O` shown bold next to "Final" in header when home team wins in last at-bat
- **Pitch count on P: line** — count moved into pitcher label as `P: Judge (72P)`; right badge now shows pitch type only
- **Last play on AB line** — when at-bat completes, shows `HR - Judge` instead of `AB: NextPlayer`
- **Jersey number on base** — filled base diamonds show the runner's jersey number in white (requires `scoreboard_live_details: true`)
- **Pre-game betting odds** — moneylines shown in score column for scheduled games; right-aligned just left of W-L record to never overlap
- **Odds via `.env`** — `ODDS_API_KEY` loaded from `.env` file (gitignored); `.env.example` committed as template
- **Odds cached daily** — `data/odds_cache.json` stores today's odds; API called at most once per calendar day

## Test plan
- [ ] Final walk-off game shows `W/O` next to "Final" in header
- [ ] In-progress game: pitcher line shows `P: Name (72P)`, right badge shows pitch type
- [ ] After completed at-bat: AB line shows `HR - Judge` style result
- [ ] Runner on base with `scoreboard_live_details: true`: jersey number visible inside filled diamond
- [ ] Copy `.env.example` → `.env`, add real key: pre-game tiles show moneylines
- [ ] Second run on same day: no new API call (check `data/odds_cache.json` date matches today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)