### PR TITLE
Hide SV badge during inning breaks

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -2036,8 +2036,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                     Himage = draw_circle(Himage, (_scx, _scy), 4, strikes_list[_si])
                     draw = ImageDraw.Draw(Himage)
 
-        # SV badge — keep visible during inning breaks too
-        if game_data.get('save_situation'):
+        if game_data.get('save_situation') and not _between_innings:
             _sv_w = int(font9.getlength('SV'))
             draw.text((start_x + horizonta_len - _sv_w - 2, start_y + 21), 'SV', font=font9, fill=0)
     else:


### PR DESCRIPTION
## Summary
- SV badge was rendering at `(horizonta_len - sv_w - 2, start_y + 21)` — the same position as the first batter-due-up name shown during inning breaks
- Added `and not _between_innings` guard so the SV badge only appears when the game is actively in progress (pitch being thrown)

## Test plan
- [ ] Start a game that has a save situation and advance to an inning break — confirm SV badge is gone and batter names are readable
- [ ] During active at-bat with save situation — confirm SV badge still appears in top-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)