### PR TITLE
Show game duration on final game boxes

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -662,6 +662,30 @@ def parse_games(data, sport_id=None, config=None):
             gd.pop('_loser_id', None)
             gd.pop('_saver_id', None)
 
+    # Attach game duration to Final games (cached permanently — duration never changes)
+    _final_states = ('Final', 'Game Over', 'Final: Tied')
+    _dur_cache = load_json_file('game_duration_cache.json') or {}
+    _dur_cache_dirty = False
+    for gd in game_array:
+        if gd.get('detailed_state') not in _final_states:
+            continue
+        pk_str = str(gd.get('game_pk'))
+        if pk_str in _dur_cache:
+            gd['game_duration_minutes'] = _dur_cache[pk_str]
+        else:
+            try:
+                _dur_url = f'https://statsapi.mlb.com/api/v1.1/game/{pk_str}/feed/live?fields=gameData,gameInfo'
+                _dur_resp = requests.get(_dur_url, timeout=5)
+                _dur_mins = _dur_resp.json().get('gameData', {}).get('gameInfo', {}).get('gameDurationMinutes')
+                if _dur_mins:
+                    gd['game_duration_minutes'] = int(_dur_mins)
+                    _dur_cache[pk_str] = int(_dur_mins)
+                    _dur_cache_dirty = True
+            except Exception:
+                pass
+    if _dur_cache_dirty:
+        save_off_results(_dur_cache, 'game_duration_cache')
+
     # Attach betting moneylines to pre-game games (key from ODDS_API_KEY env var)
     _odds_key = os.environ.get('ODDS_API_KEY')
     if _odds_key and any(gd.get('detailed_state') in _PRE_GAME_STATES for gd in game_array):

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1694,6 +1694,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         draw.text((_wo_x,     start_y + 4), 'W/O', font=font9, fill=0)
         draw.text((_wo_x + 1, start_y + 4), 'W/O', font=font9, fill=0)
 
+    if game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied'):
+        _dur_mins = game_data.get('game_duration_minutes')
+        if _dur_mins:
+            _dur_str = f'{_dur_mins // 60}:{_dur_mins % 60:02d}'
+            _dur_w = int(font9.getlength(_dur_str))
+            draw.text((start_x + horizonta_len - _dur_w - 1, start_y + 5), _dur_str, font=font9, fill=0)
+
     # Venue — right-anchored in header, as large as possible without overlapping the time
     if game_data['detailed_state'] in ('Scheduled', 'Pre-Game', 'Warmup', 'Postponed'):
         venue_clean = _clean_venue_name(game_data.get('venue'))


### PR DESCRIPTION
## Summary
- Fetches `gameDurationMinutes` from the MLB live game feed for completed games and caches it permanently in `data/game_duration_cache.json` (duration never changes once a game is Final)
- Renders the duration (e.g. `3:15`) right-aligned in the header row of each Final game box in font9, with 61px of clearance from the W/O badge

## Test plan
- [ ] After a game goes Final, confirm the duration (e.g. `2:47`) appears in the top-right of its scoreboard box
- [ ] Confirm `data/game_duration_cache.json` is written and subsequent runs read from cache instead of re-fetching
- [ ] Confirm no overlap with the "Final" label, W/O badge, or inning suffix (e.g. `Final/10`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)