### PR TITLE
Fix game duration not showing: fields param was too broad

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -674,7 +674,7 @@ def parse_games(data, sport_id=None, config=None):
             gd['game_duration_minutes'] = _dur_cache[pk_str]
         else:
             try:
-                _dur_url = f'https://statsapi.mlb.com/api/v1.1/game/{pk_str}/feed/live?fields=gameData,gameInfo'
+                _dur_url = f'https://statsapi.mlb.com/api/v1.1/game/{pk_str}/feed/live?fields=gameData,gameInfo,gameDurationMinutes'
                 _dur_resp = requests.get(_dur_url, timeout=5)
                 _dur_mins = _dur_resp.json().get('gameData', {}).get('gameInfo', {}).get('gameDurationMinutes')
                 if _dur_mins:


### PR DESCRIPTION
## Summary
- The MLB API `fields` filter requires explicit leaf-level field names — `?fields=gameData,gameInfo` returns an empty `gameInfo` object
- Fix: add `gameDurationMinutes` to the fields param so the response actually includes the duration value

## Test plan
- [ ] Fetch games for a date with completed games and confirm `game_duration_cache.json` is populated with non-zero minute values
- [ ] Confirm the duration (e.g. `3:15`) appears in the top-right of Final game boxes on the scoreboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)