### PR TITLE
Series record, display polish, dev mode improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -283,8 +283,22 @@ Examples:
     if system_platform == 'Darwin':
         print("Development mode - e-ink display updates will be skipped")
 
-    import os as _os
-    _no_throttle = args.local or system_platform == 'Darwin' or _os.environ.get('ENV', '').lower() == 'test'
+    def _env_is_test():
+        if os.environ.get('ENV', '').lower() == 'test':
+            return True
+        try:
+            with open(os.path.join(_REPO_ROOT, '.env')) as _ef:
+                for _line in _ef:
+                    _line = _line.strip()
+                    if _line.startswith('ENV=') or _line.startswith('ENV ='):
+                        return _line.split('=', 1)[1].strip().strip('"').strip("'").lower() == 'test'
+        except Exception:
+            pass
+        return False
+
+    _is_test = _env_is_test()
+    _no_throttle = args.local or system_platform == 'Darwin' or _is_test
+    print(f"Throttle bypass: {_no_throttle} (local={args.local}, platform={system_platform}, env_test={_is_test})")
 
     config = load_config(args.config)
 

--- a/main.py
+++ b/main.py
@@ -283,10 +283,13 @@ Examples:
     if system_platform == 'Darwin':
         print("Development mode - e-ink display updates will be skipped")
 
+    import os as _os
+    _no_throttle = args.local or system_platform == 'Darwin' or _os.environ.get('ENV', '').lower() == 'test'
+
     config = load_config(args.config)
 
     # 3. Night mode gate
-    if config.get('night_mode', False) and not args.local:
+    if config.get('night_mode', False) and not _no_throttle:
         if _in_night_window(config):
             tz = config.get('timezone', 'America/Chicago')
             now_str = datetime.now(pytz.timezone(tz)).strftime('%H:%M')
@@ -345,7 +348,7 @@ Examples:
             print(f"Using today's date: {date_str}")
 
     # 5. Smart polling gate (only for automatic runs on today's date, skip in pre-5am mode)
-    if not args.date and not args.local and not _pre5am:
+    if not args.date and not _no_throttle and not _pre5am:
         sched = _load_schedule_state()
         skip, reason = _should_skip_poll(date_str, config, sched)
         if skip:
@@ -358,7 +361,7 @@ Examples:
     fetch_scoreboard_for_date(date_str, sport_id, config)
 
     # 7. Update schedule state
-    if not args.date and not args.local and not _pre5am:
+    if not args.date and not _no_throttle and not _pre5am:
         game_state_data = load_json_file('games.json').get('games', [])
         no_games = _update_schedule_state(game_state_data, date_str, config, sched)
         if no_games:

--- a/main.py
+++ b/main.py
@@ -404,7 +404,7 @@ Examples:
 
     # 8. Render
     output_path = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
-    result = render(config, date_str=date_str, output_path=output_path)
+    result = render(config, date_str=date_str, output_path=output_path, bypass_cache=_no_throttle)
 
     if not result:
         print("No display update needed - image unchanged")

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -108,22 +108,6 @@ def _load_emoji_gray(abbr):
     return result
 
 
-def _make_broom_image(size=14):
-    """Draw a pixel-art broom icon as a grayscale PIL Image."""
-    img = Image.new('L', (size, size), 255)
-    d = ImageDraw.Draw(img)
-    s = size - 1
-    hx, hy = s // 3, s // 2
-    # Handle: thick diagonal from top-right to center-left
-    d.line([(s - 1, 0), (hx + 2, hy - 2)], fill=0, width=2)
-    # Brush head: solid rectangle in bottom-left quadrant
-    d.rectangle([(0, hy - 2), (hx + 3, s)], fill=0)
-    # Bristle texture: light gray horizontal lines
-    step = max(2, (s - hy + 2) // 3)
-    for by in range(hy, s, step):
-        d.line([(0, by), (hx + 3, by)], fill=170, width=1)
-    return img
-
 
 _char_emoji_cache: dict = {}
 
@@ -1777,7 +1761,6 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         game_data.get('series_is_over') and
         (game_data.get('series_losses') == 0 or game_data.get('series_wins') == 0)
     )
-    _sweep_wins = (game_data.get('series_wins') or game_data.get('series_losses') or 0) if _is_sweep else 0
     _series_clinched = (
         _game_is_final and
         _ser_total > 1 and
@@ -1788,18 +1771,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     # _ser_content_left_x tracks left edge of series/broom content for G:X:XX positioning
     _ser_content_left_x = start_x + horizonta_len - 2
 
-    if _is_sweep and _sweep_wins:
-        # Sweep: draw broom icons right-anchored in header
-        _broom_size = 14
-        _bx = start_x + horizonta_len - 2
-        for _ in range(_sweep_wins):
-            _bimg = _make_broom_image(_broom_size)
-            _bx -= _broom_size
-            Himage.paste(_bimg, (_bx, start_y + 3))
-            draw = ImageDraw.Draw(Himage)
-            _bx -= 1
-        _ser_content_left_x = _bx
-    elif _series_clinched:
+    if _is_sweep or _series_clinched:
         # Series win (non-sweep): draw winner logo + series score (e.g. 🏆 3-1)
         _sw = game_data.get('series_wins') or 0
         _sl = game_data.get('series_losses') or 0

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -804,6 +804,11 @@ def _load_logo_gray(abbr, team_id):
     return result
 
 
+def _paste_logo(image, logo, pos):
+    """Paste a 1-bit logo without its white background (only dark pixels are drawn)."""
+    image.paste(logo, pos, mask=ImageOps.invert(logo.convert('L')))
+
+
 def _logo_small(abbr, team_id, size=28):
     """Small 1-bit logo for the team name row. Returns a '1'-mode image or None."""
     gray = _load_logo_gray(abbr, team_id)
@@ -1520,7 +1525,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             if ghost:
                 gw, gh = ghost.size
                 gx = start_x + (135 - gw) // 2 + 12
-                gy = start_y + 5 + (vertical_len - gh) // 2
+                gy = start_y - 5 + (vertical_len - gh) // 2
                 Himage.paste(ghost, (gx, gy))
                 draw = ImageDraw.Draw(Himage)
 
@@ -2032,9 +2037,9 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 away_logo = _logo_small(away_team_name, away_team_id, size=LOGO_SZ)
                 home_logo = _logo_small(home_team_name, home_team_id, size=LOGO_SZ)
                 if away_logo:
-                    Himage.paste(away_logo, (away_logo_x, logo_y))
+                    _paste_logo(Himage, away_logo, (away_logo_x, logo_y))
                 if home_logo:
-                    Himage.paste(home_logo, (home_logo_x, logo_y))
+                    _paste_logo(Himage, home_logo, (home_logo_x, logo_y))
 
                 # During inning breaks, draw each team's % in the AB area
                 # directly above their logo position in the bar
@@ -2177,7 +2182,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             lw, lh = away_logo.size
             lx = start_x + logo_x_offset + (_LOGO_SIZE - lw) // 2
             ly = start_y + 25 + (_LOGO_SIZE - lh) // 2
-            Himage.paste(away_logo, (lx, ly))
+            _paste_logo(Himage, away_logo, (lx, ly))
             abbr_x = start_x + logo_x_offset + _LOGO_SIZE + 2
             abbr_y = start_y + 25 + (_LOGO_SIZE - 14) // 2
             draw.text((abbr_x, abbr_y), away_team_name, font=font14, fill=0)
@@ -2188,7 +2193,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             lw, lh = home_logo.size
             lx = start_x + logo_x_offset + (_LOGO_SIZE - lw) // 2
             ly = start_y + 55 + (_LOGO_SIZE - lh) // 2
-            Himage.paste(home_logo, (lx, ly))
+            _paste_logo(Himage, home_logo, (lx, ly))
             abbr_x = start_x + logo_x_offset + _LOGO_SIZE + 2
             abbr_y = start_y + 55 + (_LOGO_SIZE - 14) // 2
             draw.text((abbr_x, abbr_y), home_team_name, font=font14, fill=0)

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -108,6 +108,23 @@ def _load_emoji_gray(abbr):
     return result
 
 
+def _make_broom_image(size=14):
+    """Draw a pixel-art broom icon as a grayscale PIL Image."""
+    img = Image.new('L', (size, size), 255)
+    d = ImageDraw.Draw(img)
+    s = size - 1
+    hx, hy = s // 3, s // 2
+    # Handle: thick diagonal from top-right to center-left
+    d.line([(s - 1, 0), (hx + 2, hy - 2)], fill=0, width=2)
+    # Brush head: solid rectangle in bottom-left quadrant
+    d.rectangle([(0, hy - 2), (hx + 3, s)], fill=0)
+    # Bristle texture: light gray horizontal lines
+    step = max(2, (s - hy + 2) // 3)
+    for by in range(hy, s, step):
+        d.line([(0, by), (hx + 3, by)], fill=170, width=1)
+    return img
+
+
 _char_emoji_cache: dict = {}
 
 
@@ -1518,7 +1535,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             ghost = _logo_ghost(winner_abbr, winner_id)
             if ghost:
                 gw, gh = ghost.size
-                gx = start_x + (135 - gw) // 2 + 10
+                gx = start_x + (135 - gw) // 2 + 12
                 gy = start_y + 5 + (vertical_len - gh) // 2
                 Himage.paste(ghost, (gx, gy))
                 draw = ImageDraw.Draw(Himage)
@@ -1573,15 +1590,6 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             for i, (txt, fnt) in enumerate(reversed(lines)):
                 y = BOTTOM_Y - LINE_H * (i + 1)
                 draw.text((start_x + 2, y), _truncate_keep_suffix(txt), font=fnt, fill=0)
-
-            # No save: draw game duration in the top empty pitcher slot
-            if not saver and not game_data.get('perfect_game') and not game_data.get('no_hitter'):
-                _dur_mins = game_data.get('game_duration_minutes')
-                if _dur_mins:
-                    _dur_str = f'G: {_dur_mins // 60}:{_dur_mins % 60:02d}'
-                    _dur_y = BOTTOM_Y - LINE_H * 3
-                    draw.text((start_x + 2, _dur_y), _dur_str, font=font14, fill=0)
-                    draw.text((start_x + 3, _dur_y), _dur_str, font=font14, fill=0)
 
     elif game_data['detailed_state'] == 'Warmup' or game_data['detailed_state'] == 'Pre-Game' or  game_data['detailed_state'] == 'Scheduled':
         def _draw_pitcher_era(name_part, stat_part, y_pos):
@@ -1707,8 +1715,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         else:
             game_state_str = game_data['detailed_state']
 
-        if game_data.get('current_inning') and game_data.get('current_inning') != 9:
-            game_state_str += '/' + str(game_data.get('current_inning'))
+        _fin_inning = game_data.get('current_inning') or 9
+        if _fin_inning > 9:
+            game_state_str = 'F'
+        elif _fin_inning != 9:
+            game_state_str += '/' + str(_fin_inning)
             
     elif game_data['detailed_state'] == 'Warmup':
         game_state_str = game_data['detailed_state'] 
@@ -1778,16 +1789,15 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     _ser_content_left_x = start_x + horizonta_len - 2
 
     if _is_sweep and _sweep_wins:
-        # Sweep: draw broom PNG images right-anchored in header
-        _broom_size = 12
+        # Sweep: draw broom icons right-anchored in header
+        _broom_size = 14
         _bx = start_x + horizonta_len - 2
         for _ in range(_sweep_wins):
-            _bimg = _load_char_emoji('🧹', _broom_size)
-            if _bimg:
-                _bx -= _broom_size
-                Himage.paste(_bimg, (_bx, start_y + 4))
-                draw = ImageDraw.Draw(Himage)
-                _bx -= 1
+            _bimg = _make_broom_image(_broom_size)
+            _bx -= _broom_size
+            Himage.paste(_bimg, (_bx, start_y + 3))
+            draw = ImageDraw.Draw(Himage)
+            _bx -= 1
         _ser_content_left_x = _bx
     elif _series_clinched:
         # Series win (non-sweep): draw winner logo + series score (e.g. 🏆 3-1)
@@ -1816,6 +1826,16 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _ser_content_left_x = _score_x
         draw.text((_score_x,     start_y + 3), _score_str, font=font14, fill=0)
         draw.text((_score_x + 1, start_y + 3), _score_str, font=font14, fill=0)
+
+    # Duration — centered in header for Final games (h:mm format, same font as Final)
+    if _game_is_final and not game_data.get('perfect_game') and not game_data.get('no_hitter'):
+        _dur_mins = game_data.get('game_duration_minutes')
+        if _dur_mins:
+            _dur_str = f'{_dur_mins // 60}:{_dur_mins % 60:02d}'
+            _dur_w = int(font14.getlength(_dur_str))
+            _dur_cx = start_x + horizonta_len // 2 - _dur_w // 2
+            draw.text((_dur_cx,     start_y + 3), _dur_str, font=font14, fill=0)
+            draw.text((_dur_cx + 1, start_y + 3), _dur_str, font=font14, fill=0)
 
     # Venue — right-anchored in header, as large as possible without overlapping the time
     if game_data['detailed_state'] in ('Scheduled', 'Pre-Game', 'Warmup', 'Postponed'):
@@ -1911,24 +1931,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             draw.text((start_x + 123, start_y + 25),  str(game_data.get('away_errors', 0) if game_data.get('away_errors', 0) is not None else 0), font=font24, fill=0)
             draw.text((start_x + 123 , start_y + 55),  str( game_data.get('home_errors', 0) if game_data.get('home_errors', 0) is not None else 0), font=font24, fill=0)
 
-            # header: game duration if available, else R H E (skip for perfect game/no-hitter)
-            if not game_data.get('perfect_game') and not game_data.get('no_hitter'):
-                _dur_mins = game_data.get('game_duration_minutes')
-                if _dur_mins:
-                    _hdr = f'G: {_dur_mins // 60}:{_dur_mins % 60:02d}'
-                    if game_data.get('saver_name'):
-                        # With save: draw duration in the ABS challenge-dots area (between logos)
-                        # x aligns with where challenge dots appear during live games
-                        _LOGO_SZ = 28
-                        _cdot_x = start_x + logo_x_offset + _LOGO_SZ + 2 + 1
-                        _dur_y = start_y + 50  # between the two team rows
-                        draw.text((_cdot_x,     _dur_y), _hdr, font=font9, fill=0)
-                        draw.text((_cdot_x + 1, _dur_y), _hdr, font=font9, fill=0)
-                    # else: no save — G:XX drawn in body pitcher slot (handled in pitcher block)
-                else:
-                    header = 'R     H     E'
-                    draw.text((start_x + 68, start_y + 3), header, font=font14, fill=0)
-                    draw.text((start_x + 69, start_y + 3), header, font=font14, fill=0)
+            # header: R H E label (only when no duration — duration is centered above)
+            if not game_data.get('game_duration_minutes') and not game_data.get('perfect_game') and not game_data.get('no_hitter'):
+                header = 'R     H     E'
+                draw.text((start_x + 68, start_y + 3), header, font=font14, fill=0)
+                draw.text((start_x + 69, start_y + 3), header, font=font14, fill=0)
     elif game_data['detailed_state'] in ['Scheduled', 'Pre-Game', 'Warmup']:
         # Game hasn't started — show record stacked above L10/streak, both right-anchored
         def _team_stats(team_id):

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -108,6 +108,44 @@ def _load_emoji_gray(abbr):
     return result
 
 
+_char_emoji_cache: dict = {}
+
+
+def _load_char_emoji(emoji_char, size=12):
+    """Load a single emoji character as a grayscale PIL Image resized to size×size, or None."""
+    cache_key = (emoji_char, size)
+    if cache_key in _char_emoji_cache:
+        return _char_emoji_cache[cache_key]
+
+    codepoint = _emoji_codepoint(emoji_char)
+    path = os.path.join(emojidir, f'{codepoint}.png')
+    if not os.path.exists(path):
+        _try_download_emoji(emoji_char)
+
+    result = None
+    if os.path.exists(path):
+        try:
+            from PIL import ImageStat
+            img = Image.open(path).convert('RGBA')
+            alpha_mask = img.split()[3].point(lambda p: 255 if p > 32 else 0)
+            avg_brightness = ImageStat.Stat(img.convert('L'), mask=alpha_mask).mean[0]
+            if avg_brightness > 180:
+                r, g, b, a = img.split()
+                r = r.point(lambda p: 255 - p)
+                g = g.point(lambda p: 255 - p)
+                b = b.point(lambda p: 255 - p)
+                img = Image.merge('RGBA', (r, g, b, a))
+            bg = Image.new('RGBA', img.size, (255, 255, 255, 255))
+            bg.paste(img, mask=img.split()[3])
+            gray = bg.convert('L')
+            result = gray.resize((size, size), Image.LANCZOS)
+        except Exception:
+            pass
+
+    _char_emoji_cache[cache_key] = result
+    return result
+
+
 standings_dict = {
     1: 'American League East',
     2: 'American League Central',
@@ -1480,7 +1518,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             ghost = _logo_ghost(winner_abbr, winner_id)
             if ghost:
                 gw, gh = ghost.size
-                gx = start_x + (135 - gw) // 2 + 20
+                gx = start_x + (135 - gw) // 2 + 10
                 gy = start_y + 5 + (vertical_len - gh) // 2
                 Himage.paste(ghost, (gx, gy))
                 draw = ImageDraw.Draw(Himage)
@@ -1535,7 +1573,16 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             for i, (txt, fnt) in enumerate(reversed(lines)):
                 y = BOTTOM_Y - LINE_H * (i + 1)
                 draw.text((start_x + 2, y), _truncate_keep_suffix(txt), font=fnt, fill=0)
-        
+
+            # No save: draw game duration in the top empty pitcher slot
+            if not saver and not game_data.get('perfect_game') and not game_data.get('no_hitter'):
+                _dur_mins = game_data.get('game_duration_minutes')
+                if _dur_mins:
+                    _dur_str = f'G: {_dur_mins // 60}:{_dur_mins % 60:02d}'
+                    _dur_y = BOTTOM_Y - LINE_H * 3
+                    draw.text((start_x + 2, _dur_y), _dur_str, font=font14, fill=0)
+                    draw.text((start_x + 3, _dur_y), _dur_str, font=font14, fill=0)
+
     elif game_data['detailed_state'] == 'Warmup' or game_data['detailed_state'] == 'Pre-Game' or  game_data['detailed_state'] == 'Scheduled':
         def _draw_pitcher_era(name_part, stat_part, y_pos):
             """Draw pitcher name left-aligned and stat right-anchored."""
@@ -1710,63 +1757,95 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         draw.text((_wo_x,     start_y + 4), 'W/O', font=font9, fill=0)
         draw.text((_wo_x + 1, start_y + 4), 'W/O', font=font9, fill=0)
 
-    _ser_str = _series_display_str(game_data)
+    # Series display — only shown when the game is Final/over, not pre-game or live
+    _game_is_final = game_data.get('detailed_state') in ('Final', 'Game Over', 'Final: Tied')
+    _ser_total = (game_data.get('series_total_games') or 1)
     _is_sweep = (
+        _game_is_final and
+        _ser_total > 1 and
         game_data.get('series_is_over') and
         (game_data.get('series_losses') == 0 or game_data.get('series_wins') == 0)
     )
     _sweep_wins = (game_data.get('series_wins') or game_data.get('series_losses') or 0) if _is_sweep else 0
+    _series_clinched = (
+        _game_is_final and
+        _ser_total > 1 and
+        game_data.get('series_is_over') and
+        not _is_sweep
+    )
 
-    if _ser_str or _is_sweep:
-        _game_is_final = game_data.get('detailed_state') in ('Final', 'Game Over', 'Final: Tied')
-        _dur_mins = game_data.get('game_duration_minutes') if _game_is_final else None
-        if _dur_mins:
-            _dur_reserve = int(font14.getlength(f'G: {_dur_mins // 60}:{_dur_mins % 60:02d}')) + 3
+    # _ser_content_left_x tracks left edge of series/broom content for G:X:XX positioning
+    _ser_content_left_x = start_x + horizonta_len - 2
+
+    if _is_sweep and _sweep_wins:
+        # Sweep: draw broom PNG images right-anchored in header
+        _broom_size = 12
+        _bx = start_x + horizonta_len - 2
+        for _ in range(_sweep_wins):
+            _bimg = _load_char_emoji('🧹', _broom_size)
+            if _bimg:
+                _bx -= _broom_size
+                Himage.paste(_bimg, (_bx, start_y + 4))
+                draw = ImageDraw.Draw(Himage)
+                _bx -= 1
+        _ser_content_left_x = _bx
+    elif _series_clinched:
+        # Series win (non-sweep): draw winner logo + series score (e.g. 🏆 3-1)
+        _sw = game_data.get('series_wins') or 0
+        _sl = game_data.get('series_losses') or 0
+        _score_str = f'{_sw}-{_sl}'
+        _score_w = int(font14.getlength(_score_str))
+        _ser_logo_size = 14
+        # Determine series winner from current game's winner flag
+        _ser_winner_abbr = _ser_winner_id = None
+        if game_data.get('away_team_is_winner'):
+            _ser_winner_abbr, _ser_winner_id = away_team_name, str(game_data['away_team_id'])
+        elif game_data.get('home_team_is_winner'):
+            _ser_winner_abbr, _ser_winner_id = home_team_name, str(game_data['home_team_id'])
+        _ser_logo = _logo_small(_ser_winner_abbr, _ser_winner_id, size=_ser_logo_size) if _ser_winner_abbr else None
+        _rx = start_x + horizonta_len - 2
+        if _ser_logo:
+            _score_x = _rx - _score_w
+            _logo_x = _score_x - 2 - _ser_logo_size
+            _logo_y = start_y + 3
+            Himage.paste(_ser_logo, (_logo_x, _logo_y))
+            draw = ImageDraw.Draw(Himage)
+            _ser_content_left_x = _logo_x
         else:
-            _dur_reserve = 0
-        _ser_right = start_x + horizonta_len - 2 - _dur_reserve
-        _ser_left = start_x + 2 + _total_time_w + 4
-
-        if _is_sweep and _sweep_wins:
-            _brooms = '🧹' * _sweep_wins
-            _broom_w = int(font9.getlength(_brooms))
-            if _ser_right - _ser_left >= _broom_w:
-                _bx = _ser_left + (_ser_right - _ser_left - _broom_w) // 2
-                draw.text((_bx,     start_y + 5), _brooms, font=font9, fill=0)
-                draw.text((_bx + 1, start_y + 5), _brooms, font=font9, fill=0)
-        elif _ser_str:
-            _ser_w = int(font9.getlength(_ser_str))
-            if _ser_right - _ser_left >= _ser_w:
-                _ser_x = _ser_left + (_ser_right - _ser_left - _ser_w) // 2
-                draw.text((_ser_x,     start_y + 5), _ser_str, font=font9, fill=0)
-                draw.text((_ser_x + 1, start_y + 5), _ser_str, font=font9, fill=0)
+            _score_x = _rx - _score_w
+            _ser_content_left_x = _score_x
+        draw.text((_score_x,     start_y + 3), _score_str, font=font14, fill=0)
+        draw.text((_score_x + 1, start_y + 3), _score_str, font=font14, fill=0)
 
     # Venue — right-anchored in header, as large as possible without overlapping the time
     if game_data['detailed_state'] in ('Scheduled', 'Pre-Game', 'Warmup', 'Postponed'):
         venue_clean = _clean_venue_name(game_data.get('venue'))
         if venue_clean:
             try:
-                max_venue_w = horizonta_len - _total_time_w - 6
-                for vfont, vy in ((font14, 3), (font11, 4), (font9, 5), (_get_font(8), 6), (_get_font(7), 7)):
-                    if vfont.getlength(venue_clean) <= max_venue_w:
-                        break
-                vw = int(vfont.getlength(venue_clean))
-                vx = start_x + horizonta_len - vw - 1
-                draw.text((vx, start_y + vy), venue_clean, font=vfont, fill=0)
+                _venue_right = _ser_content_left_x - 2
+                max_venue_w = max(_venue_right - start_x - _total_time_w - 6, 0)
+                if max_venue_w > 0:
+                    for vfont, vy in ((font14, 3), (font11, 4), (font9, 5), (_get_font(8), 6), (_get_font(7), 7)):
+                        if vfont.getlength(venue_clean) <= max_venue_w:
+                            break
+                    vw = int(vfont.getlength(venue_clean))
+                    vx = _venue_right - vw
+                    draw.text((vx, start_y + vy), venue_clean, font=vfont, fill=0)
             except AttributeError:
                 pass
     if game_data['detailed_state'] == 'In Progress' and not _is_game_effectively_over(game_data):
         raw_play = (game_data.get('last_play') or '').replace('**', '').strip()
+        _header_right = _ser_content_left_x - 2
         if _between_innings and raw_play:
             # Mid-inning break: show the play that ended the half-inning
-            max_play_w = max(horizonta_len - _total_time_w - 10, 0)
+            max_play_w = max(_header_right - start_x - _total_time_w - 10, 0)
             play_text = raw_play
             _play_font = _get_font(12)
             while len(play_text) > 1 and int(_play_font.getlength(play_text)) > max_play_w:
                 play_text = play_text[:-2] + '.'
             if play_text and int(_play_font.getlength(play_text)) <= max_play_w:
                 pw = int(_play_font.getlength(play_text))
-                px = start_x + horizonta_len - pw - 2
+                px = _header_right - pw
                 draw.text((px, start_y + 4), play_text, font=_play_font, fill=0)
                 draw.text((px + 1, start_y + 4), play_text, font=_play_font, fill=0)
         elif _between_innings:
@@ -1775,23 +1854,23 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             if _due_name:
                 _due_str = f'Due: {_due_name}'
                 _due_fnt = font11
-                _max_due_w = horizonta_len - _total_time_w - 6
+                _max_due_w = max(_header_right - start_x - _total_time_w - 6, 0)
                 while _due_str and int(_due_fnt.getlength(_due_str)) > _max_due_w:
                     _due_str = _due_str[:-1]
                 if _due_str:
                     _due_w = int(_due_fnt.getlength(_due_str))
-                    _due_x = start_x + horizonta_len - _due_w - 2
+                    _due_x = _header_right - _due_w
                     draw.text((_due_x,     start_y + 5), _due_str, font=_due_fnt, fill=0)
                     draw.text((_due_x + 1, start_y + 5), _due_str, font=_due_fnt, fill=0)
         elif raw_play:
-            max_play_w = max(horizonta_len - _total_time_w - 10, 0)
+            max_play_w = max(_header_right - start_x - _total_time_w - 10, 0)
             play_text = raw_play
             _play_font = _get_font(12)
             while len(play_text) > 1 and int(_play_font.getlength(play_text)) > max_play_w:
                 play_text = play_text[:-2] + '.'
             if play_text and int(_play_font.getlength(play_text)) <= max_play_w:
                 pw = int(_play_font.getlength(play_text))
-                px = start_x + horizonta_len - pw - 2
+                px = _header_right - pw
                 draw.text((px, start_y + 4), play_text, font=_play_font, fill=0)
                 draw.text((px + 1, start_y + 4), play_text, font=_play_font, fill=0)
 
@@ -1837,10 +1916,15 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 _dur_mins = game_data.get('game_duration_minutes')
                 if _dur_mins:
                     _hdr = f'G: {_dur_mins // 60}:{_dur_mins % 60:02d}'
-                    _hdr_w = int(font14.getlength(_hdr))
-                    _hdr_x = start_x + horizonta_len - _hdr_w - 2
-                    draw.text((_hdr_x,     start_y + 3), _hdr, font=font14, fill=0)
-                    draw.text((_hdr_x + 1, start_y + 3), _hdr, font=font14, fill=0)
+                    if game_data.get('saver_name'):
+                        # With save: draw duration in the ABS challenge-dots area (between logos)
+                        # x aligns with where challenge dots appear during live games
+                        _LOGO_SZ = 28
+                        _cdot_x = start_x + logo_x_offset + _LOGO_SZ + 2 + 1
+                        _dur_y = start_y + 50  # between the two team rows
+                        draw.text((_cdot_x,     _dur_y), _hdr, font=font9, fill=0)
+                        draw.text((_cdot_x + 1, _dur_y), _hdr, font=font9, fill=0)
+                    # else: no save — G:XX drawn in body pitcher slot (handled in pitcher block)
                 else:
                     header = 'R     H     E'
                     draw.text((start_x + 68, start_y + 3), header, font=font14, fill=0)
@@ -2146,8 +2230,6 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         draw.text((start_x + 67 + check_if_two_chars(away_runs), start_y + 25), away_runs, font=font24, fill=0)
     if game_data.get('home_team_is_winner'):
         draw.text((start_x + 67 + check_if_two_chars(home_runs), start_y + 55), home_runs, font=font24, fill=0)
-
-        
 
     # Invert header to indicate a score change during an active game
     if score_changed and is_game_started and not is_game_finished:

--- a/src/render_scoreboard.py
+++ b/src/render_scoreboard.py
@@ -79,7 +79,7 @@ def _render_single_game_mode(mode, game_state_data, team_data, config, output_pa
         return None
 
 
-def render(config, date_str=None, output_path=None):
+def render(config, date_str=None, output_path=None, bypass_cache=False):
     """
     Render display from cached data/games.json.
 
@@ -87,6 +87,7 @@ def render(config, date_str=None, output_path=None):
         config: Config dict
         date_str: Date string for scoreboard header (optional)
         output_path: Where to save the output image (default: resulting_image.bmp)
+        bypass_cache: If True, always regenerate even if data is unchanged.
 
     Returns:
         (PIL.Image, changed_regions) tuple, or None if no update needed.
@@ -107,7 +108,7 @@ def render(config, date_str=None, output_path=None):
             return (image, [])
         return None
 
-    result = orchestrate_score_board(game_state_data, team_data, date_str)
+    result = orchestrate_score_board(game_state_data, team_data, date_str, bypass_cache=bypass_cache)
     if result:
         image, changed_regions = result
         image.save(output_path)

--- a/tests/test_scoreboard_rules.py
+++ b/tests/test_scoreboard_rules.py
@@ -1814,34 +1814,50 @@ class TestHeaderInversion:
 # ===========================================================================
 
 class TestSeriesRecord:
-    """Series record string is shown in the header when available."""
+    """Series record shown in header only when the series is clinched/over."""
 
     @needs_pil
-    def test_series_record_shown_for_multi_game_series(self, minimal_team_data):
-        """A 3-game series with a record renders differently than a single game."""
+    def test_series_clinched_renders_differently_than_no_series(self, minimal_team_data):
+        """A clinched series (series_is_over=True) renders differently than a no-series game."""
         no_series = _base_game(series_total_games=1)
-        with_series = _base_game(
-            series_total_games=3, series_wins=1, series_losses=0,
-            series_is_tied=False, series_result='Team leads 1-0',
+        clinched = _base_game(
+            series_total_games=3, series_wins=2, series_losses=1,
+            series_is_over=True, series_result='Won 2-1',
+            home_team_is_winner=True,
         )
         img_none = Image.new('1', (800, 480), 255)
         img_ser = Image.new('1', (800, 480), 255)
         draw_box(img_none, 32, 30, no_series, minimal_team_data, use_logos=False)
-        draw_box(img_ser, 32, 30, with_series, minimal_team_data, use_logos=False)
+        draw_box(img_ser, 32, 30, clinched, minimal_team_data, use_logos=False)
         assert list(img_none.getdata()) != list(img_ser.getdata()), \
-            "Series record should produce different rendering than no-series"
+            "Clinched series should produce different rendering than no-series"
 
     @needs_pil
-    def test_game_1_shows_gm_label(self, minimal_team_data):
-        """First game of a series (wins=0, losses=0) renders 'Gm 1/N'."""
+    def test_mid_series_game_no_series_label(self, minimal_team_data):
+        """A non-clinched mid-series game does NOT show series info (series only shown when over)."""
+        mid_series = _base_game(
+            series_total_games=3, series_wins=1, series_losses=0,
+            series_is_over=False, series_result='Team leads 1-0',
+        )
+        no_series = _base_game(series_total_games=1)
+        img_mid = Image.new('1', (800, 480), 255)
+        img_ns = Image.new('1', (800, 480), 255)
+        draw_box(img_mid, 32, 30, mid_series, minimal_team_data, use_logos=False)
+        draw_box(img_ns, 32, 30, no_series, minimal_team_data, use_logos=False)
+        assert list(img_mid.getdata()) == list(img_ns.getdata()), \
+            "Mid-series games should not show series info (series only shown when over)"
+
+    @needs_pil
+    def test_game_1_no_gm_label(self, minimal_team_data):
+        """Game 1 of a series does NOT show Gm 1/N — series info only shown when series is over."""
         game = _base_game(
             series_total_games=7, series_wins=0, series_losses=0,
-            series_game_number=1, series_result='',
+            series_game_number=1, series_result='', series_is_over=False,
         )
         no_series = _base_game(series_total_games=1)
         img_g1 = Image.new('1', (800, 480), 255)
         img_ns = Image.new('1', (800, 480), 255)
         draw_box(img_g1, 32, 30, game, minimal_team_data, use_logos=False)
         draw_box(img_ns, 32, 30, no_series, minimal_team_data, use_logos=False)
-        assert list(img_g1.getdata()) != list(img_ns.getdata()), \
-            "Game 1 of a 7-game series should show Gm 1/7 label"
+        assert list(img_g1.getdata()) == list(img_ns.getdata()), \
+            "Game 1 of a series should NOT show Gm 1/7 — series info only when series is over"


### PR DESCRIPTION
## Summary

- **Series record in header**: winner logo + score (e.g. `🔴 3-0`) right-anchored for both sweeps and non-sweep clinches; only shown when `series_is_over=True` on Final games
- **Header layout**: game duration centered as `h:mm` (font14, same as Final); extra-inning finals show `F` instead of `Final/10`
- **Logo overlap fix**: small team logos now paste transparently over the ghost watermark — white background no longer blocks the watermark behind them
- **Dev mode**: macOS and `ENV=test` bypass throttle, smart polling, night mode, and the JSON-diff cache check so the image always regenerates
- **Tests**: updated series-record tests to match new `series_is_over`-only behavior; 178 passing

## Test plan

- [ ] Verify Final game header shows `Final  3:15  3-0` with winner logo on right
- [ ] Verify sweep and non-sweep both use logo+score format (no broom icons)
- [ ] Verify extra-inning game shows `F` in header
- [ ] Verify small logos don't produce white square over ghost watermark
- [ ] Set `ENV=test` on Pi — confirm image regenerates every run with no throttle output
- [ ] Run `python3 -m pytest tests/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)