### PR TITLE
Draw --- between tied teams in standings sidebar

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1196,6 +1196,19 @@ def draw_standings_sidebar(Himage, standings_data, team_data, side='left'):
                     fill=0, width=2,
                 )
 
+            # Draw --- between tied consecutive slots (same W-L record)
+            if slot_idx + 1 < 5 and slot_idx + 1 < len(teams):
+                nxt = teams[slot_idx + 1]
+                cur_wl = (int(team.get('league_record_wins') or 0), int(team.get('league_record_losses') or 0))
+                nxt_wl = (int(nxt.get('league_record_wins') or 0),  int(nxt.get('league_record_losses') or 0))
+                if cur_wl == nxt_wl:
+                    gap_y      = logo_y + _SIDEBAR_LOGO_SIZE + (slot_h - _SIDEBAR_LOGO_SIZE) // 2
+                    dash_w, gap_w = 4, 2
+                    dash_start = logo_x + (_SIDEBAR_LOGO_SIZE - (3 * dash_w + 2 * gap_w)) // 2
+                    for d in range(3):
+                        x0 = dash_start + d * (dash_w + gap_w)
+                        draw.line((x0, gap_y, x0 + dash_w - 1, gap_y), fill=0, width=1)
+
         # Removed separator lines between division sections
 
     return Himage


### PR DESCRIPTION
## Summary
- Adds a three-dash (`---`) separator between consecutive tied teams in the standings sidebar
- Detects ties by comparing W-L records (not `divisionRank`, which the MLB API assigns differently even for genuinely tied teams)
- Dashes are drawn in the 8px gap between logo slots, centered horizontally in the 20px logo column

## Test plan
- [ ] Verify `---` appears between MIN and CWS (both 13-17) in AL Central sidebar
- [ ] Confirm no spurious dashes appear between teams with different records
- [ ] Check NL Central for any ties and verify correct placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)