### PR TITLE
Scoreboard display improvements + game end time from play-by-play

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -669,29 +669,43 @@ def parse_games(data, sport_id=None, config=None):
             gd.pop('_loser_id', None)
             gd.pop('_saver_id', None)
 
-    # Attach game duration to Final games (cached permanently — duration never changes)
+    # Attach game end time to Final games via last play's endTime (cached permanently)
     _final_states = ('Final', 'Game Over', 'Final: Tied')
-    _dur_cache = load_json_file('game_duration_cache.json') or {}
-    _dur_cache_dirty = False
+    _end_cache = load_json_file('game_end_time_cache.json') or {}
+    _end_cache_dirty = False
     for gd in game_array:
         if gd.get('detailed_state') not in _final_states:
             continue
         pk_str = str(gd.get('game_pk'))
-        if pk_str in _dur_cache:
-            gd['game_duration_minutes'] = _dur_cache[pk_str]
+        if pk_str in _end_cache:
+            gd['game_end_time_utc'] = _end_cache[pk_str]
         else:
             try:
-                _dur_url = f'https://statsapi.mlb.com/api/v1.1/game/{pk_str}/feed/live?fields=gameData,gameInfo,gameDurationMinutes'
-                _dur_resp = requests.get(_dur_url, timeout=5)
-                _dur_mins = _dur_resp.json().get('gameData', {}).get('gameInfo', {}).get('gameDurationMinutes')
-                if _dur_mins:
-                    gd['game_duration_minutes'] = int(_dur_mins)
-                    _dur_cache[pk_str] = int(_dur_mins)
-                    _dur_cache_dirty = True
+                _live_url = (
+                    f'https://statsapi.mlb.com/api/v1.1/game/{pk_str}/feed/live'
+                    '?fields=liveData,plays,allPlays,about,endTime'
+                )
+                _live_resp = requests.get(_live_url, timeout=5)
+                _all_plays = (
+                    _live_resp.json()
+                    .get('liveData', {})
+                    .get('plays', {})
+                    .get('allPlays', [])
+                )
+                _end_utc = None
+                for _play in reversed(_all_plays):
+                    _t = _play.get('about', {}).get('endTime')
+                    if _t:
+                        _end_utc = _t
+                        break
+                if _end_utc:
+                    gd['game_end_time_utc'] = _end_utc
+                    _end_cache[pk_str] = _end_utc
+                    _end_cache_dirty = True
             except Exception:
                 pass
-    if _dur_cache_dirty:
-        save_off_results(_dur_cache, 'game_duration_cache')
+    if _end_cache_dirty:
+        save_off_results(_end_cache, 'game_end_time_cache')
 
     # Attach betting moneylines to pre-game games (key from ODDS_API_KEY env var)
     _odds_key = os.environ.get('ODDS_API_KEY')

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1,6 +1,8 @@
 import os
 import json
 import random
+from datetime import datetime
+import pytz
 from util import load_json_file, load_yaml_file, save_off_results
 from collections import OrderedDict
 
@@ -87,6 +89,16 @@ def generate_linescore(col_start, row_start, team_abbr, Himage, new_image_dict):
     if (game_state == 'Final' or game_state == 'Game Over') and home[8] == None:
         home[8] = 'X'
 
+    game_end_time = None
+    _end_utc_str = game_info.get('game_end_time_utc')
+    if _end_utc_str and game_state in ('Final', 'Game Over'):
+        try:
+            _tz_str = load_yaml_file('config.yaml').get('timezone', 'America/Chicago')
+            _utc_dt = datetime.strptime(_end_utc_str[:19], "%Y-%m-%dT%H:%M:%S")
+            game_end_time = pytz.utc.localize(_utc_dt).astimezone(pytz.timezone(_tz_str)).strftime("%I:%M:%S%p")
+        except Exception:
+            pass
+
     first_base = data_linescore.get('runner_first')
     second_base = data_linescore.get('runner_second')
     third_base = data_linescore.get('runner_third', None)
@@ -124,7 +136,8 @@ def generate_linescore(col_start, row_start, team_abbr, Himage, new_image_dict):
                             home_probable, winner_name, loser_name, venue,
                             home_team_win_probability, away_team_win_probability,
                             result_event, weather_condition, weather_temp, weather_wind,
-                            home_team_id=home_team_id, away_team_id=away_team_id)
+                            home_team_id=home_team_id, away_team_id=away_team_id,
+                            game_end_time=game_end_time)
     return Himage, new_image_dict
 
 def draw_boards():
@@ -219,7 +232,7 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
                    home_probable,winner_name, loser_name,  venue,
                    home_team_win_probability, away_team_win_probability, result_event,
                     weather_condition, weather_temp, weather_wind,
-                   home_team_id=None, away_team_id=None):
+                   home_team_id=None, away_team_id=None, game_end_time=None):
     draw = ImageDraw.Draw(Himage)
 
     # Team logos in team name rows (24px, fits in 30px row with 3px top/bottom padding)
@@ -318,6 +331,9 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
 
     elif game_state in ('Final', 'Game Over') and winner_name and loser_name:
         draw.text(( col_start + 0 , row_start + 93), f'WP: {winner_name}  LP: {loser_name}' , font = font18, fill = 0)
+    elif game_state in ('Final', 'Game Over') and game_end_time:
+        _et_w = font14.getlength(game_end_time)
+        draw.text((col_start + 580 - _et_w, row_start + 113), game_end_time, font=font14, fill=0)
 
     draw.text((0 + col_start, 8 + row_start), game_state, font = font18, fill = 0, stroke_width=1, stroke_fill=0)
     draw.text((30 + col_start, 30 + row_start), away_team, font = font24, fill = 0)


### PR DESCRIPTION
## Summary
- Show game end time right-anchored below the linescore after a game goes Final, until WP/LP pitcher decisions are available
- Source the end time from the last play's `endTime` in the MLB live feed play-by-play (not duration math from start time)
- Cache end times permanently in `game_end_time_cache.json` (replaces `game_duration_cache.json`)
- Format: `HH:MM:SS AM/PM` in the configured local timezone

## Test plan
- [ ] Run against a completed game — verify end time appears right-anchored below the grid before pitcher info loads
- [ ] Confirm end time disappears once WP/LP names are populated
- [ ] Verify `game_end_time_cache.json` is written and reused on subsequent runs
- [ ] Check timezone conversion matches actual game end time

🤖 Generated with [Claude Code](https://claude.com/claude-code)