### PR TITLE
Fetch game duration and always show end time on Final boxes

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -582,6 +582,7 @@ def parse_games(data, sport_id=None, config=None):
                 away_abbreviation,
                 home_abbreviation,
             ),
+            'game_duration_minutes': game.get('gameInfo', {}).get('gameDurationMinutes'),
         }
         _h_inn = game_dict.get('home_inning_runs') or []
         _a_inn = game_dict.get('away_inning_runs') or []
@@ -748,7 +749,7 @@ def fetch_scoreboard_for_date(date, sport_id=None, config=None):
     endpoint_url = (
         'https://statsapi.mlb.com/api/v1/schedule?'
         f'startDate={date}&endDate={date}&sportId={sport_id}'
-        '&hydrate=decisions,probablePitcher(note),linescore,flags,team,broadcasts(all),seriesStatus'
+        '&hydrate=decisions,probablePitcher(note),linescore,flags,team,broadcasts(all),seriesStatus,gameInfo'
     )
     response = requests.get(endpoint_url)
     data = response.json()

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -345,7 +345,8 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
 
     elif game_state in ('Final', 'Game Over') and winner_name and loser_name:
         draw.text(( col_start + 0 , row_start + 93), f'WP: {winner_name}  LP: {loser_name}' , font = font18, fill = 0)
-    elif game_state in ('Final', 'Game Over') and game_end_time:
+
+    if game_state in ('Final', 'Game Over') and game_end_time:
         _et_w = font14.getlength(game_end_time)
         draw.text((col_start + 580 - _et_w, row_start + 113), game_end_time, font=font14, fill=0)
 


### PR DESCRIPTION
## Summary
- Add `gameInfo` to the schedule API hydrate so `gameDurationMinutes` is returned — this field was referenced in `image_box.py` but never fetched, so game duration never rendered
- Write `game_duration_minutes` into `game_dict` from the API response
- Fix game end time visibility: was in an `elif` that only triggered when WP/LP data was absent — changed to a standalone `if` so end time renders for all Final games alongside the WP/LP line

## Test plan
- [ ] Fetch a completed game and verify `game_duration_minutes` is populated in `data/games.json`
- [ ] Confirm game duration (e.g. `3:10`) appears centered in the header of Final boxes
- [ ] Confirm game end time appears bottom-right of Final boxes even when WP/LP names are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)