### PR TITLE
Add league_mode config for MLB vs AAA display

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,13 @@ max_live_game_calls: 15
 # Timezone for game start times (IANA timezone string, e.g. America/Chicago, America/New_York)
 timezone: America/Chicago
 
+# League mode: "mlb" or "aaa"
+# "mlb" — show MLB games + AL/NL standings (uses sport_id_priority list below)
+# "aaa" — show Triple-A games + IL/PCL standings (forces sport_id=12, ignores priority list)
+league_mode: mlb
+
 # Sport ID Priority List (checked in order, first with games is used)
+# Only used when league_mode is "mlb".
 # 1  = MLB
 # 8  = World Baseball Classic
 # 11 = College Baseball

--- a/main.py
+++ b/main.py
@@ -396,10 +396,18 @@ Examples:
         display_image(overlay)
         _mark_discord_applied()
 
+    league_mode = config.get('league_mode', 'mlb')
+
     # Handle --sport-id / --fetch-teams
     if args.sport_id:
         sport_id = args.sport_id
         print(f"Using specified sport: {SPORT_NAMES.get(sport_id, f'Sport ID {sport_id}')}")
+        if args.fetch_teams:
+            fetch_all_team_abbreviations(sport_id)
+            return
+    elif league_mode == 'aaa':
+        sport_id = 12
+        print("League mode: AAA (Triple-A)")
         if args.fetch_teams:
             fetch_all_team_abbreviations(sport_id)
             return
@@ -455,6 +463,7 @@ Examples:
 
     # 7b. Standings refresh
     _needs_standings = config.get('show_standings_sidebar', False) or config.get('show_wildcard_standings', False)
+    _standings_league_ids = [117, 112] if league_mode == 'aaa' else [103, 104]
     if _needs_standings:
         if args.date:
             # Historical replay: fetch standings as of that specific date so the sidebar
@@ -462,10 +471,10 @@ Examples:
             print(f"Fetching historical standings for {date_str}...")
             try:
                 _hist = datetime.strptime(date_str, '%Y-%m-%d')
-                get_standings([103, 104], season=_hist.year,
+                get_standings(_standings_league_ids, season=_hist.year,
                               date=_hist.strftime('%m/%d/%Y'))
                 _prev = _hist - timedelta(days=1)
-                get_standings([103, 104], season=_prev.year,
+                get_standings(_standings_league_ids, season=_prev.year,
                               date=_prev.strftime('%m/%d/%Y'), save_as='standings_prev')
             except Exception as e:
                 print(f"Warning: historical standings fetch failed: {e}")
@@ -473,9 +482,9 @@ Examples:
             print("Refreshing standings (new Finals detected or no cache)...")
             try:
                 today = datetime.now()
-                get_standings([103, 104], season=today.year)
+                get_standings(_standings_league_ids, season=today.year)
                 prev_day = today - timedelta(days=1)
-                get_standings([103, 104], season=prev_day.year,
+                get_standings(_standings_league_ids, season=prev_day.year,
                               date=prev_day.strftime('%m/%d/%Y'), save_as='standings_prev')
                 games = load_json_file('games.json').get('games', [])
                 sched['standings_final_pks'] = [

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -669,19 +669,21 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
     Himage = Image.new('1', (800, 480), 255)
     Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob)
 
+    league_mode = config.get('league_mode', 'mlb')
+
     standings_data = None
     if config.get('show_wildcard_standings', False) or config.get('show_standings_sidebar', False):
         standings_data = load_json_file('standings.json')
 
-    if config.get('show_wildcard_standings', False):
+    if config.get('show_wildcard_standings', False) and league_mode != 'aaa':
         if standings_data and 'standings' in standings_data:
             wildcard_data = derive_wildcard_from_standings(standings_data)
             Himage = draw_wildcard_header(Himage, wildcard_data)
 
     if config.get('show_standings_sidebar', False):
         if standings_data and 'standings' in standings_data:
-            Himage = draw_standings_sidebar(Himage, standings_data, team_data, side='left')
-            Himage = draw_standings_sidebar(Himage, standings_data, team_data, side='right')
+            Himage = draw_standings_sidebar(Himage, standings_data, team_data, side='left', league_mode=league_mode)
+            Himage = draw_standings_sidebar(Himage, standings_data, team_data, side='right', league_mode=league_mode)
 
     if config.get('dark_mode', False):
         Himage = ImageOps.invert(Himage.convert('L')).convert('1')

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -132,19 +132,27 @@ def draw_wildcard_header(Himage, wildcard_data):
     return Himage
 
 
-def draw_standings_sidebar(Himage, standings_data, team_data, side='left'):
-    """Draw a vertical strip of division-standings logos on the left (AL) or right (NL) edge.
+def _aaa_divisions(standings_data, side):
+    """Return ordered IL (left) or PCL (right) division names from standings data."""
+    all_divs = [d for d in standings_data.get('standings', {}).keys() if d]
+    if side == 'left':
+        divs = sorted(d for d in all_divs if 'International' in d)
+    else:
+        divs = sorted(d for d in all_divs if 'Pacific' in d)
+    # Prefer East → South → West order (alphabetical happens to match)
+    return divs
 
-    Logos are 26px, ordered 1st place (top) to 5th place (bottom) within each
-    division section. Three sections align with the three scoreboard game rows:
-      section 0 = East   (y=30–180)
-      section 1 = Central (y=180–330)
-      section 2 = West   (y=330–480)
 
-    side='left'  → AL divisions, logo_x=6  (centered in 32px left margin)
-    side='right' → NL divisions, logo_x=774 (centered in 32px right margin)
+def draw_standings_sidebar(Himage, standings_data, team_data, side='left', league_mode='mlb'):
+    """Draw a vertical strip of division-standings logos on the left or right edge.
+
+    MLB: left=AL divisions, right=NL divisions.
+    AAA: left=IL divisions, right=PCL divisions.
     """
-    divisions = _AL_DIV_ORDER if side == 'left' else _NL_DIV_ORDER
+    if league_mode == 'aaa':
+        divisions = _aaa_divisions(standings_data, side)
+    else:
+        divisions = _AL_DIV_ORDER if side == 'left' else _NL_DIV_ORDER
     abbr_map  = {**standings_data.get('team_abbreviation', {}),
                  **team_data.get('team_abbreviation', {})}
 

--- a/src/standings.py
+++ b/src/standings.py
@@ -67,7 +67,8 @@ def get_standings(league_id_list, season=2025, date=None, save_as='standings'):
 
 
 
-            division_id = leauge_dict.get(record.get('division', {}).get('id'))
+            div_info = record.get('division', {})
+            division_id = leauge_dict.get(div_info.get('id')) or div_info.get('name')
             division_team_list = []
             for division in record['teamRecords']:
                 last_ten_wins = last_ten_losses = None
@@ -208,13 +209,17 @@ def fetch_wildcard_standings(season=None, date=None):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Fetch MLB standings for a specific season or date')
+    parser = argparse.ArgumentParser(description='Fetch standings for a specific season or date')
     parser.add_argument('--season', '-s', type=int, default=datetime.now().year,
                         help='Season year (e.g., 2024, 2023). Default is current year.')
     parser.add_argument('--date', '-d', type=str,
                         help='Specific date for standings (format: YYYY-MM-DD or MM/DD/YYYY).')
+    parser.add_argument('--aaa', action='store_true',
+                        help='Fetch Triple-A (IL + PCL) standings instead of MLB (AL + NL).')
 
     args = parser.parse_args()
+
+    league_ids = [117, 112] if args.aaa else [103, 104]
 
     # If a specific date is provided, extract the year from it and format it properly
     date_param = None
@@ -236,7 +241,7 @@ def main():
         season = args.season
         print(f'Fetching standings for season: {season}')
 
-    get_standings([103, 104], season=season, date=date_param)
+    get_standings(league_ids, season=season, date=date_param)
     print(f'\nTeam abbreviations loaded: {len(team_abbreviation_list)} teams')
     print(f'Standings data saved to data/standings.json')
 


### PR DESCRIPTION
## Summary
- New `league_mode: mlb | aaa` config option in `config.yaml`
- `aaa` mode forces `sport_id=12` (Triple-A), bypassing the sport priority list
- Standings fetch uses IL (117) + PCL (112) league IDs instead of hardcoded AL (103) + NL (104)
- `standings.py` now falls back to the API's own division name when the ID isn't in the local dict — no need to hardcode AAA division IDs
- `image_standings.py` sidebar splits dynamically: divisions containing "International" → left, "Pacific" → right
- Wildcard header auto-skipped in AAA mode (AL/NL wildcard format doesn't apply)
- `standings.py` CLI gains `--aaa` flag: `python src/standings.py --aaa` to seed the cache

## Test plan
- [ ] Set `league_mode: aaa` in config.yaml, run `python3 src/standings.py --aaa` to seed standings cache
- [ ] Run main pipeline and confirm sport_id=12 games are fetched
- [ ] Confirm IL divisions appear on left sidebar, PCL on right
- [ ] Switch back to `league_mode: mlb` and confirm AL/NL sidebar + wildcard header return normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)