### PR TITLE
Extend linescore display window to 60 minutes after game ends

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -140,11 +140,11 @@ def generate_linescore(col_start, row_start, team_abbr, Himage, new_image_dict):
                             game_end_time=game_end_time)
     return Himage, new_image_dict
 
-_LINESCORE_SHOW_SECONDS = 10 * 60  # show linescore for 10 min after last play
+_LINESCORE_SHOW_SECONDS = 60 * 60  # show linescore for 60 min after last play
 
 
 def _game_in_window(team_abbr, games_scheduled):
-    """Return True if the team's game is live or ended less than 10 minutes ago."""
+    """Return True if the team's game is live or ended less than 60 minutes ago."""
     game_id = (games_scheduled or {}).get('team_to_game_id', {}).get(team_abbr)
     if not game_id:
         return True


### PR DESCRIPTION
## Summary
- Increases `_LINESCORE_SHOW_SECONDS` from 10 minutes to 60 minutes so the linescore stays visible for an hour after a game finishes

## Test plan
- [ ] Verify linescore remains on display for ~60 min after a game goes Final
- [ ] Confirm linescore disappears after the 60-min window expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)