### PR TITLE
Sweep detection for postseason + linescore window expiry re-render

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1,6 +1,7 @@
 import os
 import json
 import random
+import time as _time_mod
 from datetime import datetime
 import pytz
 from util import load_json_file, load_yaml_file, save_off_results
@@ -19,7 +20,7 @@ from image_standings import (
     _WC_STRIP_H,
     derive_wildcard_from_standings, draw_wildcard_header, draw_standings_sidebar,
 )
-from image_box import draw_box
+from image_box import draw_box, _FINAL_LINESCORE_SECS
 
 # ---------------------------------------------------------------------------
 # logging.basicConfig(level=logging.DEBUG)
@@ -662,7 +663,41 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         save_off_results(new_scores, 'score_alerts')
         # --- End score change detection ---
 
-        if compare_json_dicts_sorted(new_dict, old_dict):
+        # Detect when a Final game's linescore window transitions True→False.
+        # The visual content (linescore grid vs WP/LP) changes at the 60-min boundary
+        # without any change to game_state_data, so the data comparison above won't
+        # catch it. We track the window state separately and force a re-render when
+        # any game exits the window.
+        _final_state_set = {'Final', 'Game Over', 'Final: Tied'}
+        _final_times = load_json_file('game_final_times.json') or {}
+        _old_win_state = load_json_file('old_linescore_window_state.json') or {}
+        _new_win_state = {}
+        _linescore_window_changed = False
+        for _g in game_state_data:
+            if _g.get('detailed_state') in _final_state_set:
+                _pk = str(_g.get('game_pk', ''))
+                if not _pk:
+                    continue
+                _ft = _final_times.get(_pk)
+                if _ft is None:
+                    continue
+                _end_utc = _g.get('game_end_time_utc')
+                if _end_utc:
+                    try:
+                        _end_dt = pytz.utc.localize(datetime.strptime(_end_utc[:19], "%Y-%m-%dT%H:%M:%S"))
+                        _in_win = (datetime.now(pytz.utc) - _end_dt).total_seconds() < _FINAL_LINESCORE_SECS
+                    except Exception:
+                        _in_win = (_time_mod.time() - float(_ft)) < _FINAL_LINESCORE_SECS
+                else:
+                    _in_win = (_time_mod.time() - float(_ft)) < _FINAL_LINESCORE_SECS
+                _new_win_state[_pk] = _in_win
+                if _old_win_state.get(_pk) is True and not _in_win:
+                    _linescore_window_changed = True
+                    refreshed_game_ids.add(_pk)
+                    print(f'Linescore window expired for game {_pk} — forcing re-render')
+        save_off_results(_new_win_state, 'old_linescore_window_state')
+
+        if compare_json_dicts_sorted(new_dict, old_dict) and not _linescore_window_changed:
             print('images the same')
             return None
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -703,12 +703,18 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     # Pre-draw SWEEP ghost before header text so Final / logo sit on top
     _gf_early = game_data.get('detailed_state') in ('Final', 'Game Over', 'Final: Tied')
     _st_early  = game_data.get('series_total_games') or 1
+    _se_wins   = game_data.get('series_wins', 0) or 0
+    _se_losses = game_data.get('series_losses', 0) or 0
+    _se_desc   = game_data.get('series_description', '')
+    _se_one_side_won = (_se_losses == 0 or _se_wins == 0)
     _is_sweep_early = (
         _gf_early and
         _st_early > 1 and
-        game_data.get('series_description') == 'Regular Season' and
-        (game_data.get('series_wins', 0) + game_data.get('series_losses', 0)) == _st_early and
-        (game_data.get('series_losses') == 0 or game_data.get('series_wins') == 0)
+        _se_one_side_won and
+        (
+            (_se_desc == 'Regular Season' and (_se_wins + _se_losses) == _st_early) or
+            (_se_desc != 'Regular Season' and bool(game_data.get('series_is_over')))
+        )
     )
     if _is_sweep_early:
         _sw_text = 'SWEEP'
@@ -743,12 +749,18 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         (game_data.get('current_inning') or 0) >= 4
     )
     _ser_total = (game_data.get('series_total_games') or 1)
+    _sw_wins   = game_data.get('series_wins', 0) or 0
+    _sw_losses = game_data.get('series_losses', 0) or 0
+    _sw_desc   = game_data.get('series_description', '')
+    _sw_one_side_won = (_sw_losses == 0 or _sw_wins == 0)
     _is_sweep = (
         _game_is_final and
         _ser_total > 1 and
-        game_data.get('series_description') == 'Regular Season' and
-        (game_data.get('series_wins', 0) + game_data.get('series_losses', 0)) == _ser_total and
-        (game_data.get('series_losses') == 0 or game_data.get('series_wins') == 0)
+        _sw_one_side_won and
+        (
+            (_sw_desc == 'Regular Season' and (_sw_wins + _sw_losses) == _ser_total) or
+            (_sw_desc != 'Regular Season' and bool(game_data.get('series_is_over')))
+        )
     )
     _series_clinched = (
         _game_is_final and
@@ -770,16 +782,17 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         (game_data.get('series_wins') or 0) > 0
     )
 
-    # Overline when no more games remain in the series.
-    # Regular season: last game of the set (game N of N) regardless of result.
-    # Postseason: only when a team has clinched the series.
-    _show_overline = False
-    if _game_is_final and _ser_total > 1:
-        if game_data.get('series_description') == 'Regular Season':
-            _sgn = game_data.get('series_game_number') or 0
-            _show_overline = _sgn > 0 and _sgn >= _ser_total
-        else:
-            _show_overline = _is_sweep or _series_clinched
+    # Overline when the full series has concluded.
+    # Regular Season: all scheduled games must have been played (wins+losses == total).
+    # Playoffs: series_is_over is sufficient (series ends before all games are needed).
+    _show_overline = (
+        _game_is_final and
+        _ser_total > 1 and
+        (
+            (_sw_desc == 'Regular Season' and (_sw_wins + _sw_losses) == _ser_total) or
+            (_sw_desc != 'Regular Season' and bool(game_data.get('series_is_over')))
+        )
+    )
 
     # _ser_content_left_x tracks left edge of series/broom content for G:X:XX positioning
     _ser_content_left_x = start_x + horizonta_len - 2
@@ -1103,11 +1116,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             draw.text((_dur_x,     _dur_y), _dur_str, font=_dur_font, fill=0)
             draw.text((_dur_x + 1, _dur_y), _dur_str, font=_dur_font, fill=0)
 
-    # End time — right-aligned in the win-probability strip below the box, shown for 60 min.
-    # Same font and bold double-draw as the "Final" header text.
-    if _game_is_final and _in_linescore_window and _end_utc_str:
+    # End time — right-aligned in the win-probability strip below the box.
+    # Default: shown only while the linescore window is active (disappears with the linescore).
+    # Set show_game_end_time_always: true in config to keep it visible after the window closes.
+    _et_cfg = load_yaml_file('config.yaml')
+    _show_end_time_always = _et_cfg.get('show_game_end_time_always', False)
+    if _game_is_final and (_in_linescore_window or _show_end_time_always) and _end_utc_str:
         try:
-            _tz_str = load_yaml_file('config.yaml').get('timezone', 'America/Chicago')
+            _tz_str = _et_cfg.get('timezone', 'America/Chicago')
             _end_utc_parsed = pytz.utc.localize(_datetime.strptime(_end_utc_str[:19], "%Y-%m-%dT%H:%M:%S"))
             _end_local = _end_utc_parsed.astimezone(pytz.timezone(_tz_str))
             _end_str = _end_local.strftime("%I:%M").lstrip("0") + " " + _end_local.strftime("%p").lower()


### PR DESCRIPTION
## Summary
- Extend sweep/overline display logic to postseason series: previously only detected sweeps in Regular Season games (checked wins+losses == total). Now uses `series_is_over` flag for non-regular-season series (playoffs, ALDS, ALCS, WS, etc.)
- Force a re-render when a Final game's 60-minute linescore window expires without any game data change — ensures WP/LP view replaces the linescore grid on schedule even if scores don't update
- Add `show_game_end_time_always: true` config option to keep the game end time visible after the linescore window closes (defaults to false, existing behavior)

## Test plan
- [ ] Verify SWEEP text and overline appear correctly for a completed postseason series (check `series_is_over` in game data)
- [ ] Verify regular season sweep/overline still works (wins+losses == series_total)
- [ ] Wait for a final game's linescore window to expire (~60 min) — confirm display re-renders to WP/LP without a manual restart
- [ ] Test `show_game_end_time_always: true` in config — end time should persist after linescore disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)