### PR TITLE
Fix logo centering in linescore and scoreboard grid

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,6 +80,10 @@ show_wildcard_standings: true
 # Set to 2 to align with the box edge. Increase to shift the logo right.
 small_logo_x_offset: 2
 
+# Minutes to show the per-inning linescore grid in each finished game's box after it goes Final.
+# Set to a large number (e.g. 9999) to always show the linescore for finished games.
+final_linescore_minutes: 1260
+
 # Win probability bar in scoreboard mode: show team logos at their win probability position during live games
 # Left edge = 0% (certain loss), right edge = 100% (certain win). Only shown for In Progress games.
 scoreboard_win_probability: true

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -20,7 +20,7 @@ from image_standings import (
     _WC_STRIP_H,
     derive_wildcard_from_standings, draw_wildcard_header, draw_standings_sidebar,
 )
-from image_box import draw_box, _FINAL_LINESCORE_SECS
+from image_box import draw_box
 
 # ---------------------------------------------------------------------------
 # logging.basicConfig(level=logging.DEBUG)
@@ -250,18 +250,19 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
                    home_team_id=None, away_team_id=None, game_end_time=None):
     draw = ImageDraw.Draw(Himage)
 
-    # Team logos in team name rows (24px, fits in 30px row with 3px top/bottom padding)
+    # Team logos in team name rows (24px bounding box, centered in 30px logo cell)
     _logo_size = 24
-    _logo_x = col_start + 2
     if away_team_id:
         _away_logo = _logo_small(away_team, away_team_id, size=_logo_size)
         if _away_logo:
-            Himage.paste(_away_logo, (_logo_x, row_start + 33))
+            _lw, _lh = _away_logo.size
+            Himage.paste(_away_logo, (col_start + (30 - _lw) // 2, row_start + 31 + (29 - _lh) // 2))
             draw = ImageDraw.Draw(Himage)
     if home_team_id:
         _home_logo = _logo_small(home_team, home_team_id, size=_logo_size)
         if _home_logo:
-            Himage.paste(_home_logo, (_logo_x, row_start + 63))
+            _lw, _lh = _home_logo.size
+            Himage.paste(_home_logo, (col_start + (30 - _lw) // 2, row_start + 61 + (29 - _lh) // 2))
             draw = ImageDraw.Draw(Himage)
 
     # bmp = Image.open(os.path.join('/home/pi/Documents/e-Paper/RaspberryPi_JetsonNano/python/examples/', 'qr.jpg'))
@@ -673,6 +674,7 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         _old_win_state = load_json_file('old_linescore_window_state.json') or {}
         _new_win_state = {}
         _linescore_window_changed = False
+        _final_linescore_secs = config.get('final_linescore_minutes', 60) * 60
         for _g in game_state_data:
             if _g.get('detailed_state') in _final_state_set:
                 _pk = str(_g.get('game_pk', ''))
@@ -685,11 +687,11 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
                 if _end_utc:
                     try:
                         _end_dt = pytz.utc.localize(datetime.strptime(_end_utc[:19], "%Y-%m-%dT%H:%M:%S"))
-                        _in_win = (datetime.now(pytz.utc) - _end_dt).total_seconds() < _FINAL_LINESCORE_SECS
+                        _in_win = (datetime.now(pytz.utc) - _end_dt).total_seconds() < _final_linescore_secs
                     except Exception:
-                        _in_win = (_time_mod.time() - float(_ft)) < _FINAL_LINESCORE_SECS
+                        _in_win = (_time_mod.time() - float(_ft)) < _final_linescore_secs
                 else:
-                    _in_win = (_time_mod.time() - float(_ft)) < _FINAL_LINESCORE_SECS
+                    _in_win = (_time_mod.time() - float(_ft)) < _final_linescore_secs
                 _new_win_state[_pk] = _in_win
                 if _old_win_state.get(_pk) is True and not _in_win:
                     _linescore_window_changed = True

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -15,7 +15,6 @@ from image_utils import (
 )
 from util import load_json_file, load_yaml_file, save_off_results
 
-_FINAL_LINESCORE_SECS = 3600  # show linescore for 60 min after game ends
 _final_time_cache = {}       # game_pk (str) -> unix timestamp, in-memory layer
 _historical_mode = False     # True for --date replays: skip linescore window
 
@@ -98,14 +97,14 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
       Row 1 (16px): away logo + per-inning runs
       Row 2 (16px): home logo + per-inning runs
 
-    Columns: 15px logo col + 9 × 13px inning cols = 132px
+    Columns: 16px logo col + 9 × 13px inning cols = 133px
     Extra-innings: window shifts so the current inning is the rightmost column.
     """
-    LOGO_COL_W = 15
+    LOGO_COL_W = 16
     ROW_H_HDR  = 14
     ROW_H_TEAM = 16
     N_COLS     = 9
-    COL_W      = 13   # 15 + 9×13 = 132 ≤ 135
+    COL_W      = 13   # 16 + 9×13 = 133 ≤ 135
 
     y0 = start_y + 83            # grid top — bottom half of box (scores/logos/bases stay above)
     y1 = y0 + ROW_H_HDR          # = start_y + 97  (away row top)
@@ -152,7 +151,8 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
         lsz = 12
         logo = _logo_small(abbr, tid, size=lsz) if use_logos else None
         if logo:
-            Himage.paste(logo, (start_x + (LOGO_COL_W - lsz) // 2, row_y + (ROW_H_TEAM - lsz) // 2))
+            lw, lh = logo.size
+            Himage.paste(logo, (start_x + (LOGO_COL_W - lw) // 2, row_y + 1 + (ROW_H_TEAM - 1 - lh) // 2))
             draw = ImageDraw.Draw(Himage)
         else:
             s = (abbr or '')[:3]
@@ -192,10 +192,10 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
             if 0 <= col_k < N_COLS:
                 cell_x = start_x + LOGO_COL_W + col_k * COL_W
                 _xfont = font11
-                bbox = _xfont.getbbox('x')
+                bbox = _xfont.getbbox('X')
                 vis_w = bbox[2] - bbox[0]
                 tx = cell_x + (COL_W - vis_w) // 2 - bbox[0] + 1
-                draw.text((tx, y2 + (ROW_H_TEAM - 11) // 2), 'x', font=_xfont, fill=0)
+                draw.text((tx, y2 + (ROW_H_TEAM - 11) // 2), 'X', font=_xfont, fill=0)
 
     return draw, Himage
 
@@ -365,6 +365,9 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     font11 = _get_font(11)
     font9 = _get_font(9)
 
+    _cfg = load_yaml_file('config.yaml')
+    _FINAL_LINESCORE_SECS = _cfg.get('final_linescore_minutes', 60) * 60
+
     vertical_len = 110
     horizonta_len = 135
     max_text_width = horizonta_len - 14
@@ -392,7 +395,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         (game_data.get('away_runs') or 0) != (game_data.get('home_runs') or 0)
     )
 
-    _in_linescore_window = False  # set True inside Final block when within 60-min window
+    _in_linescore_window = False  # set True inside Final block when within the linescore window
 
     def fit_text(text, max_w):
         try:


### PR DESCRIPTION
## Summary
- Center each logo on its actual post-thumbnail size — `thumbnail()` preserves aspect ratio so logos aren't square, and the old code assumed a fixed bounding box size
- Account for the 1px border line when computing vertical offset, so logos sit in the true interior of each row cell (was off by 1–4px depending on logo height)
- Widen linescore grid logo column 15→16px so a 12px logo gets 2px on each side (was 1px left / 2px right)
- Move `final_linescore_minutes` to `config.yaml` (was hardcoded `_FINAL_LINESCORE_SECS = 3600`); set to 1260 min (~21 hrs) to show linescore grid all day for finished games
- Use uppercase `'X'` for unplayed home-team inning — lowercase `'x'` has vis_h=6 vs digits/X at vis_h=8, making it appear shorter than the inning numbers

## Test plan
- [ ] Verify logos appear horizontally centered in linescore team rows (full-screen linescore mode)
- [ ] Verify logos appear vertically centered in linescore team rows — CIN in particular (wide logo, was biased toward top)
- [ ] Verify scoreboard grid linescore logos are centered in their 16px column
- [ ] Verify `X` in unplayed home inning matches the height of inning run numbers
- [ ] Confirm `final_linescore_minutes: 1260` keeps linescore grid visible for finished games across the day

🤖 Generated with [Claude Code](https://claude.com/claude-code)