### PR TITLE
Morning alternating mode + featured team fullscreen display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@
 # Free API key from https://the-odds-api.com — 500 requests/month free tier.
 # Odds are cached in data/odds_cache.json and only re-fetched once per calendar day.
 ODDS_API_KEY=your_key_here
+
+# Enlarge the primary team's game to fill the entire 800x480 display.
+# Set to true to enable fullscreen featured-game mode.
+FEATURED_TEAM_FULLSCREEN=false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -60,7 +60,7 @@ morning_alternate_games: true
 # Featured team full-screen: enlarge the primary team's game to fill the entire 800x480 display.
 # When enabled, one game is rendered full-screen instead of the 15-game scoreboard grid.
 # Game selection: first Scheduled/Pre-Game/Warmup game for the day → else most recent Final.
-featured_team_fullscreen: false
+featured_team_fullscreen: true
 
 
 # Team emoji overrides: display emoji instead of logo for these teams

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -57,11 +57,6 @@ night_end: 7     # 7am
 # today's schedule every 5 minutes. Before 7am always shows yesterday; after 9am always today.
 morning_alternate_games: true
 
-# Featured team full-screen: enlarge the primary team's game to fill the entire 800x480 display.
-# When enabled, one game is rendered full-screen instead of the 15-game scoreboard grid.
-# Game selection: first Scheduled/Pre-Game/Warmup game for the day → else most recent Final.
-featured_team_fullscreen: true
-
 
 # Team emoji overrides: display emoji instead of logo for these teams
 # Dark mode: invert display (white on black instead of black on white)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,6 +53,15 @@ night_mode: true
 night_start: 2   # midnight (hour in 24h, local timezone)
 night_end: 7     # 7am
 
+# Morning alternating mode: between 7am and 9am, alternate between yesterday's results and
+# today's schedule every 5 minutes. Before 7am always shows yesterday; after 9am always today.
+morning_alternate_games: true
+
+# Featured team full-screen: enlarge the primary team's game to fill the entire 800x480 display.
+# When enabled, one game is rendered full-screen instead of the 15-game scoreboard grid.
+# Game selection: first Scheduled/Pre-Game/Warmup game for the day → else most recent Final.
+featured_team_fullscreen: false
+
 
 # Team emoji overrides: display emoji instead of logo for these teams
 # Dark mode: invert display (white on black instead of black on white)

--- a/main.py
+++ b/main.py
@@ -465,6 +465,10 @@ Examples:
         sched = {}
 
     # 6. Fetch
+    # In fullscreen mode tell the fetcher which team is featured so it skips
+    # live-feed calls for all other games.
+    if config.get('featured_team_fullscreen', False):
+        config['_featured_abbr'] = config.get('primary', '')
     fetch_scoreboard_for_date(date_str, sport_id, config)
 
     # 7. Update schedule state

--- a/main.py
+++ b/main.py
@@ -467,7 +467,7 @@ Examples:
     # 6. Fetch
     # In fullscreen mode tell the fetcher which team is featured so it skips
     # live-feed calls for all other games.
-    if config.get('featured_team_fullscreen', False):
+    if os.environ.get('FEATURED_TEAM_FULLSCREEN', '').lower() in ('true', '1', 'yes'):
         config['_featured_abbr'] = config.get('primary', '')
     fetch_scoreboard_for_date(date_str, sport_id, config)
 

--- a/main.py
+++ b/main.py
@@ -436,13 +436,23 @@ Examples:
     else:
         tz = config.get('timezone', 'America/Chicago')
         _now = datetime.now(pytz.timezone(tz))
-        if _now.hour < 9:
+        if _now.hour >= 9:
+            date_str = _now.date().strftime('%Y-%m-%d')
+            print(f"Using today's date: {date_str}")
+        elif _now.hour >= 7 and config.get('morning_alternate_games', True):
+            # 7am–9am: alternate between yesterday and today every 5 minutes
+            _pre9am = True
+            five_min_block = (_now.hour * 60 + _now.minute) // 5
+            if five_min_block % 2 == 0:
+                date_str = (_now.date() - timedelta(days=1)).strftime('%Y-%m-%d')
+                print(f"Morning alternating (block {five_min_block}) — showing previous day: {date_str}")
+            else:
+                date_str = _now.date().strftime('%Y-%m-%d')
+                print(f"Morning alternating (block {five_min_block}) — showing today: {date_str}")
+        else:
             date_str = (_now.date() - timedelta(days=1)).strftime('%Y-%m-%d')
             _pre9am = True
             print(f"Before 9am — showing previous day: {date_str}")
-        else:
-            date_str = _now.date().strftime('%Y-%m-%d')
-            print(f"Using today's date: {date_str}")
 
     # 5. Smart polling gate (only for automatic runs on today's date, skip in pre-5am mode)
     if not args.date and not _no_throttle and not _pre9am:

--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -597,7 +597,13 @@ def parse_games(data, sport_id=None, config=None):
             len(_h_inn) == len(_a_inn) and
             _h_inn[-1] is not None and _h_inn[-1] > 0
         )
-        if game_dict.get('detailed_state') in ('In Progress', 'Player challenge', 'Manager challenge') and live_calls_made < max_live_calls:
+        # In fullscreen mode only make live-feed calls for the one displayed game
+        _featured = config.get('_featured_abbr', '')
+        _is_featured = (not _featured) or (_featured in (
+            team_abbreviations.get(str(away_team_id), ''),
+            team_abbreviations.get(str(home_team_id), ''),
+        ))
+        if _is_featured and game_dict.get('detailed_state') in ('In Progress', 'Player challenge', 'Manager challenge') and live_calls_made < max_live_calls:
             away_wp, home_wp, last_play, last_play_inning, last_play_is_top = fetch_win_probability(game_id)
             live_calls_made += 1
             game_dict['last_play'] = last_play
@@ -615,7 +621,7 @@ def parse_games(data, sport_id=None, config=None):
                 bi_info = fetch_between_inning_info(game_id, game_dict['inningState'])
                 live_calls_made += 1
                 game_dict.update(bi_info)
-        elif game_dict.get('detailed_state') == 'Delayed' and (game_dict.get('current_inning') or 0) > 0 and live_calls_made < max_live_calls:
+        elif _is_featured and game_dict.get('detailed_state') == 'Delayed' and (game_dict.get('current_inning') or 0) > 0 and live_calls_made < max_live_calls:
             # Fetch upcoming batters/pitcher so the delay screen can show who's due up
             from game_detail_fetch import fetch_between_inning_info
             _inning_state = game_dict.get('inningState') or ''

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -19,6 +19,7 @@ from image_utils import (
 from image_standings import (
     _WC_STRIP_H,
     derive_wildcard_from_standings, draw_wildcard_header, draw_standings_sidebar,
+    draw_standings_sidebar_fullscreen,
 )
 from image_box import draw_box
 
@@ -708,7 +709,7 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
     league_mode = config.get('league_mode', 'mlb')
 
     # --- Featured team full-screen mode ---
-    if config.get('featured_team_fullscreen', False):
+    if os.environ.get('FEATURED_TEAM_FULLSCREEN', '').lower() in ('true', '1', 'yes'):
         primary = config.get('primary', '')
         featured_game = _find_featured_game(game_state_data, team_data, primary)
         if featured_game:
@@ -831,24 +832,24 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
     win_prob    = config.get('scoreboard_win_probability', False)
     league_mode = config.get('league_mode', 'mlb')
 
-    # Standings chrome dimensions (must match the normal scoreboard grid)
-    SB_W = 32        # sidebar strip width on each side (x_start used by draw_out_of_town_score_board)
-    AREA_W = 800 - 2 * SB_W          # 736 px
+    # Scale game cell to fill the content height at integer scale (3×).
+    # Center the 405px box content (135*3) horizontally so the 45px dead zone in the
+    # cell image is split ~22px on each side, giving equal-width sidebars.
+    CELL   = 150
     AREA_H = 480 - _WC_STRIP_H       # 450 px
+    SCALED = (AREA_H // CELL) * CELL  # 450 px at scale 3
+    _scale = SCALED // CELL           # 3
+    _box_w = 135 * _scale             # 405 px — where draw_box's horizontal line ends
+    paste_x = (800 - _box_w) // 2    # 197 — centers box content in the display
+    paste_y = _WC_STRIP_H            # 30
 
-    # Scale the 150×150 cell to fit the content area with uniform (1:1) ratio
-    CELL = 150
-    scale  = min(AREA_W, AREA_H) // CELL   # 3  (limited by height: 450//150)
-    SCALED = CELL * scale                   # 450 px
-
-    # Render WITHOUT the winner ghost so upscaling doesn't smear faint dither dots
-    # into heavy blobs that obscure text.  Ghost is overlaid separately below.
-    cell = Image.new('1', (CELL, CELL), 255)
+    # Render at full target resolution — no upscaling needed, fonts/logos are native size
+    cell = Image.new('L', (SCALED, SCALED), 255)
     cell = draw_box(cell, 0, 0, game_data, team_data,
                     use_logos=use_logos, logo_x_offset=logo_offset,
-                    show_win_prob=win_prob, show_winner_logo=False)
-    scaled_gray = cell.convert('L').resize((SCALED, SCALED), Image.LANCZOS)
-    scaled_cell = scaled_gray.point(lambda p: 0 if p < 180 else 255).convert('1')
+                    show_win_prob=win_prob, show_winner_logo=False,
+                    scale=_scale)
+    scaled_cell = cell.point(lambda p: 0 if p < 128 else 255).convert('1')
 
     # Overlay winner ghost rendered natively at SCALED px — no upscaling artifacts.
     # lightness=215 → ~15% dot density: recognisable watermark that doesn't obscure text.
@@ -862,21 +863,24 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
             winner_abbr = abbr_map.get(str(game_data.get('home_team_id', '')))
             winner_id   = str(game_data.get('home_team_id', ''))
         if winner_abbr and winner_id:
-            # draw_box places a 110px ghost centred in the 135×110 content area
-            # (gx = (135-gw)//2, gy = 20 + (110-gh)//2).  Mirror that at scale×.
-            GHOST_SZ = 110 * scale          # 330 px
+            sf = float(_scale)
+            GHOST_SZ = round(110 * sf)
             ghost = _logo_ghost(winner_abbr, winner_id, size=GHOST_SZ, lightness=215)
             if ghost:
                 gw, gh = ghost.size
-                gx = (135 * scale - gw) // 2
-                gy = 20 * scale + (110 * scale - gh) // 2
+                gx = (round(135 * sf) - gw) // 2
+                gy = round(20 * sf) + (round(110 * sf) - gh) // 2
                 _paste_logo(scaled_cell, ghost, (gx, gy))
 
-    # Paste the scaled cell centred in the content area
     canvas = Image.new('1', (800, 480), 255)
-    paste_x = SB_W + (AREA_W - SCALED) // 2    # 32 + 143 = 175
-    paste_y = _WC_STRIP_H + (AREA_H - SCALED) // 2   # 30 + 0 = 30
     canvas.paste(scaled_cell, (paste_x, paste_y))
+
+    # Sidebars: left = x=0..paste_x-1, right = x=(paste_x+_box_w)..799
+    # Both widths are ~197-198px so logos are the same size on each side.
+    _left_sb_w  = paste_x             # 197
+    _right_sb_x = paste_x + _box_w   # 602
+    _right_sb_w = 800 - _right_sb_x  # 198
+    _sb_logo_sz = 52
 
     # Overlay wildcard header and standings sidebars
     standings_data = load_json_file('standings.json')
@@ -885,8 +889,12 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
             wildcard_data = derive_wildcard_from_standings(standings_data)
             canvas = draw_wildcard_header(canvas, wildcard_data)
         if config.get('show_standings_sidebar', False):
-            canvas = draw_standings_sidebar(canvas, standings_data, team_data, side='left', league_mode=league_mode)
-            canvas = draw_standings_sidebar(canvas, standings_data, team_data, side='right', league_mode=league_mode)
+            canvas = draw_standings_sidebar_fullscreen(
+                canvas, standings_data, team_data, side='left', league_mode=league_mode,
+                x_anchor=0, sidebar_w=_left_sb_w, logo_sz=_sb_logo_sz)
+            canvas = draw_standings_sidebar_fullscreen(
+                canvas, standings_data, team_data, side='right', league_mode=league_mode,
+                x_anchor=_right_sb_x, sidebar_w=_right_sb_w, logo_sz=_sb_logo_sz)
 
     return canvas
 

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -845,7 +845,7 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
     cell = Image.new('1', (CELL, CELL), 255)
     cell = draw_box(cell, 0, 0, game_data, team_data,
                     use_logos=use_logos, logo_x_offset=logo_offset,
-                    show_win_prob=win_prob)
+                    show_win_prob=win_prob, show_winner_logo=False)
     scaled_gray = cell.convert('L').resize((SCALED, SCALED), Image.LANCZOS)
     scaled_cell = scaled_gray.point(lambda p: 0 if p < 180 else 255).convert('1')
 

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -862,11 +862,14 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
             winner_abbr = abbr_map.get(str(game_data.get('home_team_id', '')))
             winner_id   = str(game_data.get('home_team_id', ''))
         if winner_abbr and winner_id:
-            ghost = _logo_ghost(winner_abbr, winner_id, size=SCALED, lightness=215)
+            # draw_box places a 110px ghost centred in the 135×110 content area
+            # (gx = (135-gw)//2, gy = 20 + (110-gh)//2).  Mirror that at scale×.
+            GHOST_SZ = 110 * scale          # 330 px
+            ghost = _logo_ghost(winner_abbr, winner_id, size=GHOST_SZ, lightness=215)
             if ghost:
                 gw, gh = ghost.size
-                gx = (SCALED - gw) // 2
-                gy = (SCALED - gh) // 2
+                gx = (135 * scale - gw) // 2
+                gy = 20 * scale + (110 * scale - gh) // 2
                 _paste_logo(scaled_cell, ghost, (gx, gy))
 
     # Paste the scaled cell centred in the content area

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -8,7 +8,7 @@ from util import load_json_file, load_yaml_file, save_off_results
 from collections import OrderedDict
 
 from image_assets import (
-    picdir, _get_font, _logo_small, _load_logo_gray,
+    picdir, _get_font, _logo_small, _load_logo_gray, _paste_logo,
     Image, ImageDraw, ImageFont, ImageOps,
 )
 from image_utils import (
@@ -704,10 +704,26 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
             return None
 
     print('image is different')
-    Himage = Image.new('1', (800, 480), 255)
-    Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob)
 
     league_mode = config.get('league_mode', 'mlb')
+
+    # --- Featured team full-screen mode ---
+    if config.get('featured_team_fullscreen', False):
+        primary = config.get('primary', '')
+        featured_game = _find_featured_game(game_state_data, team_data, primary)
+        if featured_game:
+            Himage = draw_featured_game_fullscreen(featured_game, team_data, config)
+        else:
+            Himage = Image.new('1', (800, 480), 255)
+            Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob)
+
+        if config.get('dark_mode', False):
+            Himage = ImageOps.invert(Himage.convert('L')).convert('1')
+        return (Himage, [])   # always full refresh for fullscreen
+
+    # --- Normal scoreboard grid ---
+    Himage = Image.new('1', (800, 480), 255)
+    Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob)
 
     standings_data = None
     if config.get('show_wildcard_standings', False) or config.get('show_standings_sidebar', False):
@@ -762,3 +778,371 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         changed_regions = []
 
     return (Himage, changed_regions)
+
+
+# ---------------------------------------------------------------------------
+# Featured team full-screen rendering
+# ---------------------------------------------------------------------------
+
+def _find_featured_game(game_state_data, team_data, primary_abbr):
+    """Return the best game to display for primary_abbr in fullscreen mode.
+
+    Priority: first Scheduled/Pre-Game/Warmup → first In Progress → last Final.
+    Falls back to the first game in the list if the primary team has no game.
+    """
+    abbr_map = team_data.get('team_abbreviation', {})
+    primary_games = []
+    for game in game_state_data:
+        away = abbr_map.get(str(game.get('away_team_id', '')), '')
+        home = abbr_map.get(str(game.get('home_team_id', '')), '')
+        if primary_abbr in (away, home):
+            primary_games.append(game)
+
+    if not primary_games:
+        return game_state_data[0] if game_state_data else None
+
+    _scheduled = {'Scheduled', 'Pre-Game', 'Warmup', 'Delayed Start'}
+    _final     = {'Final', 'Game Over', 'Final: Tied'}
+
+    for g in primary_games:
+        if g.get('detailed_state') in _scheduled:
+            return g
+    for g in primary_games:
+        if g.get('detailed_state') == 'In Progress':
+            return g
+    for g in reversed(primary_games):
+        if g.get('detailed_state', '').startswith('Completed Early') or g.get('detailed_state') in _final:
+            return g
+    return primary_games[-1]
+
+
+def _draw_fullscreen_linescore(draw, Himage, start_y, game_data, team_data, font_hdr, font_val):
+    """Render a full-width inning-by-inning grid.  Returns the Y coord of the grid bottom."""
+    W = 800
+    MARGIN = 12
+    TEAM_COL_W = 52
+    HEADER_H = 22
+    ROW_H = 28
+
+    away_inn = game_data.get('away_inning_runs') or []
+    home_inn = game_data.get('home_inning_runs') or []
+    current  = game_data.get('current_inning') or max(len(away_inn), 9)
+    N = max(9, current)
+
+    MAX_INN = 12
+    if N > MAX_INN:
+        first_inn = N - MAX_INN + 1
+        n_cols = MAX_INN
+    else:
+        first_inn = 1
+        n_cols = N
+
+    total_data_cols = n_cols + 3           # innings + R + H + E
+    avail_w = W - 2 * MARGIN - TEAM_COL_W
+    col_w = avail_w // total_data_cols
+    x0 = MARGIN + TEAM_COL_W
+
+    abbr_map = team_data.get('team_abbreviation', {})
+    away_id  = str(game_data.get('away_team_id', ''))
+    home_id  = str(game_data.get('home_team_id', ''))
+    away_abbr = abbr_map.get(away_id, '???')
+    home_abbr = abbr_map.get(home_id, '???')
+
+    # Header row — inning numbers + RHE labels
+    for i in range(n_cols):
+        label = str(first_inn + i)
+        lw = int(font_hdr.getlength(label))
+        cx = x0 + i * col_w + col_w // 2
+        draw.text((cx - lw // 2, start_y), label, font=font_hdr, fill=0)
+    for j, lbl in enumerate(('R', 'H', 'E')):
+        lw = int(font_hdr.getlength(lbl))
+        cx = x0 + n_cols * col_w + j * col_w + col_w // 2
+        draw.text((cx - lw // 2, start_y), lbl, font=font_hdr, fill=0)
+
+    sep_y = start_y + HEADER_H
+    draw.line((MARGIN, sep_y, W - MARGIN, sep_y), fill=0)
+
+    rows = [
+        (away_abbr, away_inn, game_data.get('away_runs') or 0,
+         game_data.get('away_hits') or 0, game_data.get('away_errors') or 0),
+        (home_abbr, home_inn, game_data.get('home_runs') or 0,
+         game_data.get('home_hits') or 0, game_data.get('home_errors') or 0),
+    ]
+    for row_idx, (abbr, inn_runs, runs, hits, errors) in enumerate(rows):
+        ry = sep_y + 2 + row_idx * ROW_H
+        text_y = ry + (ROW_H - 18) // 2
+
+        # Team abbreviation right-aligned in team column
+        aw = int(font_val.getlength(abbr))
+        draw.text((MARGIN + TEAM_COL_W - aw - 4, text_y), abbr, font=font_val, fill=0)
+
+        # Per-inning cells
+        for i in range(n_cols):
+            idx = first_inn + i - 1
+            if idx < len(inn_runs):
+                cell = 'X' if inn_runs[idx] is None else str(inn_runs[idx])
+            else:
+                cell = '-'
+            cw_val = int(font_val.getlength(cell))
+            cx = x0 + i * col_w + col_w // 2
+            draw.text((cx - cw_val // 2, text_y), cell, font=font_val, fill=0)
+
+        # R H E
+        for j, val in enumerate((str(runs), str(hits), str(errors))):
+            vw = int(font_val.getlength(val))
+            cx = x0 + n_cols * col_w + j * col_w + col_w // 2
+            draw.text((cx - vw // 2, text_y), val, font=font_val, fill=0)
+
+    bottom_y = sep_y + 2 + 2 * ROW_H
+    draw.line((MARGIN, bottom_y, W - MARGIN, bottom_y), fill=0)
+    return bottom_y
+
+
+def draw_featured_game_fullscreen(game_data, team_data, config=None):
+    """Render a single game at full 800×480 resolution for the featured team display."""
+    if config is None:
+        config = load_yaml_file('config.yaml')
+
+    W, H = 800, 480
+    Himage = Image.new('1', (W, H), 255)
+    draw = ImageDraw.Draw(Himage)
+    use_logos = config.get('use_team_logos', False)
+
+    # Normalize states (mirrors draw_box)
+    if game_data.get('detailed_state', '').startswith('Completed Early'):
+        game_data = dict(game_data)
+        game_data['detailed_state'] = 'Final'
+    if game_data.get('detailed_state') == 'Delayed Start':
+        game_data = dict(game_data)
+        game_data['detailed_state'] = 'Pre-Game'
+    if game_data.get('detailed_state') == 'In Progress':
+        _has_play = (
+            (game_data.get('balls') or 0) > 0
+            or (game_data.get('strikes') or 0) > 0
+            or (game_data.get('num_of_outs') or 0) > 0
+            or (game_data.get('away_runs') or 0) > 0
+            or (game_data.get('home_runs') or 0) > 0
+            or game_data.get('inningState') in ('Middle', 'End')
+            or (game_data.get('current_inning') or 1) > 1
+            or game_data.get('runner_on_first')
+            or game_data.get('runner_on_second')
+            or game_data.get('runner_on_third')
+            or game_data.get('last_play')
+        )
+        if not _has_play:
+            game_data = dict(game_data)
+            game_data['detailed_state'] = 'Pre-Game'
+
+    state = game_data.get('detailed_state', '')
+    abbr_map = team_data.get('team_abbreviation', {})
+    away_id   = str(game_data.get('away_team_id', ''))
+    home_id   = str(game_data.get('home_team_id', ''))
+    away_abbr = abbr_map.get(away_id, '???')
+    home_abbr = abbr_map.get(home_id, '???')
+    away_runs = game_data.get('away_runs') or 0
+    home_runs = game_data.get('home_runs') or 0
+
+    _FINAL_STATES = {'Final', 'Game Over', 'Final: Tied'}
+    _PRE_STATES   = {'Scheduled', 'Pre-Game', 'Warmup'}
+    _ORDINALS     = {1:'1st',2:'2nd',3:'3rd',4:'4th',5:'5th',
+                     6:'6th',7:'7th',8:'8th',9:'9th',10:'10th',11:'11th',12:'12th'}
+
+    font72 = _get_font(72)
+    font42 = _get_font(42)
+    font30 = _get_font(30)
+    font22 = _get_font(22)
+    font18 = _get_font(18)
+    LOGO_SIZE = 90
+
+    # ── Status header (Y=0..54) ──────────────────────────────────────────────
+    if state in _FINAL_STATES:
+        status = 'FINAL (TIE)' if state == 'Final: Tied' else 'FINAL'
+    elif state == 'In Progress':
+        inning = game_data.get('current_inning') or 1
+        inn_label = _ORDINALS.get(inning, f'{inning}th')
+        status = f"{game_data.get('inningState', 'Top')} {inn_label}"
+    elif state in _PRE_STATES:
+        status = state
+    elif state == 'Postponed':
+        reason = game_data.get('postpone_reason') or ''
+        status = f'PPD: {reason}' if reason else 'POSTPONED'
+    else:
+        status = state
+
+    sw = int(font30.getlength(status))
+    draw.text(((W - sw) // 2,     12), status, font=font30, fill=0)
+    draw.text(((W - sw) // 2 + 1, 12), status, font=font30, fill=0)
+    draw.line((0, 54, W, 54), fill=0)
+
+    # ── Teams + scores (Y=60..229) ───────────────────────────────────────────
+    ZONE_MID = 145   # vertical centre of this zone
+
+    def _place_logo(abbr, team_id, cx, side):
+        """Paste a logo at cx, clipped to screen edge. side='left' or 'right'."""
+        logo = _logo_small(abbr, team_id, size=LOGO_SIZE)
+        if not logo:
+            return
+        lx = (cx - LOGO_SIZE - 8) if side == 'left' else (cx + 8)
+        lx = max(0, min(W - LOGO_SIZE, lx))
+        ly = ZONE_MID - LOGO_SIZE // 2
+        _paste_logo(Himage, logo, (lx, ly))
+
+    if state in _FINAL_STATES or state == 'In Progress':
+        a_str = str(away_runs)
+        h_str = str(home_runs)
+        dash   = '-'
+        asw = int(font72.getlength(a_str))
+        hsw = int(font72.getlength(h_str))
+        dw  = int(font42.getlength(dash))
+
+        total_score_w = asw + 30 + dw + 30 + hsw
+        score_x = (W - total_score_w) // 2
+        score_y = ZONE_MID - 36        # 72-px font: half-height = 36
+
+        draw.text((score_x,                         score_y), a_str, font=font72, fill=0)
+        draw.text((score_x + asw + 30,              score_y + 16), dash, font=font42, fill=0)
+        draw.text((score_x + asw + 30 + dw + 30,   score_y), h_str, font=font72, fill=0)
+
+        # Away team left of score block
+        aaw = int(font42.getlength(away_abbr))
+        ax  = score_x - aaw - 50
+        draw.text((ax, ZONE_MID - 21), away_abbr, font=font42, fill=0)
+        if use_logos:
+            _place_logo(away_abbr, away_id, ax, 'left')
+
+        # Home team right of score block
+        hx = score_x + asw + 30 + dw + 30 + hsw + 50
+        draw.text((hx, ZONE_MID - 21), home_abbr, font=font42, fill=0)
+        if use_logos:
+            haw = int(font42.getlength(home_abbr))
+            _place_logo(home_abbr, home_id, hx + haw, 'right')
+
+    else:
+        # Scheduled / Pre-Game / Postponed: "AWAY @ HOME"
+        matchup = f'{away_abbr}  @  {home_abbr}'
+        mw = int(font42.getlength(matchup))
+        mx = (W - mw) // 2
+        draw.text((mx, ZONE_MID - 21), matchup, font=font42, fill=0)
+        if use_logos:
+            _place_logo(away_abbr, away_id, mx, 'left')
+            _place_logo(home_abbr, home_id, mx + mw, 'right')
+
+    draw.line((0, 233, W, 233), fill=0)
+
+    # ── Details zone (Y=238..479) ────────────────────────────────────────────
+    DETAIL_TOP = 240
+
+    if state in _FINAL_STATES:
+        ls_bottom = _draw_fullscreen_linescore(
+            draw, Himage, DETAIL_TOP, game_data, team_data, font18, font18)
+
+        # WP / LP / SV — one per column, centred
+        winner  = game_data.get('winner_name') or ''
+        loser   = game_data.get('loser_name') or ''
+        saver   = game_data.get('saver_name') or ''
+        wp_rec  = game_data.get('winner_record') or ''
+        lp_rec  = game_data.get('loser_record') or ''
+        sv_saves = game_data.get('saver_saves')
+        is_walkoff = bool(game_data.get('walk_off'))
+
+        lines = []
+        if winner:
+            s = f'WP: {_format_player_name(winner)}'
+            if wp_rec: s += f' ({wp_rec})'
+            lines.append(s)
+        if loser:
+            s = f'LP: {_format_player_name(loser)}'
+            if lp_rec: s += f' ({lp_rec})'
+            lines.append(s)
+        if saver:
+            s = f'SV: {_format_player_name(saver)}'
+            if sv_saves is not None: s += f' (S{sv_saves})'
+            lines.append(s)
+        if is_walkoff and lines:
+            lines.insert(0, 'Walk-off')
+
+        if lines:
+            pit_y = ls_bottom + 10
+            gap = (W - 20) // max(len(lines), 1)
+            for i, line in enumerate(lines):
+                lw = int(font22.getlength(line))
+                px = 10 + i * gap + (gap - lw) // 2
+                draw.text((px, pit_y), line, font=font22, fill=0)
+
+    elif state == 'In Progress':
+        ls_bottom = _draw_fullscreen_linescore(
+            draw, Himage, DETAIL_TOP, game_data, team_data, font18, font18)
+
+        count_y = ls_bottom + 10
+        balls   = game_data.get('balls') or 0
+        strikes = game_data.get('strikes') or 0
+        outs    = game_data.get('num_of_outs') or 0
+        count_str = f'B:{balls}  S:{strikes}  O:{outs}'
+        cw = int(font22.getlength(count_str))
+        draw.text(((W - cw) // 2, count_y), count_str, font=font22, fill=0)
+
+        last_play = game_data.get('last_play') or ''
+        if last_play:
+            lp_str = f'Last: {last_play}'
+            lpw = int(font22.getlength(lp_str))
+            if lpw > W - 20:
+                lp_str = last_play
+                lpw = int(font22.getlength(lp_str))
+            draw.text(((W - lpw) // 2, count_y + 30), lp_str, font=font22, fill=0)
+
+    elif state in _PRE_STATES:
+        away_pitcher_name, away_pitcher_stat = _pitcher_line(
+            game_data.get('away_probable'), game_data.get('away_probable_note'))
+        home_pitcher_name, home_pitcher_stat = _pitcher_line(
+            game_data.get('home_probable'), game_data.get('home_probable_note'))
+
+        def _draw_fs_pitcher(y, team, name, stat):
+            MARGIN_L = 12
+            MARGIN_R = W - 12
+            label = f'{team}:'
+            lw = int(font22.getlength(label))
+            draw.text((MARGIN_L,     y), label, font=font22, fill=0)
+            draw.text((MARGIN_L + 1, y), label, font=font22, fill=0)
+            name_x = MARGIN_L + lw + 10
+            stat_w = int(font18.getlength(stat)) if stat else 0
+            stat_x = MARGIN_R - stat_w
+            avail = stat_x - name_x - 8
+            n = name or 'TBD'
+            while n and int(font22.getlength(n)) > avail:
+                n = n[:-1]
+            draw.text((name_x, y), n, font=font22, fill=0)
+            if stat:
+                draw.text((stat_x, y + 2), stat, font=font18, fill=0)
+
+        _draw_fs_pitcher(DETAIL_TOP,      away_abbr, away_pitcher_name, away_pitcher_stat)
+        _draw_fs_pitcher(DETAIL_TOP + 34, home_abbr, home_pitcher_name, home_pitcher_stat)
+
+        # Weather
+        weather_parts = []
+        temp = game_data.get('weather_temp_f')
+        if temp is not None:
+            weather_parts.append(f'{temp}°F')
+        wind_speed = game_data.get('weather_wind_mph')
+        wind_dir   = (game_data.get('weather_wind_dir') or '').strip()
+        if wind_speed is not None:
+            weather_parts.append(f'{wind_speed}mph {wind_dir}'.strip())
+        precip = game_data.get('weather_precip_pct')
+        if precip is not None:
+            weather_parts.append(f'{precip}% precip')
+
+        if weather_parts:
+            wx_str = '  •  '.join(weather_parts)
+            ww = int(font22.getlength(wx_str))
+            draw.text(((W - ww) // 2, DETAIL_TOP + 80), wx_str, font=font22, fill=0)
+
+        venue = game_data.get('venue') or ''
+        if venue:
+            vw = int(font18.getlength(venue))
+            draw.text(((W - vw) // 2, DETAIL_TOP + 112), venue, font=font18, fill=0)
+
+    elif state == 'Postponed':
+        msg = game_data.get('postpone_reason') or game_data.get('description') or 'Game Postponed'
+        mw = int(font30.getlength(msg))
+        draw.text(((W - mw) // 2, DETAIL_TOP + 80), msg, font=font30, fill=0)
+
+    return Himage

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -8,7 +8,7 @@ from util import load_json_file, load_yaml_file, save_off_results
 from collections import OrderedDict
 
 from image_assets import (
-    picdir, _get_font, _logo_small, _load_logo_gray,
+    picdir, _get_font, _logo_small, _load_logo_gray, _logo_ghost, _paste_logo,
     Image, ImageDraw, ImageFont, ImageOps,
 )
 from image_utils import (
@@ -841,13 +841,33 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
     scale  = min(AREA_W, AREA_H) // CELL   # 3  (limited by height: 450//150)
     SCALED = CELL * scale                   # 450 px
 
-    # Render the cell then upscale via grayscale for smoother strokes
+    # Render WITHOUT the winner ghost so upscaling doesn't smear faint dither dots
+    # into heavy blobs that obscure text.  Ghost is overlaid separately below.
     cell = Image.new('1', (CELL, CELL), 255)
     cell = draw_box(cell, 0, 0, game_data, team_data,
                     use_logos=use_logos, logo_x_offset=logo_offset,
                     show_win_prob=win_prob, show_winner_logo=False)
     scaled_gray = cell.convert('L').resize((SCALED, SCALED), Image.LANCZOS)
     scaled_cell = scaled_gray.point(lambda p: 0 if p < 180 else 255).convert('1')
+
+    # Overlay winner ghost rendered natively at SCALED px — no upscaling artifacts.
+    # lightness=215 → ~15% dot density: recognisable watermark that doesn't obscure text.
+    if use_logos and game_data.get('detailed_state') in ('Final', 'Game Over', 'Final: Tied'):
+        abbr_map = team_data.get('team_abbreviation', {})
+        winner_abbr = winner_id = None
+        if game_data.get('away_team_is_winner'):
+            winner_abbr = abbr_map.get(str(game_data.get('away_team_id', '')))
+            winner_id   = str(game_data.get('away_team_id', ''))
+        elif game_data.get('home_team_is_winner'):
+            winner_abbr = abbr_map.get(str(game_data.get('home_team_id', '')))
+            winner_id   = str(game_data.get('home_team_id', ''))
+        if winner_abbr and winner_id:
+            ghost = _logo_ghost(winner_abbr, winner_id, size=SCALED, lightness=215)
+            if ghost:
+                gw, gh = ghost.size
+                gx = (SCALED - gw) // 2
+                gy = (SCALED - gh) // 2
+                _paste_logo(scaled_cell, ghost, (gx, gy))
 
     # Paste the scaled cell centred in the content area
     canvas = Image.new('1', (800, 480), 255)

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -817,10 +817,11 @@ def _find_featured_game(game_state_data, team_data, primary_abbr):
 
 
 def draw_featured_game_fullscreen(game_data, team_data, config=None):
-    """Enlarge a single scoreboard cell to 800×480 using the same draw_box layout.
+    """Enlarge a single scoreboard cell while preserving its 1:1 aspect ratio.
 
-    Renders the game with draw_box at its normal scale, then upscales the result
-    to fill the full display — same layout, no repositioning.
+    The cell is scaled to fill the content area (inside the standings chrome)
+    uniformly, then the wildcard header and standings sidebars are drawn on top
+    exactly as they appear in the normal scoreboard view.
     """
     if config is None:
         config = load_yaml_file('config.yaml')
@@ -828,19 +829,42 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
     use_logos   = config.get('use_team_logos', False)
     logo_offset = config.get('small_logo_x_offset', 2)
     win_prob    = config.get('scoreboard_win_probability', False)
+    league_mode = config.get('league_mode', 'mlb')
 
-    # draw_box renders into ~135×130 px starting at (start_x, start_y).
-    # Use a 150×150 canvas with the box at (0, 0) so nothing is clipped.
+    # Standings chrome dimensions (must match the normal scoreboard grid)
+    SB_W = 32        # sidebar strip width on each side (x_start used by draw_out_of_town_score_board)
+    AREA_W = 800 - 2 * SB_W          # 736 px
+    AREA_H = 480 - _WC_STRIP_H       # 450 px
+
+    # Scale the 150×150 cell to fit the content area with uniform (1:1) ratio
     CELL = 150
+    scale  = min(AREA_W, AREA_H) // CELL   # 3  (limited by height: 450//150)
+    SCALED = CELL * scale                   # 450 px
+
+    # Render the cell then upscale via grayscale for smoother strokes
     cell = Image.new('1', (CELL, CELL), 255)
     cell = draw_box(cell, 0, 0, game_data, team_data,
                     use_logos=use_logos, logo_x_offset=logo_offset,
                     show_win_prob=win_prob)
+    scaled_gray = cell.convert('L').resize((SCALED, SCALED), Image.LANCZOS)
+    scaled_cell = scaled_gray.point(lambda p: 0 if p < 180 else 255).convert('1')
 
-    # Upscale to full display via grayscale (LANCZOS gives smoother edges than NEAREST)
-    # then threshold back to 1-bit.  Threshold at 180 keeps strokes slightly thicker
-    # at high magnification, improving readability on e-ink.
-    scaled = cell.convert('L').resize((800, 480), Image.LANCZOS)
-    return scaled.point(lambda p: 0 if p < 180 else 255).convert('1')
+    # Paste the scaled cell centred in the content area
+    canvas = Image.new('1', (800, 480), 255)
+    paste_x = SB_W + (AREA_W - SCALED) // 2    # 32 + 143 = 175
+    paste_y = _WC_STRIP_H + (AREA_H - SCALED) // 2   # 30 + 0 = 30
+    canvas.paste(scaled_cell, (paste_x, paste_y))
+
+    # Overlay wildcard header and standings sidebars
+    standings_data = load_json_file('standings.json')
+    if standings_data and 'standings' in standings_data:
+        if config.get('show_wildcard_standings', False) and league_mode != 'aaa':
+            wildcard_data = derive_wildcard_from_standings(standings_data)
+            canvas = draw_wildcard_header(canvas, wildcard_data)
+        if config.get('show_standings_sidebar', False):
+            canvas = draw_standings_sidebar(canvas, standings_data, team_data, side='left', league_mode=league_mode)
+            canvas = draw_standings_sidebar(canvas, standings_data, team_data, side='right', league_mode=league_mode)
+
+    return canvas
 
 

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -8,13 +8,13 @@ from util import load_json_file, load_yaml_file, save_off_results
 from collections import OrderedDict
 
 from image_assets import (
-    picdir, _get_font, _logo_small, _load_logo_gray, _paste_logo,
+    picdir, _get_font, _logo_small, _load_logo_gray,
     Image, ImageDraw, ImageFont, ImageOps,
 )
 from image_utils import (
     normalize_dict, standings_dict,
     draw_diamond, draw_circle, check_if_two_chars,
-    _format_player_name, _last_name, _pitcher_line, _clean_venue_name, _is_game_effectively_over,
+    _last_name, _pitcher_line, _clean_venue_name, _is_game_effectively_over,
 )
 from image_standings import (
     _WC_STRIP_H,
@@ -816,333 +816,31 @@ def _find_featured_game(game_state_data, team_data, primary_abbr):
     return primary_games[-1]
 
 
-def _draw_fullscreen_linescore(draw, Himage, start_y, game_data, team_data, font_hdr, font_val):
-    """Render a full-width inning-by-inning grid.  Returns the Y coord of the grid bottom."""
-    W = 800
-    MARGIN = 12
-    TEAM_COL_W = 52
-    HEADER_H = 22
-    ROW_H = 28
-
-    away_inn = game_data.get('away_inning_runs') or []
-    home_inn = game_data.get('home_inning_runs') or []
-    current  = game_data.get('current_inning') or max(len(away_inn), 9)
-    N = max(9, current)
-
-    MAX_INN = 12
-    if N > MAX_INN:
-        first_inn = N - MAX_INN + 1
-        n_cols = MAX_INN
-    else:
-        first_inn = 1
-        n_cols = N
-
-    total_data_cols = n_cols + 3           # innings + R + H + E
-    avail_w = W - 2 * MARGIN - TEAM_COL_W
-    col_w = avail_w // total_data_cols
-    x0 = MARGIN + TEAM_COL_W
-
-    abbr_map = team_data.get('team_abbreviation', {})
-    away_id  = str(game_data.get('away_team_id', ''))
-    home_id  = str(game_data.get('home_team_id', ''))
-    away_abbr = abbr_map.get(away_id, '???')
-    home_abbr = abbr_map.get(home_id, '???')
-
-    # Header row — inning numbers + RHE labels
-    for i in range(n_cols):
-        label = str(first_inn + i)
-        lw = int(font_hdr.getlength(label))
-        cx = x0 + i * col_w + col_w // 2
-        draw.text((cx - lw // 2, start_y), label, font=font_hdr, fill=0)
-    for j, lbl in enumerate(('R', 'H', 'E')):
-        lw = int(font_hdr.getlength(lbl))
-        cx = x0 + n_cols * col_w + j * col_w + col_w // 2
-        draw.text((cx - lw // 2, start_y), lbl, font=font_hdr, fill=0)
-
-    sep_y = start_y + HEADER_H
-    draw.line((MARGIN, sep_y, W - MARGIN, sep_y), fill=0)
-
-    rows = [
-        (away_abbr, away_inn, game_data.get('away_runs') or 0,
-         game_data.get('away_hits') or 0, game_data.get('away_errors') or 0),
-        (home_abbr, home_inn, game_data.get('home_runs') or 0,
-         game_data.get('home_hits') or 0, game_data.get('home_errors') or 0),
-    ]
-    for row_idx, (abbr, inn_runs, runs, hits, errors) in enumerate(rows):
-        ry = sep_y + 2 + row_idx * ROW_H
-        text_y = ry + (ROW_H - 18) // 2
-
-        # Team abbreviation right-aligned in team column
-        aw = int(font_val.getlength(abbr))
-        draw.text((MARGIN + TEAM_COL_W - aw - 4, text_y), abbr, font=font_val, fill=0)
-
-        # Per-inning cells
-        for i in range(n_cols):
-            idx = first_inn + i - 1
-            if idx < len(inn_runs):
-                cell = 'X' if inn_runs[idx] is None else str(inn_runs[idx])
-            else:
-                cell = '-'
-            cw_val = int(font_val.getlength(cell))
-            cx = x0 + i * col_w + col_w // 2
-            draw.text((cx - cw_val // 2, text_y), cell, font=font_val, fill=0)
-
-        # R H E
-        for j, val in enumerate((str(runs), str(hits), str(errors))):
-            vw = int(font_val.getlength(val))
-            cx = x0 + n_cols * col_w + j * col_w + col_w // 2
-            draw.text((cx - vw // 2, text_y), val, font=font_val, fill=0)
-
-    bottom_y = sep_y + 2 + 2 * ROW_H
-    draw.line((MARGIN, bottom_y, W - MARGIN, bottom_y), fill=0)
-    return bottom_y
-
-
 def draw_featured_game_fullscreen(game_data, team_data, config=None):
-    """Render a single game at full 800×480 resolution for the featured team display."""
+    """Enlarge a single scoreboard cell to 800×480 using the same draw_box layout.
+
+    Renders the game with draw_box at its normal scale, then upscales the result
+    to fill the full display — same layout, no repositioning.
+    """
     if config is None:
         config = load_yaml_file('config.yaml')
 
-    W, H = 800, 480
-    Himage = Image.new('1', (W, H), 255)
-    draw = ImageDraw.Draw(Himage)
-    use_logos = config.get('use_team_logos', False)
+    use_logos   = config.get('use_team_logos', False)
+    logo_offset = config.get('small_logo_x_offset', 2)
+    win_prob    = config.get('scoreboard_win_probability', False)
 
-    # Normalize states (mirrors draw_box)
-    if game_data.get('detailed_state', '').startswith('Completed Early'):
-        game_data = dict(game_data)
-        game_data['detailed_state'] = 'Final'
-    if game_data.get('detailed_state') == 'Delayed Start':
-        game_data = dict(game_data)
-        game_data['detailed_state'] = 'Pre-Game'
-    if game_data.get('detailed_state') == 'In Progress':
-        _has_play = (
-            (game_data.get('balls') or 0) > 0
-            or (game_data.get('strikes') or 0) > 0
-            or (game_data.get('num_of_outs') or 0) > 0
-            or (game_data.get('away_runs') or 0) > 0
-            or (game_data.get('home_runs') or 0) > 0
-            or game_data.get('inningState') in ('Middle', 'End')
-            or (game_data.get('current_inning') or 1) > 1
-            or game_data.get('runner_on_first')
-            or game_data.get('runner_on_second')
-            or game_data.get('runner_on_third')
-            or game_data.get('last_play')
-        )
-        if not _has_play:
-            game_data = dict(game_data)
-            game_data['detailed_state'] = 'Pre-Game'
+    # draw_box renders into ~135×130 px starting at (start_x, start_y).
+    # Use a 150×150 canvas with the box at (0, 0) so nothing is clipped.
+    CELL = 150
+    cell = Image.new('1', (CELL, CELL), 255)
+    cell = draw_box(cell, 0, 0, game_data, team_data,
+                    use_logos=use_logos, logo_x_offset=logo_offset,
+                    show_win_prob=win_prob)
 
-    state = game_data.get('detailed_state', '')
-    abbr_map = team_data.get('team_abbreviation', {})
-    away_id   = str(game_data.get('away_team_id', ''))
-    home_id   = str(game_data.get('home_team_id', ''))
-    away_abbr = abbr_map.get(away_id, '???')
-    home_abbr = abbr_map.get(home_id, '???')
-    away_runs = game_data.get('away_runs') or 0
-    home_runs = game_data.get('home_runs') or 0
+    # Upscale to full display via grayscale (LANCZOS gives smoother edges than NEAREST)
+    # then threshold back to 1-bit.  Threshold at 180 keeps strokes slightly thicker
+    # at high magnification, improving readability on e-ink.
+    scaled = cell.convert('L').resize((800, 480), Image.LANCZOS)
+    return scaled.point(lambda p: 0 if p < 180 else 255).convert('1')
 
-    _FINAL_STATES = {'Final', 'Game Over', 'Final: Tied'}
-    _PRE_STATES   = {'Scheduled', 'Pre-Game', 'Warmup'}
-    _ORDINALS     = {1:'1st',2:'2nd',3:'3rd',4:'4th',5:'5th',
-                     6:'6th',7:'7th',8:'8th',9:'9th',10:'10th',11:'11th',12:'12th'}
 
-    font72 = _get_font(72)
-    font42 = _get_font(42)
-    font30 = _get_font(30)
-    font22 = _get_font(22)
-    font18 = _get_font(18)
-    LOGO_SIZE = 90
-
-    # ── Status header (Y=0..54) ──────────────────────────────────────────────
-    if state in _FINAL_STATES:
-        status = 'FINAL (TIE)' if state == 'Final: Tied' else 'FINAL'
-    elif state == 'In Progress':
-        inning = game_data.get('current_inning') or 1
-        inn_label = _ORDINALS.get(inning, f'{inning}th')
-        status = f"{game_data.get('inningState', 'Top')} {inn_label}"
-    elif state in _PRE_STATES:
-        status = state
-    elif state == 'Postponed':
-        reason = game_data.get('postpone_reason') or ''
-        status = f'PPD: {reason}' if reason else 'POSTPONED'
-    else:
-        status = state
-
-    sw = int(font30.getlength(status))
-    draw.text(((W - sw) // 2,     12), status, font=font30, fill=0)
-    draw.text(((W - sw) // 2 + 1, 12), status, font=font30, fill=0)
-    draw.line((0, 54, W, 54), fill=0)
-
-    # ── Teams + scores (Y=60..229) ───────────────────────────────────────────
-    ZONE_MID = 145   # vertical centre of this zone
-
-    def _place_logo(abbr, team_id, cx, side):
-        """Paste a logo at cx, clipped to screen edge. side='left' or 'right'."""
-        logo = _logo_small(abbr, team_id, size=LOGO_SIZE)
-        if not logo:
-            return
-        lx = (cx - LOGO_SIZE - 8) if side == 'left' else (cx + 8)
-        lx = max(0, min(W - LOGO_SIZE, lx))
-        ly = ZONE_MID - LOGO_SIZE // 2
-        _paste_logo(Himage, logo, (lx, ly))
-
-    if state in _FINAL_STATES or state == 'In Progress':
-        a_str = str(away_runs)
-        h_str = str(home_runs)
-        dash   = '-'
-        asw = int(font72.getlength(a_str))
-        hsw = int(font72.getlength(h_str))
-        dw  = int(font42.getlength(dash))
-
-        total_score_w = asw + 30 + dw + 30 + hsw
-        score_x = (W - total_score_w) // 2
-        score_y = ZONE_MID - 36        # 72-px font: half-height = 36
-
-        draw.text((score_x,                         score_y), a_str, font=font72, fill=0)
-        draw.text((score_x + asw + 30,              score_y + 16), dash, font=font42, fill=0)
-        draw.text((score_x + asw + 30 + dw + 30,   score_y), h_str, font=font72, fill=0)
-
-        # Away team left of score block
-        aaw = int(font42.getlength(away_abbr))
-        ax  = score_x - aaw - 50
-        draw.text((ax, ZONE_MID - 21), away_abbr, font=font42, fill=0)
-        if use_logos:
-            _place_logo(away_abbr, away_id, ax, 'left')
-
-        # Home team right of score block
-        hx = score_x + asw + 30 + dw + 30 + hsw + 50
-        draw.text((hx, ZONE_MID - 21), home_abbr, font=font42, fill=0)
-        if use_logos:
-            haw = int(font42.getlength(home_abbr))
-            _place_logo(home_abbr, home_id, hx + haw, 'right')
-
-    else:
-        # Scheduled / Pre-Game / Postponed: "AWAY @ HOME"
-        matchup = f'{away_abbr}  @  {home_abbr}'
-        mw = int(font42.getlength(matchup))
-        mx = (W - mw) // 2
-        draw.text((mx, ZONE_MID - 21), matchup, font=font42, fill=0)
-        if use_logos:
-            _place_logo(away_abbr, away_id, mx, 'left')
-            _place_logo(home_abbr, home_id, mx + mw, 'right')
-
-    draw.line((0, 233, W, 233), fill=0)
-
-    # ── Details zone (Y=238..479) ────────────────────────────────────────────
-    DETAIL_TOP = 240
-
-    if state in _FINAL_STATES:
-        ls_bottom = _draw_fullscreen_linescore(
-            draw, Himage, DETAIL_TOP, game_data, team_data, font18, font18)
-
-        # WP / LP / SV — one per column, centred
-        winner  = game_data.get('winner_name') or ''
-        loser   = game_data.get('loser_name') or ''
-        saver   = game_data.get('saver_name') or ''
-        wp_rec  = game_data.get('winner_record') or ''
-        lp_rec  = game_data.get('loser_record') or ''
-        sv_saves = game_data.get('saver_saves')
-        is_walkoff = bool(game_data.get('walk_off'))
-
-        lines = []
-        if winner:
-            s = f'WP: {_format_player_name(winner)}'
-            if wp_rec: s += f' ({wp_rec})'
-            lines.append(s)
-        if loser:
-            s = f'LP: {_format_player_name(loser)}'
-            if lp_rec: s += f' ({lp_rec})'
-            lines.append(s)
-        if saver:
-            s = f'SV: {_format_player_name(saver)}'
-            if sv_saves is not None: s += f' (S{sv_saves})'
-            lines.append(s)
-        if is_walkoff and lines:
-            lines.insert(0, 'Walk-off')
-
-        if lines:
-            pit_y = ls_bottom + 10
-            gap = (W - 20) // max(len(lines), 1)
-            for i, line in enumerate(lines):
-                lw = int(font22.getlength(line))
-                px = 10 + i * gap + (gap - lw) // 2
-                draw.text((px, pit_y), line, font=font22, fill=0)
-
-    elif state == 'In Progress':
-        ls_bottom = _draw_fullscreen_linescore(
-            draw, Himage, DETAIL_TOP, game_data, team_data, font18, font18)
-
-        count_y = ls_bottom + 10
-        balls   = game_data.get('balls') or 0
-        strikes = game_data.get('strikes') or 0
-        outs    = game_data.get('num_of_outs') or 0
-        count_str = f'B:{balls}  S:{strikes}  O:{outs}'
-        cw = int(font22.getlength(count_str))
-        draw.text(((W - cw) // 2, count_y), count_str, font=font22, fill=0)
-
-        last_play = game_data.get('last_play') or ''
-        if last_play:
-            lp_str = f'Last: {last_play}'
-            lpw = int(font22.getlength(lp_str))
-            if lpw > W - 20:
-                lp_str = last_play
-                lpw = int(font22.getlength(lp_str))
-            draw.text(((W - lpw) // 2, count_y + 30), lp_str, font=font22, fill=0)
-
-    elif state in _PRE_STATES:
-        away_pitcher_name, away_pitcher_stat = _pitcher_line(
-            game_data.get('away_probable'), game_data.get('away_probable_note'))
-        home_pitcher_name, home_pitcher_stat = _pitcher_line(
-            game_data.get('home_probable'), game_data.get('home_probable_note'))
-
-        def _draw_fs_pitcher(y, team, name, stat):
-            MARGIN_L = 12
-            MARGIN_R = W - 12
-            label = f'{team}:'
-            lw = int(font22.getlength(label))
-            draw.text((MARGIN_L,     y), label, font=font22, fill=0)
-            draw.text((MARGIN_L + 1, y), label, font=font22, fill=0)
-            name_x = MARGIN_L + lw + 10
-            stat_w = int(font18.getlength(stat)) if stat else 0
-            stat_x = MARGIN_R - stat_w
-            avail = stat_x - name_x - 8
-            n = name or 'TBD'
-            while n and int(font22.getlength(n)) > avail:
-                n = n[:-1]
-            draw.text((name_x, y), n, font=font22, fill=0)
-            if stat:
-                draw.text((stat_x, y + 2), stat, font=font18, fill=0)
-
-        _draw_fs_pitcher(DETAIL_TOP,      away_abbr, away_pitcher_name, away_pitcher_stat)
-        _draw_fs_pitcher(DETAIL_TOP + 34, home_abbr, home_pitcher_name, home_pitcher_stat)
-
-        # Weather
-        weather_parts = []
-        temp = game_data.get('weather_temp_f')
-        if temp is not None:
-            weather_parts.append(f'{temp}°F')
-        wind_speed = game_data.get('weather_wind_mph')
-        wind_dir   = (game_data.get('weather_wind_dir') or '').strip()
-        if wind_speed is not None:
-            weather_parts.append(f'{wind_speed}mph {wind_dir}'.strip())
-        precip = game_data.get('weather_precip_pct')
-        if precip is not None:
-            weather_parts.append(f'{precip}% precip')
-
-        if weather_parts:
-            wx_str = '  •  '.join(weather_parts)
-            ww = int(font22.getlength(wx_str))
-            draw.text(((W - ww) // 2, DETAIL_TOP + 80), wx_str, font=font22, fill=0)
-
-        venue = game_data.get('venue') or ''
-        if venue:
-            vw = int(font18.getlength(venue))
-            draw.text(((W - vw) // 2, DETAIL_TOP + 112), venue, font=font18, fill=0)
-
-    elif state == 'Postponed':
-        msg = game_data.get('postpone_reason') or game_data.get('description') or 'Game Postponed'
-        mw = int(font30.getlength(msg))
-        draw.text(((W - mw) // 2, DETAIL_TOP + 80), msg, font=font30, fill=0)
-
-    return Himage

--- a/src/image_assets.py
+++ b/src/image_assets.py
@@ -208,12 +208,12 @@ def _logo_small(abbr, team_id, size=28):
     return gray.convert('1')
 
 
-def _logo_ghost(abbr, team_id, size=110):
+def _logo_ghost(abbr, team_id, size=110, lightness=160):
     """Large, very-light ghost logo for the winner watermark on finished games.
 
-    The logo is dramatically brightened before Floyd-Steinberg dithering so only
-    ~30-35 % of the logo's darkest pixels survive as black dots — giving a clearly
-    recognisable watermark crest without obscuring the score text drawn on top.
+    lightness controls how bright (faint) the watermark is.  160 = normal (~30-35%
+    black dots); higher values produce fewer dots (e.g. 215 ≈ 15% for fullscreen use
+    where the logo is rendered at native resolution instead of being upscaled).
     Returns a '1'-mode image or None.
     """
     gray = _load_logo_gray(abbr, team_id)
@@ -221,8 +221,7 @@ def _logo_ghost(abbr, team_id, size=110):
         return None
     gray = gray.copy()
     gray.thumbnail((size, size), Image.LANCZOS)
-    # Lift dark pixels moderately so ~30-35% survive as black dots
-    gray = gray.point(lambda p: 255 if p > 180 else min(255, int(p * 0.3 + 160)))
+    gray = gray.point(lambda p: 255 if p > 180 else min(255, int(p * 0.3 + lightness)))
     return gray.convert('1')
 
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -89,7 +89,7 @@ def _get_or_set_final_time(game_pk):
     return ts
 
 
-def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos):
+def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos, scale=1):
     """Full-width per-inning linescore grid for between-inning scoreboard tiles.
 
     Layout (135px wide box):
@@ -100,13 +100,14 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
     Columns: 16px logo col + 9 × 13px inning cols = 133px
     Extra-innings: window shifts so the current inning is the rightmost column.
     """
-    LOGO_COL_W = 16
-    ROW_H_HDR  = 14
-    ROW_H_TEAM = 16
+    s = scale
+    LOGO_COL_W = 16 * s
+    ROW_H_HDR  = 14 * s
+    ROW_H_TEAM = 16 * s
     N_COLS     = 9
-    COL_W      = 13   # 16 + 9×13 = 133 ≤ 135
+    COL_W      = 13 * s   # 16 + 9×13 = 133 ≤ 135
 
-    y0 = start_y + 83            # grid top — bottom half of box (scores/logos/bases stay above)
+    y0 = start_y + 83 * s            # grid top — bottom half of box (scores/logos/bases stay above)
     y1 = y0 + ROW_H_HDR          # = start_y + 97  (away row top)
     y2 = y1 + ROW_H_TEAM         # = start_y + 113 (home row top)
     y3 = y2 + ROW_H_TEAM         # = start_y + 129 (grid bottom)
@@ -117,8 +118,8 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
     away_inn = game_data.get('away_inning_runs') or []
     home_inn = game_data.get('home_inning_runs') or []
 
-    font9  = _get_font(9)
-    font11 = _get_font(11)
+    font9  = _get_font(9 * s)
+    font11 = _get_font(11 * s)
 
     grid_right = start_x + LOGO_COL_W + N_COLS * COL_W
 
@@ -132,12 +133,12 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
 
     # --- inning header labels ---
     for k in range(N_COLS):
-        s = str(first_inn + k)
+        inn_label = str(first_inn + k)
         cell_x = start_x + LOGO_COL_W + k * COL_W
-        bbox = font9.getbbox(s)
+        bbox = font9.getbbox(inn_label)
         vis_w = bbox[2] - bbox[0]
         tx = cell_x + (COL_W - vis_w) // 2 - bbox[0] + 1
-        draw.text((tx, y0 + (ROW_H_HDR - 9) // 2), s, font=font9, fill=0)
+        draw.text((tx, y0 + (ROW_H_HDR - 9 * s) // 2), inn_label, font=font9, fill=0)
 
     # --- logos / abbr in team rows ---
     away_id  = str(game_data.get('away_team_id', ''))
@@ -148,16 +149,16 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
 
     def _place(abbr, tid, row_y):
         nonlocal draw
-        lsz = 12
+        lsz = 12 * s
         logo = _logo_small(abbr, tid, size=lsz) if use_logos else None
         if logo:
             lw, lh = logo.size
             Himage.paste(logo, (start_x + (LOGO_COL_W - lw) // 2, row_y + 1 + (ROW_H_TEAM - 1 - lh) // 2))
             draw = ImageDraw.Draw(Himage)
         else:
-            s = (abbr or '')[:3]
-            tw = int(font9.getlength(s))
-            draw.text((start_x + (LOGO_COL_W - tw) // 2, row_y + (ROW_H_TEAM - 9) // 2), s, font=font9, fill=0)
+            abbr_str = (abbr or '')[:3]
+            tw = int(font9.getlength(abbr_str))
+            draw.text((start_x + (LOGO_COL_W - tw) // 2, row_y + (ROW_H_TEAM - 9 * s) // 2), abbr_str, font=font9, fill=0)
 
     _place(away_abbr, away_id, y1)
     _place(home_abbr, home_id, y2)
@@ -171,7 +172,7 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
                 cell_x = start_x + LOGO_COL_W + k * COL_W
                 # Use font9 for double-digit values that won't fit in font11
                 fnt = font11 if int(font11.getlength(val)) <= COL_W - 2 else font9
-                fnt_h = 11 if fnt is font11 else 9
+                fnt_h = 11 * s if fnt is font11 else 9 * s
                 bbox = fnt.getbbox(val)
                 vis_w = bbox[2] - bbox[0]
                 tx = cell_x + (COL_W - vis_w) // 2 - bbox[0] + 1
@@ -195,7 +196,7 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
                 bbox = _xfont.getbbox('X')
                 vis_w = bbox[2] - bbox[0]
                 tx = cell_x + (COL_W - vis_w) // 2 - bbox[0] + 1
-                draw.text((tx, y2 + (ROW_H_TEAM - 11) // 2), 'X', font=_xfont, fill=0)
+                draw.text((tx, y2 + (ROW_H_TEAM - 11 * s) // 2), 'X', font=_xfont, fill=0)
 
     return draw, Himage
 
@@ -315,7 +316,8 @@ def _draw_weather_footer(draw, start_x, start_y, horiz_len, game_data, fnt, show
                 return
 
 
-def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True):
+def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1):
+    s = scale
     # Normalize early-completion states (e.g. spring training games called after 6 innings)
     if game_data.get('detailed_state', '').startswith('Completed Early'):
         game_data = dict(game_data)
@@ -359,18 +361,18 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             game_data['detailed_state'] = 'Pre-Game'
 
     draw = ImageDraw.Draw(Himage)
-    font24 = _get_font(24)
-    font18 = _get_font(18)
-    font14 = _get_font(14)
-    font11 = _get_font(11)
-    font9 = _get_font(9)
+    font24 = _get_font(24 * s)
+    font18 = _get_font(18 * s)
+    font14 = _get_font(14 * s)
+    font11 = _get_font(11 * s)
+    font9 = _get_font(9 * s)
 
     _cfg = load_yaml_file('config.yaml')
     _FINAL_LINESCORE_SECS = _cfg.get('final_linescore_minutes', 60) * 60
 
-    vertical_len = 110
-    horizonta_len = 135
-    max_text_width = horizonta_len - 14
+    vertical_len = 110 * s
+    horizonta_len = 135 * s
+    max_text_width = horizonta_len - 14 * s
 
     # Needed by the elif chain below — define early so all branches can reference it
     _delayed_with_score = (
@@ -422,11 +424,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     if game_data['detailed_state'] == 'Postponed':
         import random as _random
         _ppd_cp = _random.Random(game_data.get('game_pk', 0) ^ int(_time.time() // 60)).choice(_PPD_EMOJI_CODEPOINTS)
-        _ppd_ghost = _load_codepoint_ghost(_ppd_cp, size=90)
+        _ppd_ghost = _load_codepoint_ghost(_ppd_cp, size=90 * s)
         if _ppd_ghost:
             _gw, _gh = _ppd_ghost.size
             _gx = start_x + (horizonta_len - _gw) // 2
-            _gy = start_y + (vertical_len + 20 - _gh) // 2
+            _gy = start_y + (vertical_len + 20 * s - _gh) // 2
             Himage.paste(_ppd_ghost, (_gx, _gy))
             draw = ImageDraw.Draw(Himage)
 
@@ -438,11 +440,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         elif game_data.get('home_team_is_winner'):
             winner_abbr, winner_id = home_team_name, home_team_id
         if winner_abbr:
-            ghost = _logo_ghost(winner_abbr, winner_id)
+            ghost = _logo_ghost(winner_abbr, winner_id, size=110 * s)
             if ghost:
                 gw, gh = ghost.size
-                gx = start_x + (135 - gw) // 2 + 0
-                gy = start_y + 20 + (vertical_len - gh) // 2
+                gx = start_x + (135 * s - gw) // 2 + 0
+                gy = start_y + 20 * s + (vertical_len - gh) // 2
                 Himage.paste(ghost, (gx, gy))
                 draw = ImageDraw.Draw(Himage)
 
@@ -482,12 +484,12 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         if _show_linescore:
             # Show linescore for 10 min after game ends; switch once both window
             # has elapsed AND decisions are posted.
-            draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos)
+            draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos, scale=scale)
         else:
             # Pitchers of record — anchored to bottom of box, working upward.
             # bottom border is at start_y + vertical_len + 20 = start_y + 130
-            LINE_H = 15
-            BOTTOM_Y = start_y + vertical_len + 20 - 3  # 3px margin above bottom border
+            LINE_H = 15 * s
+            BOTTOM_Y = start_y + vertical_len + 20 * s - 3 * s  # 3px margin above bottom border
             saver = game_data.get('saver_name')
             winner_record = game_data.get('winner_record')
             loser_record = game_data.get('loser_record')
@@ -529,47 +531,47 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             for i, (txt, fnt, bold) in enumerate(reversed(lines)):
                 y = BOTTOM_Y - LINE_H * (i + 1)
                 t = _truncate_keep_suffix(txt)
-                draw.text((start_x + 2, y), t, font=fnt, fill=0)
+                draw.text((start_x + 2 * s, y), t, font=fnt, fill=0)
                 if bold:
-                    draw.text((start_x + 3, y), t, font=fnt, fill=0)
+                    draw.text((start_x + 3 * s, y), t, font=fnt, fill=0)
 
     elif game_data['detailed_state'] == 'Warmup' or game_data['detailed_state'] == 'Pre-Game' or  game_data['detailed_state'] == 'Scheduled':
         def _draw_pitcher_era(name_part, stat_part, y_pos):
             """Draw pitcher name left-aligned and stat right-anchored."""
             if stat_part:
                 stat_w = int(font14.getlength(stat_part))
-                stat_x = start_x + horizonta_len - stat_w - 1
+                stat_x = start_x + horizonta_len - stat_w - 1 * s
                 draw.text((stat_x, y_pos), stat_part, font=font14, fill=0)
-                max_name_w = stat_x - (start_x + 2) - 2
-                name_str, name_fnt = fit_text(name_part, max(max_name_w, 20))
-                draw.text((start_x + 2, y_pos), name_str, font=name_fnt, fill=0)
+                max_name_w = stat_x - (start_x + 2 * s) - 2 * s
+                name_str, name_fnt = fit_text(name_part, max(max_name_w, 20 * s))
+                draw.text((start_x + 2 * s, y_pos), name_str, font=name_fnt, fill=0)
             else:
                 name_str, name_fnt = fit_text(name_part, max_text_width)
-                draw.text((start_x + 2, y_pos), name_str, font=name_fnt, fill=0)
+                draw.text((start_x + 2 * s, y_pos), name_str, font=name_fnt, fill=0)
 
         away_name, away_stat = _pitcher_line(game_data.get("away_probable"), game_data.get("away_probable_note"))
         home_name, home_stat = _pitcher_line(game_data.get("home_probable"), game_data.get("home_probable_note"))
-        _draw_pitcher_era(away_name, away_stat, start_y + 25 + 59)
-        _draw_pitcher_era(home_name, home_stat, start_y + 25 + 74)
+        _draw_pitcher_era(away_name, away_stat, start_y + 25 * s + 59 * s)
+        _draw_pitcher_era(home_name, home_stat, start_y + 25 * s + 74 * s)
     elif game_data['detailed_state'] == 'Postponed':
         reason = game_data.get('postpone_reason') or game_data.get('description') or ''
         postponed_line, postponed_fnt = fit_text(f'PPD: {reason}' if reason else 'Postponed', max_text_width)
-        draw.text((start_x + 7, start_y + 25 + 59), postponed_line, font=postponed_fnt, fill=0)
+        draw.text((start_x + 7 * s, start_y + 25 * s + 59 * s), postponed_line, font=postponed_fnt, fill=0)
         desc = game_data.get('description') or ''
         if desc.lower().startswith('makeup') and game_data.get('postpone_reason'):
             makeup_line, makeup_fnt = fit_text(desc, max_text_width)
-            draw.text((start_x + 7, start_y + 25 + 74), makeup_line, font=makeup_fnt, fill=0)
+            draw.text((start_x + 7 * s, start_y + 25 * s + 74 * s), makeup_line, font=makeup_fnt, fill=0)
     elif _delayed_with_score:
-        draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos)
+        draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos, scale=scale)
         # Next 3 batters + pitcher — same panel used for between-innings
-        _right_x = start_x + horizonta_len - 2
-        _max_name_w = 46
+        _right_x = start_x + horizonta_len - 2 * s
+        _max_name_w = 46 * s
         _batter_names = [
             _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
             _last_name(game_data.get('next_batter_2') or game_data.get('due_up') or ''),
             _last_name(game_data.get('next_batter_3') or game_data.get('in_hole') or ''),
         ]
-        _name_y = start_y + 21
+        _name_y = start_y + 21 * s
         for _nm in _batter_names:
             if _nm:
                 _nm_disp = _nm
@@ -577,11 +579,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                     _nm_disp = _nm_disp[:-1]
                 _nw = int(font14.getlength(_nm_disp))
                 draw.text((_right_x - _nw, _name_y), _nm_disp, font=font14, fill=0)
-            _name_y += 12
-        _sep_y = _name_y + 5
-        draw.line((start_x + 87, _sep_y, _right_x, _sep_y), fill=0)
+            _name_y += 12 * s
+        _sep_y = _name_y + 5 * s
+        draw.line((start_x + 87 * s, _sep_y, _right_x, _sep_y), fill=0)
         _pit_name = _last_name(game_data.get('next_pitcher') or game_data.get('current_pitcher') or '')
-        _pit_max_w = horizonta_len - 2 - 87
+        _pit_max_w = horizonta_len - 2 * s - 87 * s
         if _pit_name:
             _pit_fnt = font14
             if int(font14.getlength(_pit_name)) > _pit_max_w:
@@ -591,10 +593,10 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                     while _pit_name and int(font9.getlength(_pit_name)) > _pit_max_w:
                         _pit_name = _pit_name[:-1]
             _pit_w = int(_pit_fnt.getlength(_pit_name))
-            draw.text((_right_x - _pit_w, _sep_y + 2), _pit_name, font=_pit_fnt, fill=0)
+            draw.text((_right_x - _pit_w, _sep_y + 2 * s), _pit_name, font=_pit_fnt, fill=0)
     elif game_data['detailed_state'] == 'In Progress':
         if _between_innings or _pitching_change:
-            draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos)
+            draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos, scale=scale)
         else:
             # Active play: pitch/pitcher/batter info
             _pc = game_data.get('pitch_count')
@@ -603,7 +605,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
 
             # Pitcher line right badge: pitch type only; count moves into the label
             _right_str = _pt if _pt else ''
-            _right_w = int(font11.getlength(_right_str)) + 2 if _right_str else 0
+            _right_w = int(font11.getlength(_right_str)) + 2 * s if _right_str else 0
 
             _pitcher_name = _format_player_name(game_data.get("current_pitcher") or "")
             _pit_avail = max_text_width - _right_w
@@ -612,47 +614,47 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 pitcher_str, pitcher_font = _pit_str, font14
             else:
                 pitcher_str, pitcher_font = fit_text(_pit_str, _pit_avail)
-            draw.text((start_x + 2, start_y + 25 + 74), pitcher_str, font=pitcher_font, fill=0)
+            draw.text((start_x + 2 * s, start_y + 25 * s + 74 * s), pitcher_str, font=pitcher_font, fill=0)
             if _right_str:
-                draw.text((start_x + horizonta_len - _right_w, start_y + 25 + 74), _right_str, font=font11, fill=0)
+                draw.text((start_x + horizonta_len - _right_w, start_y + 25 * s + 74 * s), _right_str, font=font11, fill=0)
 
             # Speed right-aligned; pitch count left of speed on same row
-            _speed_y = start_y + 25 + 62
+            _speed_y = start_y + 25 * s + 62 * s
             if _lps:
                 _speed_str = str(int(_lps))
-                _speed_w = int(font11.getlength(_speed_str)) + 2
+                _speed_w = int(font11.getlength(_speed_str)) + 2 * s
                 _speed_x = start_x + horizonta_len - _speed_w
-                draw.text((_speed_x,     _speed_y), _speed_str, font=font11, fill=0)
-                draw.text((_speed_x + 1, _speed_y), _speed_str, font=font11, fill=0)
+                draw.text((_speed_x,         _speed_y), _speed_str, font=font11, fill=0)
+                draw.text((_speed_x + 1 * s, _speed_y), _speed_str, font=font11, fill=0)
                 if _pc is not None:
                     _pc_disp = f'{_pc}P'
                     _pc_w = int(font11.getlength(_pc_disp))
-                    draw.text((_speed_x - _pc_w - 3, _speed_y), _pc_disp, font=font11, fill=0)
+                    draw.text((_speed_x - _pc_w - 3 * s, _speed_y), _pc_disp, font=font11, fill=0)
             elif _pc is not None:
                 _pc_disp = f'{_pc}P'
-                _pc_w = int(font11.getlength(_pc_disp)) + 2
+                _pc_w = int(font11.getlength(_pc_disp)) + 2 * s
                 draw.text((start_x + horizonta_len - _pc_w, _speed_y), _pc_disp, font=font11, fill=0)
 
             # Batter record for the night "2-4" right-anchored on hitter line
             _bh = game_data.get('batter_hits')
             _ba = game_data.get('batter_at_bats')
             _ba_str = f'{_bh}-{_ba}' if _bh is not None and _ba is not None else ''
-            _ba_w = min(int(font11.getlength(_ba_str)) + 2, horizonta_len - 8) if _ba_str else 0
+            _ba_w = min(int(font11.getlength(_ba_str)) + 2 * s, horizonta_len - 8 * s) if _ba_str else 0
             _ab_done = game_data.get('current_at_bat_complete', False)
             if _ab_done and not _is_game_effectively_over(game_data):
                 _next_hitter = _format_player_name(game_data.get('due_up') or game_data.get('next_batter_1') or '')
                 if _next_hitter:
                     _next_str, _next_font = fit_text(f'AB: {_next_hitter}', max(1, max_text_width - _ba_w))
-                    draw.text((start_x + 2, start_y + 25 + 89), _next_str, font=_next_font, fill=0)
+                    draw.text((start_x + 2 * s, start_y + 25 * s + 89 * s), _next_str, font=_next_font, fill=0)
             else:
                 _hitter_name = _format_player_name(game_data.get('current_hitter') or '')
                 hitter_str, hitter_font = fit_text(
                     f'AB: {_hitter_name}',
                     max(1, max_text_width - _ba_w),
                 )
-                draw.text((start_x + 2, start_y + 25 + 89), hitter_str, font=hitter_font, fill=0)
+                draw.text((start_x + 2 * s, start_y + 25 * s + 89 * s), hitter_str, font=hitter_font, fill=0)
             if _ba_str:
-                draw.text((start_x + horizonta_len - _ba_w, start_y + 25 + 89), _ba_str, font=font11, fill=0)
+                draw.text((start_x + horizonta_len - _ba_w, start_y + 25 * s + 89 * s), _ba_str, font=font11, fill=0)
 
     if game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied', 'Postponed', 'Delayed'):
         # Normalize display labels
@@ -723,25 +725,25 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         _sw_text = 'SWEEP'
         _sw_w    = int(font18.getlength(_sw_text))
         _sw_x    = (horizonta_len - _sw_w) // 2
-        _sw_y    = (20 - 18) // 2
-        draw.text((start_x + _sw_x,     start_y + _sw_y), _sw_text, font=font18, fill=0)
-        draw.text((start_x + _sw_x + 1, start_y + _sw_y), _sw_text, font=font18, fill=0)
+        _sw_y    = (20 * s - 18 * s) // 2
+        draw.text((start_x + _sw_x,         start_y + _sw_y), _sw_text, font=font18, fill=0)
+        draw.text((start_x + _sw_x + 1 * s, start_y + _sw_y), _sw_text, font=font18, fill=0)
 
     # game state — bold via double draw; for pre-game times render AM/PM smaller + bold
     if game_data['detailed_state'] in ('Scheduled', 'Pre-Game', 'Warmup') and ' ' in game_state_str:
         _time_parts = game_state_str.rsplit(' ', 1)
         _time_main, _time_ampm = _time_parts[0], _time_parts[1].lower()
-        for _dx in (2, 3):
-            draw.text((start_x + _dx, start_y + 3), _time_main, font=font14, fill=0)
+        for _dx in (2 * s, 3 * s):
+            draw.text((start_x + _dx, start_y + 3 * s), _time_main, font=font14, fill=0)
         _main_w = int(font14.getlength(_time_main))
-        _ampm_x = start_x + 3 + _main_w + 1
-        _ampm_y = start_y + 8
-        draw.text((_ampm_x, _ampm_y), _time_ampm, font=font9, fill=0)
-        draw.text((_ampm_x + 1, _ampm_y), _time_ampm, font=font9, fill=0)
-        _total_time_w = _main_w + int(font9.getlength(_time_ampm)) + 2
+        _ampm_x = start_x + 3 * s + _main_w + 1 * s
+        _ampm_y = start_y + 8 * s
+        draw.text((_ampm_x,         _ampm_y), _time_ampm, font=font9, fill=0)
+        draw.text((_ampm_x + 1 * s, _ampm_y), _time_ampm, font=font9, fill=0)
+        _total_time_w = _main_w + int(font9.getlength(_time_ampm)) + 2 * s
     else:
-        draw.text((start_x + 2, start_y + 3), game_state_str, font=font14, fill=0)
-        draw.text((start_x + 3, start_y + 3), game_state_str, font=font14, fill=0)
+        draw.text((start_x + 2 * s, start_y + 3 * s), game_state_str, font=font14, fill=0)
+        draw.text((start_x + 3 * s, start_y + 3 * s), game_state_str, font=font14, fill=0)
         _total_time_w = int(font14.getlength(game_state_str))
 
     # Series display — only shown when the game is Final/over, not pre-game or live
@@ -798,7 +800,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     )
 
     # _ser_content_left_x tracks left edge of series/broom content for G:X:XX positioning
-    _ser_content_left_x = start_x + horizonta_len - 2
+    _ser_content_left_x = start_x + horizonta_len - 2 * s
 
     if _is_sweep or _series_clinched:
         # Series win: draw winner logo + series score (e.g. 3-1)
@@ -806,7 +808,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         _sl = game_data.get('series_losses') or 0
         _score_str = f'{_sw}-{_sl}'
         _score_w = int(font14.getlength(_score_str))
-        _ser_logo_size = 14
+        _ser_logo_size = 14 * s
         # Determine series winner from series_result (e.g. "NYY wins 2-1")
         _ser_winner_abbr = _ser_winner_id = None
         _ser_result_sw = game_data.get('series_result', '')
@@ -823,35 +825,35 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             elif game_data.get('home_team_is_winner'):
                 _ser_winner_abbr, _ser_winner_id = home_team_name, str(game_data['home_team_id'])
         _ser_logo = _logo_small(_ser_winner_abbr, _ser_winner_id, size=_ser_logo_size) if _ser_winner_abbr else None
-        _rx = start_x + horizonta_len - 2
+        _rx = start_x + horizonta_len - 2 * s
         if _ser_logo:
             _logo_w, _logo_h = _ser_logo.size
             _score_x = _rx - _score_w
-            _logo_x = _score_x - 2 - _logo_w
-            _logo_y = start_y + (20 - _logo_h) // 2
+            _logo_x = _score_x - 2 * s - _logo_w
+            _logo_y = start_y + (20 * s - _logo_h) // 2
             Himage.paste(_ser_logo, (_logo_x, _logo_y))
             draw = ImageDraw.Draw(Himage)
             _ser_content_left_x = _logo_x
         else:
             _score_x = _rx - _score_w
             _ser_content_left_x = _score_x
-        draw.text((_score_x,     start_y + 3), _score_str, font=font14, fill=0)
-        draw.text((_score_x + 1, start_y + 3), _score_str, font=font14, fill=0)
+        draw.text((_score_x,         start_y + 3 * s), _score_str, font=font14, fill=0)
+        draw.text((_score_x + 1 * s, start_y + 3 * s), _score_str, font=font14, fill=0)
         if _show_overline:
-            draw.line((_score_x, start_y + 3, _score_x + _score_w, start_y + 3), fill=0, width=2)
+            draw.line((_score_x, start_y + 3 * s, _score_x + _score_w, start_y + 3 * s), fill=0, width=2)
 
     elif _series_tied:
         _sw = game_data.get('series_wins') or 0
         _sl = game_data.get('series_losses') or 0
         _tied_str = f'{_sw}-{_sl}'
         _tied_w = int(font14.getlength(_tied_str))
-        _rx = start_x + horizonta_len - 2
+        _rx = start_x + horizonta_len - 2 * s
         _tx = _rx - _tied_w
         _ser_content_left_x = _tx
-        draw.text((_tx,     start_y + 3), _tied_str, font=font14, fill=0)
-        draw.text((_tx + 1, start_y + 3), _tied_str, font=font14, fill=0)
+        draw.text((_tx,         start_y + 3 * s), _tied_str, font=font14, fill=0)
+        draw.text((_tx + 1 * s, start_y + 3 * s), _tied_str, font=font14, fill=0)
         if _show_overline:
-            draw.line((_tx, start_y + 3, _tx + _tied_w, start_y + 3), fill=0, width=2)
+            draw.line((_tx, start_y + 3 * s, _tx + _tied_w, start_y + 3 * s), fill=0, width=2)
 
     elif _series_leading:
         # Series leader: draw leading team's logo + score (e.g. [NYY logo] 1-0)
@@ -859,7 +861,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         _sl = game_data.get('series_losses') or 0
         _score_str = f'{_sw}-{_sl}'
         _score_w = int(font14.getlength(_score_str))
-        _ser_logo_size = 14
+        _ser_logo_size = 14 * s
         _ser_leader_abbr = _ser_leader_id = None
         _ser_result = game_data.get('series_result', '')
         _ser_result_parts = _ser_result.split()
@@ -875,21 +877,21 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             elif game_data.get('home_team_is_winner'):
                 _ser_leader_abbr, _ser_leader_id = home_team_name, str(game_data['home_team_id'])
         _ser_logo = _logo_small(_ser_leader_abbr, _ser_leader_id, size=_ser_logo_size) if _ser_leader_abbr else None
-        _rx = start_x + horizonta_len - 2
+        _rx = start_x + horizonta_len - 2 * s
         if _ser_logo:
             _logo_w, _logo_h = _ser_logo.size
             _score_x = _rx - _score_w
-            _logo_x = _score_x - 2 - _logo_w
-            _logo_y = start_y + (20 - _logo_h) // 2
+            _logo_x = _score_x - 2 * s - _logo_w
+            _logo_y = start_y + (20 * s - _logo_h) // 2
             Himage.paste(_ser_logo, (_logo_x, _logo_y))
             draw = ImageDraw.Draw(Himage)
             _ser_content_left_x = _logo_x
         else:
             _score_x = _rx - _score_w
             _ser_content_left_x = _score_x
-        draw.text((_score_x, start_y + 3), _score_str, font=font14, fill=0)
+        draw.text((_score_x, start_y + 3 * s), _score_str, font=font14, fill=0)
         if _show_overline:
-            draw.line((_score_x, start_y + 3, _score_x + _score_w, start_y + 3), fill=0, width=2)
+            draw.line((_score_x, start_y + 3 * s, _score_x + _score_w, start_y + 3 * s), fill=0, width=2)
 
     # Series context in header for postponed games
     if game_data['detailed_state'] == 'Postponed' and (game_data.get('series_total_games') or 1) > 1:
@@ -899,14 +901,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         _ppd_sw = game_data.get('series_wins') or 0
         _ppd_sl = game_data.get('series_losses') or 0
         _ppd_total = game_data.get('series_total_games') or 1
-        _rx = start_x + horizonta_len - 2
+        _rx = start_x + horizonta_len - 2 * s
 
         if (_ppd_sw + _ppd_sl) == 0:
             # Series hasn't started — show "0/X"
             _ppd_score = f'0/{_ppd_total}'
             _ppd_score_w = int(font11.getlength(_ppd_score))
             _ppd_score_x = _rx - _ppd_score_w
-            draw.text((_ppd_score_x, start_y + 5), _ppd_score, font=font11, fill=0)
+            draw.text((_ppd_score_x, start_y + 5 * s), _ppd_score, font=font11, fill=0)
             _ser_content_left_x = _ppd_score_x
         elif not _ppd_is_tied and len(_ppd_parts) >= 3 and _ppd_parts[1] == 'leads':
             _ppd_score = _ppd_parts[2]
@@ -918,14 +920,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 _ppd_logo_abbr, _ppd_logo_id = home_team_name, str(game_data['home_team_id'])
             _ppd_score_w = int(font11.getlength(_ppd_score))
             _ppd_score_x = _rx - _ppd_score_w
-            draw.text((_ppd_score_x, start_y + 5), _ppd_score, font=font11, fill=0)
+            draw.text((_ppd_score_x, start_y + 5 * s), _ppd_score, font=font11, fill=0)
             _ser_content_left_x = _ppd_score_x
             if _ppd_logo_abbr:
-                _ppd_logo = _logo_small(_ppd_logo_abbr, _ppd_logo_id, size=14)
+                _ppd_logo = _logo_small(_ppd_logo_abbr, _ppd_logo_id, size=14 * s)
                 if _ppd_logo:
                     _lw, _lh = _ppd_logo.size
-                    _ppd_logo_x = _ppd_score_x - 2 - _lw
-                    _ppd_logo_y = start_y + (20 - _lh) // 2
+                    _ppd_logo_x = _ppd_score_x - 2 * s - _lw
+                    _ppd_logo_y = start_y + (20 * s - _lh) // 2
                     Himage.paste(_ppd_logo, (_ppd_logo_x, _ppd_logo_y))
                     draw = ImageDraw.Draw(Himage)
                     _ser_content_left_x = _ppd_logo_x
@@ -935,16 +937,16 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         venue_clean = _clean_venue_name(game_data.get('venue'))
         if venue_clean:
             try:
-                _venue_right = _ser_content_left_x - 2
-                max_venue_w = max(_venue_right - start_x - _total_time_w - 6, 0)
+                _venue_right = _ser_content_left_x - 2 * s
+                max_venue_w = max(_venue_right - start_x - _total_time_w - 6 * s, 0)
                 if max_venue_w > 0:
-                    for vfont, vy in ((_get_font(16), 2), (font14, 3), (font11, 4), (font9, 5), (_get_font(8), 6)):
+                    for vfont, vy in ((_get_font(16 * s), 2 * s), (font14, 3 * s), (font11, 4 * s), (font9, 5 * s), (_get_font(8 * s), 6 * s)):
                         if vfont.getlength(venue_clean) <= max_venue_w:
                             break
                     vw = int(vfont.getlength(venue_clean))
                     vx = _venue_right - vw
-                    draw.text((vx,     start_y + vy), venue_clean, font=vfont, fill=0)
-                    draw.text((vx + 1, start_y + vy), venue_clean, font=vfont, fill=0)  # bold
+                    draw.text((vx,         start_y + vy), venue_clean, font=vfont, fill=0)
+                    draw.text((vx + 1 * s, start_y + vy), venue_clean, font=vfont, fill=0)  # bold
             except AttributeError:
                 pass
     if game_data['detailed_state'] == 'In Progress' and not _is_game_effectively_over(game_data):
@@ -964,29 +966,29 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         raw_play = (_sub_ev or game_data.get('last_review_result') or _last_play_val or '').replace('**', '').strip()
         # Abbreviate verbose play names so they fit cleanly without truncation
         play_display = _abbr_play(raw_play) if raw_play else ''
-        _header_right = _ser_content_left_x - 2
+        _header_right = _ser_content_left_x - 2 * s
 
         def _draw_play_right(text, fnt=None, y_off=4):
             if not text:
                 return
-            _fnt = fnt or _get_font(12)
-            _max_w = max(_header_right - start_x - _total_time_w - 10, 0)
+            _fnt = fnt or _get_font(12 * s)
+            _max_w = max(_header_right - start_x - _total_time_w - 10 * s, 0)
             _t = text
             while len(_t) > 1 and int(_fnt.getlength(_t)) > _max_w:
                 _t = _t[:-2] + '.'
             if _t and int(_fnt.getlength(_t)) <= _max_w:
                 _pw = int(_fnt.getlength(_t))
                 _px = _header_right - _pw
-                draw.text((_px,     start_y + y_off), _t, font=_fnt, fill=0)
-                draw.text((_px + 1, start_y + y_off), _t, font=_fnt, fill=0)
+                draw.text((_px,         start_y + y_off * s), _t, font=_fnt, fill=0)
+                draw.text((_px + 1 * s, start_y + y_off * s), _t, font=_fnt, fill=0)
 
         if _active_no_no:
             # Right-align label; inning state stays on left as-is
             _nh_label = 'Perfect Game' if game_data.get('perfect_game') else 'No-Hitter'
             _nh_lw = int(font14.getlength(_nh_label))
             _nh_lx = _header_right - _nh_lw
-            draw.text((_nh_lx,     start_y + 3), _nh_label, font=font14, fill=0)
-            draw.text((_nh_lx + 1, start_y + 3), _nh_label, font=font14, fill=0)
+            draw.text((_nh_lx,         start_y + 3 * s), _nh_label, font=font14, fill=0)
+            draw.text((_nh_lx + 1 * s, start_y + 3 * s), _nh_label, font=font14, fill=0)
         elif _between_innings and play_display:
             # Mid-inning break: show abbreviated play that ended the half-inning
             _draw_play_right(play_display)
@@ -996,14 +998,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             if _due_name:
                 _due_str = f'Due: {_due_name}'
                 _due_fnt = font11
-                _max_due_w = max(_header_right - start_x - _total_time_w - 6, 0)
+                _max_due_w = max(_header_right - start_x - _total_time_w - 6 * s, 0)
                 while _due_str and int(_due_fnt.getlength(_due_str)) > _max_due_w:
                     _due_str = _due_str[:-1]
                 if _due_str:
                     _due_w = int(_due_fnt.getlength(_due_str))
                     _due_x = _header_right - _due_w
-                    draw.text((_due_x,     start_y + 5), _due_str, font=_due_fnt, fill=0)
-                    draw.text((_due_x + 1, start_y + 5), _due_str, font=_due_fnt, fill=0)
+                    draw.text((_due_x,         start_y + 5 * s), _due_str, font=_due_fnt, fill=0)
+                    draw.text((_due_x + 1 * s, start_y + 5 * s), _due_str, font=_due_fnt, fill=0)
         elif play_display:
             _draw_play_right(play_display)
 
@@ -1011,15 +1013,15 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         _delay_reason = game_data.get('postpone_reason') or ''
         if _delay_reason:
             _delay_str = f'R: {_delay_reason}'
-            _max_delay_w = max(horizonta_len - _total_time_w - 10, 0)
-            _delay_fnt = _get_font(12)
+            _max_delay_w = max(horizonta_len - _total_time_w - 10 * s, 0)
+            _delay_fnt = _get_font(12 * s)
             while len(_delay_str) > 1 and int(_delay_fnt.getlength(_delay_str)) > _max_delay_w:
                 _delay_str = _delay_str[:-2] + '.'
             if _delay_str and int(_delay_fnt.getlength(_delay_str)) <= _max_delay_w:
                 _dw = int(_delay_fnt.getlength(_delay_str))
-                _dx_pos = start_x + horizonta_len - _dw - 2
-                draw.text((_dx_pos, start_y + 4), _delay_str, font=_delay_fnt, fill=0)
-                draw.text((_dx_pos + 1, start_y + 4), _delay_str, font=_delay_fnt, fill=0)
+                _dx_pos = start_x + horizonta_len - _dw - 2 * s
+                draw.text((_dx_pos,         start_y + 4 * s), _delay_str, font=_delay_fnt, fill=0)
+                draw.text((_dx_pos + 1 * s, start_y + 4 * s), _delay_str, font=_delay_fnt, fill=0)
 
     # Initialize score variables (will be used later for winner display)
     away_runs = str(game_data.get('away_runs', 0) if game_data.get('away_runs', 0) is not None else 0)
@@ -1030,19 +1032,19 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
 
     # Display score if game has started
     if is_game_started:
-        draw.text((start_x + 66 + check_if_two_chars(away_runs), start_y + 25), away_runs, font=font24, fill=0)
-        draw.text((start_x + 66 + check_if_two_chars(home_runs), start_y + 55), home_runs, font=font24, fill=0)
+        draw.text((start_x + 66 * s + check_if_two_chars(away_runs), start_y + 25 * s), away_runs, font=font24, fill=0)
+        draw.text((start_x + 66 * s + check_if_two_chars(home_runs), start_y + 55 * s), home_runs, font=font24, fill=0)
 
         if is_game_finished:
             # hits
             away_hits = str(game_data.get('away_hits', 0) if game_data.get('away_hits', 0) is not None else 0)
             home_hits = str(game_data.get('home_hits', 0) if game_data.get('home_hits', 0) is not None else 0)
-            draw.text((start_x + 95 + check_if_two_chars(away_hits), start_y + 25),  away_hits, font=font24, fill=0)
-            draw.text((start_x + 95 + check_if_two_chars(home_hits), start_y + 55), home_hits , font=font24, fill=0)
+            draw.text((start_x + 95 * s + check_if_two_chars(away_hits), start_y + 25 * s),  away_hits, font=font24, fill=0)
+            draw.text((start_x + 95 * s + check_if_two_chars(home_hits), start_y + 55 * s), home_hits , font=font24, fill=0)
 
             # errors
-            draw.text((start_x + 123, start_y + 25),  str(game_data.get('away_errors', 0) if game_data.get('away_errors', 0) is not None else 0), font=font24, fill=0)
-            draw.text((start_x + 123 , start_y + 55),  str( game_data.get('home_errors', 0) if game_data.get('home_errors', 0) is not None else 0), font=font24, fill=0)
+            draw.text((start_x + 123 * s, start_y + 25 * s),  str(game_data.get('away_errors', 0) if game_data.get('away_errors', 0) is not None else 0), font=font24, fill=0)
+            draw.text((start_x + 123 * s, start_y + 55 * s),  str( game_data.get('home_errors', 0) if game_data.get('home_errors', 0) is not None else 0), font=font24, fill=0)
 
     elif game_data['detailed_state'] in ['Scheduled', 'Pre-Game', 'Warmup', 'Postponed']:
         # Game hasn't started — show record stacked above L10/streak, both right-anchored
@@ -1055,48 +1057,48 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             # Primary: W-L in font14, bold via double-draw, aligned to top of logo row
             main_txt = f'{wins}-{losses}'
             main_w = int(font14.getlength(main_txt))
-            rx = start_x + horizonta_len - main_w - 1
-            draw.text((rx,     y_pos), main_txt, font=font14, fill=0)
-            draw.text((rx + 1, y_pos), main_txt, font=font14, fill=0)
+            rx = start_x + horizonta_len - main_w - 1 * s
+            draw.text((rx,         y_pos), main_txt, font=font14, fill=0)
+            draw.text((rx + 1 * s, y_pos), main_txt, font=font14, fill=0)
 
             # Secondary: L10 and streak on the line below in font9
             stats = _team_stats(team_id)
             w10, l10 = stats.get('l10_wins'), stats.get('l10_losses')
-            s = stats.get('streak') or ''
+            streak_val = stats.get('streak') or ''
             parts = []
             if w10 is not None and l10 is not None:
                 parts.append(f'{w10}-{l10}')
-            if s:
-                parts.append(s)
+            if streak_val:
+                parts.append(streak_val)
             if parts:
                 sub_txt = ' '.join(parts)
                 sub_w = int(font11.getlength(sub_txt))
-                sx = start_x + horizonta_len - sub_w - 1
-                draw.text((sx, y_pos + 15), sub_txt, font=font11, fill=0)
+                sx = start_x + horizonta_len - sub_w - 1 * s
+                draw.text((sx, y_pos + 15 * s), sub_txt, font=font11, fill=0)
 
         _away_wins  = game_data.get("away_team_record_wins", "0")
         _away_losses = game_data.get("away_team_record_losses", "0")
         _home_wins  = game_data.get("home_team_record_wins", "0")
         _home_losses = game_data.get("home_team_record_losses", "0")
 
-        _draw_record(_away_wins, _away_losses, game_data.get("away_team_id"), start_y + 25)
-        _draw_record(_home_wins, _home_losses, game_data.get("home_team_id"), start_y + 55)
+        _draw_record(_away_wins, _away_losses, game_data.get("away_team_id"), start_y + 25 * s)
+        _draw_record(_home_wins, _home_losses, game_data.get("home_team_id"), start_y + 55 * s)
 
         # Betting moneylines — right-aligned just left of each team's record (not on postponed)
         _away_ml = game_data.get('away_ml')
         _home_ml = game_data.get('home_ml')
         if _away_ml is not None and _home_ml is not None and game_data['detailed_state'] != 'Postponed':
-            _away_rec_left = start_x + horizonta_len - int(font14.getlength(f'{_away_wins}-{_away_losses}')) - 5
-            _home_rec_left = start_x + horizonta_len - int(font14.getlength(f'{_home_wins}-{_home_losses}')) - 5
-            _odds_right = min(_away_rec_left, _home_rec_left) - 4
+            _away_rec_left = start_x + horizonta_len - int(font14.getlength(f'{_away_wins}-{_away_losses}')) - 5 * s
+            _home_rec_left = start_x + horizonta_len - int(font14.getlength(f'{_home_wins}-{_home_losses}')) - 5 * s
+            _odds_right = min(_away_rec_left, _home_rec_left) - 4 * s
 
             def _ml_str(v):
                 return f'+{v}' if v > 0 else str(v)
 
             _aml_s = _ml_str(_away_ml)
             _hml_s = _ml_str(_home_ml)
-            _away_odds_y = start_y + (32 if use_logos else 25)
-            _home_odds_y = start_y + (62 if use_logos else 55)
+            _away_odds_y = start_y + (32 * s if use_logos else 25 * s)
+            _home_odds_y = start_y + (62 * s if use_logos else 55 * s)
             draw.text((_odds_right - int(font11.getlength(_aml_s)), _away_odds_y), _aml_s, font=font11, fill=0)
             draw.text((_odds_right - int(font11.getlength(_hml_s)), _home_odds_y), _hml_s, font=font11, fill=0)
 
@@ -1110,14 +1112,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _dur_str = f'{_dur_mins // 60}:{_dur_mins % 60:02d}'
             if _is_sweep:
                 _dur_font = font9
-                _dur_x = start_x + logo_x_offset + 28 + 2 + 3 if use_logos else start_x + 8
-                _dur_y = start_y + 50
+                _dur_x = start_x + logo_x_offset + 28 * s + 2 * s + 3 * s if use_logos else start_x + 8 * s
+                _dur_y = start_y + 50 * s
             else:
                 _dur_font = font14
                 _dur_x = start_x + horizonta_len // 2 - int(_dur_font.getlength(_dur_str)) // 2
-                _dur_y = start_y + 3
-            draw.text((_dur_x,     _dur_y), _dur_str, font=_dur_font, fill=0)
-            draw.text((_dur_x + 1, _dur_y), _dur_str, font=_dur_font, fill=0)
+                _dur_y = start_y + 3 * s
+            draw.text((_dur_x,         _dur_y), _dur_str, font=_dur_font, fill=0)
+            draw.text((_dur_x + 1 * s, _dur_y), _dur_str, font=_dur_font, fill=0)
 
     # End time — right-aligned in the win-probability strip below the box.
     # Default: shown only while the linescore window is active (disappears with the linescore).
@@ -1130,15 +1132,28 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _end_utc_parsed = pytz.utc.localize(_datetime.strptime(_end_utc_str[:19], "%Y-%m-%dT%H:%M:%S"))
             _end_local = _end_utc_parsed.astimezone(pytz.timezone(_tz_str))
             _end_str = _end_local.strftime("%I:%M").lstrip("0") + " " + _end_local.strftime("%p").lower()
-            _et_strip_y = start_y + vertical_len + 21  # same y as win-prob bar
-            _et_strip_h = 19
+            _et_strip_y = start_y + vertical_len + 21 * s  # same y as win-prob bar
+            _et_strip_h = 19 * s
             _et_w = int(font14.getlength(_end_str))
-            _et_x = start_x + horizonta_len - _et_w - 1
-            _et_y = _et_strip_y + (_et_strip_h - 14) // 2
-            draw.text((_et_x,     _et_y), _end_str, font=font14, fill=0)
-            draw.text((_et_x + 1, _et_y), _end_str, font=font14, fill=0)
+            _et_x = start_x + horizonta_len - _et_w - 1 * s
+            _et_y = _et_strip_y + (_et_strip_h - 14 * s) // 2
+            draw.text((_et_x,         _et_y), _end_str, font=font14, fill=0)
+            draw.text((_et_x + 1 * s, _et_y), _end_str, font=font14, fill=0)
         except Exception:
             pass
+
+    # Doubleheader game number — left-anchored in the win-prob strip for non-live states
+    _dh = game_data.get('double_header', 'N')
+    _gnum = game_data.get('game_number')
+    _dh_state = game_data['detailed_state'] in (
+        'Scheduled', 'Pre-Game', 'Warmup', 'Final', 'Game Over', 'Final: Tied')
+    if _dh in ('Y', 'S') and _gnum and _dh_state:
+        _gn_str = f'Game {_gnum}'
+        _gn_strip_y = start_y + vertical_len + 21 * s
+        _gn_strip_h = 19 * s
+        _gn_y = _gn_strip_y + (_gn_strip_h - 14 * s) // 2
+        draw.text((start_x + 2 * s, _gn_y), _gn_str, font=font14, fill=0)
+        draw.text((start_x + 3 * s, _gn_y), _gn_str, font=font14, fill=0)
 
     # ABS challenges remaining — small stacked dots to the left of each team's logo
     if game_data['detailed_state'] == 'In Progress':
@@ -1148,7 +1163,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     end_x = start_x + horizonta_len
     end_y = start_y
     draw.line((start_x, start_y, end_x, end_y), fill = 0)
-    draw.line((start_x, start_y + 20, end_x, end_y  + 20), fill = 0)
+    draw.line((start_x, start_y + 20 * s, end_x, end_y + 20 * s), fill = 0)
 
     # Win probability bar — live games only, when show_win_prob enabled
     # Win prob bar — all In Progress states including between-inning breaks
@@ -1165,18 +1180,18 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             except (ValueError, TypeError):
                 away_wp, home_wp = 50.0, 50.0
 
-            LOGO_SZ = 18
-            BAR_Y = start_y + vertical_len + 21  # 1px below bottom border, in the inter-row gap
-            BAR_H = 19                            # available inter-row height
-            BAR_X = start_x + 1
-            BAR_W = horizonta_len - 2
+            LOGO_SZ = 18 * s
+            BAR_Y = start_y + vertical_len + 21 * s  # 1px below bottom border, in the inter-row gap
+            BAR_H = 19 * s                            # available inter-row height
+            BAR_X = start_x + 1 * s
+            BAR_W = horizonta_len - 2 * s
 
             # Ghost "LOSS" / "WIN" watermarks, then a solid horizontal center line
             _ghost_strip = Image.new('L', (BAR_W, BAR_H), 255)
             _ghost_draw = ImageDraw.Draw(_ghost_strip)
-            _ghost_draw.text((1, (BAR_H - 18) // 2), 'LOSS', font=font18, fill=0)
+            _ghost_draw.text((1 * s, (BAR_H - 18 * s) // 2), 'LOSS', font=font18, fill=0)
             _win_w = int(font18.getlength('WIN'))
-            _ghost_draw.text((BAR_W - _win_w - 1, (BAR_H - 18) // 2), 'WIN', font=font18, fill=0)
+            _ghost_draw.text((BAR_W - _win_w - 1 * s, (BAR_H - 18 * s) // 2), 'WIN', font=font18, fill=0)
             _ghost_strip = _ghost_strip.point(lambda p: 255 if p > 180 else min(255, int(p * 0.35 + 155)))
             # Solid center line drawn after ghost transform so it stays black
             _ghost_draw.line((0, BAR_H // 2, BAR_W, BAR_H // 2), fill=0)
@@ -1192,7 +1207,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             home_logo_x = max(BAR_X, min(BAR_X + BAR_W - LOGO_SZ, home_px - LOGO_SZ // 2))
 
             # Prevent logos from overlapping each other
-            MIN_SEP = LOGO_SZ + 1
+            MIN_SEP = LOGO_SZ + 1 * s
             if away_logo_x > home_logo_x:
                 if away_logo_x - home_logo_x < MIN_SEP:
                     mid = (away_logo_x + home_logo_x) // 2
@@ -1219,17 +1234,17 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 draw.line((home_px, BAR_Y, home_px, BAR_Y + BAR_H), fill=0)
 
     end_x = start_x + horizonta_len
-    end_y = start_y + vertical_len + 20
-    draw.line((start_x, start_y + vertical_len + 20, end_x, end_y), fill=0)
+    end_y = start_y + vertical_len + 20 * s
+    draw.line((start_x, start_y + vertical_len + 20 * s, end_x, end_y), fill=0)
 
 
     # vertical line
     end_x = start_x
-    end_y = start_y + vertical_len
+    end_y = start_y + vertical_len  # noqa: F841
     # draw.line((start_x, start_y, end_x, end_y), fill = 0)
 
     end_x = start_x + horizonta_len
-    end_y = start_y + vertical_len
+    end_y = start_y + vertical_len  # noqa: F841
     # draw.line((start_x + horizonta_len , start_y, end_x, end_y), fill = 0)
 
 
@@ -1250,8 +1265,8 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             # Between-innings OR mid-inning pitching change: show upcoming batters on right side.
             # For between-innings the batter list is next_batter_1/2/3 (next half-inning).
             # For mid-inning PC the current hitter is at the plate — show them first, then due up.
-            _right_x = start_x + horizonta_len - 2
-            _left_x = start_x + 88
+            _right_x = start_x + horizonta_len - 2 * s
+            _left_x = start_x + 88 * s
             _max_name_w = _right_x - _left_x
             if _pitching_change and not _between_innings:
                 # Mid-inning: bottom = current hitter at plate, middle = on deck, top = in the hole
@@ -1271,27 +1286,27 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                     _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
                 ]
                 _pit_name = _last_name(game_data.get('next_pitcher') or game_data.get('current_pitcher') or '')
-            _name_y = start_y + 21
+            _name_y = start_y + 21 * s
             for _nm in _batter_names:
                 if _nm:
                     _nm_disp = _nm
                     while _nm_disp and int(font14.getlength(_nm_disp)) > _max_name_w:
                         _nm_disp = _nm_disp[:-1]
                     draw.text((_left_x, _name_y), _nm_disp, font=font14, fill=0)
-                _name_y += 12
+                _name_y += 12 * s
             if _pitching_change and not _between_innings and (game_data.get('num_of_outs') or 0) < 3:
                 # Mid-inning PC: no pitcher name (outs circles occupy that space).
                 # Outs circles at y=73 — above the linescore grid (y=83+), no overlap.
                 _outs_val = game_data.get('num_of_outs') or 0
                 _outs_list = [i + 1 <= _outs_val for i in range(3)]
-                Himage = draw_circle(Himage, (start_x + 97,  start_y + 73), 6, _outs_list[0], outline_width=2)
-                Himage = draw_circle(Himage, (start_x + 111, start_y + 73), 6, _outs_list[1], outline_width=2)
-                Himage = draw_circle(Himage, (start_x + 125, start_y + 73), 6, _outs_list[2], outline_width=2)
+                Himage = draw_circle(Himage, (start_x + 97 * s,  start_y + 73 * s), 6 * s, _outs_list[0], outline_width=2)
+                Himage = draw_circle(Himage, (start_x + 111 * s, start_y + 73 * s), 6 * s, _outs_list[1], outline_width=2)
+                Himage = draw_circle(Himage, (start_x + 125 * s, start_y + 73 * s), 6 * s, _outs_list[2], outline_width=2)
                 draw = ImageDraw.Draw(Himage)
             else:
                 # Between-innings PC (or normal between-innings): separator + pitcher name.
-                _sep_y = _name_y + 5
-                draw.line((start_x + 87, _sep_y, _right_x, _sep_y), fill=0)
+                _sep_y = _name_y + 5 * s
+                draw.line((start_x + 87 * s, _sep_y, _right_x, _sep_y), fill=0)
                 _pit_max_w = _max_name_w
                 if _pit_name:
                     _pit_fnt = font14
@@ -1301,132 +1316,132 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                             _pit_fnt = font9
                             while _pit_name and int(font9.getlength(_pit_name)) > _pit_max_w:
                                 _pit_name = _pit_name[:-1]
-                    draw.text((_left_x, _sep_y + 2), _pit_name, font=_pit_fnt, fill=0)
+                    draw.text((_left_x, _sep_y + 2 * s), _pit_name, font=_pit_fnt, fill=0)
         else:
             _hi_third = isinstance(game_data['runner_on_third'], str)
             _hi_second = isinstance(game_data['runner_on_second'], str)
             _hi_first = isinstance(game_data['runner_on_first'], str)
 
-            Himage = draw_diamond(Himage, (start_x + 97,  start_y + 52), 10, _hi_third)
-            Himage = draw_diamond(Himage, (start_x + 109, start_y + 40), 10, _hi_second)
-            Himage = draw_diamond(Himage, (start_x + 121, start_y + 52), 10, _hi_first)
+            Himage = draw_diamond(Himage, (start_x + 97 * s,  start_y + 52 * s), 10 * s, _hi_third)
+            Himage = draw_diamond(Himage, (start_x + 109 * s, start_y + 40 * s), 10 * s, _hi_second)
+            Himage = draw_diamond(Himage, (start_x + 121 * s, start_y + 52 * s), 10 * s, _hi_first)
             draw = ImageDraw.Draw(Himage)
             for _bfill, _bcx, _bcy, _bkey in (
-                (_hi_third,  start_x + 97,  start_y + 52, 'runner_third_number'),
-                (_hi_second, start_x + 109, start_y + 40, 'runner_second_number'),
-                (_hi_first,  start_x + 121, start_y + 52, 'runner_first_number'),
+                (_hi_third,  start_x + 97 * s,  start_y + 52 * s, 'runner_third_number'),
+                (_hi_second, start_x + 109 * s, start_y + 40 * s, 'runner_second_number'),
+                (_hi_first,  start_x + 121 * s, start_y + 52 * s, 'runner_first_number'),
             ):
                 if _bfill:
                     _raw = game_data.get(_bkey)
                     _bnum = str(_raw) if _raw is not None else ''
                     _bnw = int(font9.getlength(_bnum)) if _bnum else 0
-                    draw.text((_bcx - _bnw // 2, _bcy - 5), _bnum, font=font9, fill=255)
+                    draw.text((_bcx - _bnw // 2, _bcy - 5 * s), _bnum, font=font9, fill=255)
 
             outs_list = [None] * 3
             for i in range(1, 4):
                 outs_list[i-1] = i <= game_data['num_of_outs']
-            Himage = draw_circle(Himage, (start_x + 97,  start_y + 73), 6, outs_list[0], outline_width=2)
-            Himage = draw_circle(Himage, (start_x + 111, start_y + 73), 6, outs_list[1], outline_width=2)
-            Himage = draw_circle(Himage, (start_x + 125, start_y + 73), 6, outs_list[2], outline_width=2)
+            Himage = draw_circle(Himage, (start_x + 97 * s,  start_y + 73 * s), 6 * s, outs_list[0], outline_width=2)
+            Himage = draw_circle(Himage, (start_x + 111 * s, start_y + 73 * s), 6 * s, outs_list[1], outline_width=2)
+            Himage = draw_circle(Himage, (start_x + 125 * s, start_y + 73 * s), 6 * s, outs_list[2], outline_width=2)
 
             balls_list = [None] * 4
             for i in range(1, 4):
                 balls_list[i-1] = i <= game_data['balls']
 
-            draw.text((start_x + 2, start_y + 25 + 59), 'B', font=font14, fill=0)
-            Himage = draw_circle(Himage, (start_x + 19, start_y + 25 + 68), 4, balls_list[0])
-            Himage = draw_circle(Himage, (start_x + 31, start_y + 25 + 68), 4, balls_list[1])
-            Himage = draw_circle(Himage, (start_x + 43, start_y + 25 + 68), 4, balls_list[2])
+            draw.text((start_x + 2 * s, start_y + 25 * s + 59 * s), 'B', font=font14, fill=0)
+            Himage = draw_circle(Himage, (start_x + 19 * s, start_y + 25 * s + 68 * s), 4 * s, balls_list[0])
+            Himage = draw_circle(Himage, (start_x + 31 * s, start_y + 25 * s + 68 * s), 4 * s, balls_list[1])
+            Himage = draw_circle(Himage, (start_x + 43 * s, start_y + 25 * s + 68 * s), 4 * s, balls_list[2])
 
             _num_strikes = game_data.get('strikes') or 0
             strikes_list = [i + 1 <= _num_strikes for i in range(2)]
             _strike_calls = game_data.get('strike_calls', [])
 
-            draw.text((start_x + 19 + 39, start_y + 25 + 59), 'S', font=font14, fill=0)
+            draw.text((start_x + 19 * s + 39 * s, start_y + 25 * s + 59 * s), 'S', font=font14, fill=0)
             for _si, (_scx, _scy) in enumerate([
-                (start_x + 19 + 55, start_y + 25 + 68),
-                (start_x + 31 + 55, start_y + 25 + 68),
+                (start_x + 19 * s + 55 * s, start_y + 25 * s + 68 * s),
+                (start_x + 31 * s + 55 * s, start_y + 25 * s + 68 * s),
             ]):
                 _call = _strike_calls[_si] if _si < len(_strike_calls) else None
                 if strikes_list[_si] and _call in ('S', 'F'):
                     # Swinging or foul: outline ring with filled center dot
-                    Himage = draw_circle(Himage, (_scx, _scy), 4, False)
+                    Himage = draw_circle(Himage, (_scx, _scy), 4 * s, False)
                     draw = ImageDraw.Draw(Himage)
-                    draw.ellipse([_scx - 2, _scy - 2, _scx + 2, _scy + 2], fill='black', outline='black')
+                    draw.ellipse([_scx - 2 * s, _scy - 2 * s, _scx + 2 * s, _scy + 2 * s], fill='black', outline='black')
                 else:
                     # Looking / empty: solid filled circle
-                    Himage = draw_circle(Himage, (_scx, _scy), 4, strikes_list[_si])
+                    Himage = draw_circle(Himage, (_scx, _scy), 4 * s, strikes_list[_si])
                     draw = ImageDraw.Draw(Himage)
 
         if game_data.get('save_situation') and not _between_innings and not _pitching_change:
             _sv_w = int(font9.getlength('SV'))
-            _sv_x = start_x + horizonta_len - _sv_w - 2
-            draw.text((_sv_x,     start_y + 25), 'SV', font=font9, fill=0)
-            draw.text((_sv_x + 1, start_y + 25), 'SV', font=font9, fill=0)
+            _sv_x = start_x + horizonta_len - _sv_w - 2 * s
+            draw.text((_sv_x,         start_y + 25 * s), 'SV', font=font9, fill=0)
+            draw.text((_sv_x + 1 * s, start_y + 25 * s), 'SV', font=font9, fill=0)
     else:
 
         # Perfect game takes precedence over no-hitter display — right-aligned in header
         if game_data.get('perfect_game') or game_data.get('no_hitter'):
             _nh_label = 'Perfect Game' if game_data.get('perfect_game') else 'No-Hitter'
             _nh_lw = int(font14.getlength(_nh_label))
-            _nh_lx = (_ser_content_left_x - 2) - _nh_lw
-            draw.text((_nh_lx,     start_y + 3), _nh_label, font=font14, fill=0)
-            draw.text((_nh_lx + 1, start_y + 3), _nh_label, font=font14, fill=0)
+            _nh_lx = (_ser_content_left_x - 2 * s) - _nh_lw
+            draw.text((_nh_lx,         start_y + 3 * s), _nh_label, font=font14, fill=0)
+            draw.text((_nh_lx + 1 * s, start_y + 3 * s), _nh_label, font=font14, fill=0)
 
 
 
     # Team names / logos
-    _LOGO_SIZE = 28  # matches _logo_small default size
+    _LOGO_SIZE = 28 * s  # matches _logo_small default size
     if use_logos:
-        away_logo = _logo_small(away_team_name, away_team_id)
-        home_logo = _logo_small(home_team_name, home_team_id)
+        away_logo = _logo_small(away_team_name, away_team_id, size=_LOGO_SIZE)
+        home_logo = _logo_small(home_team_name, home_team_id, size=_LOGO_SIZE)
         if away_logo:
             lw, lh = away_logo.size
             lx = start_x + logo_x_offset + (_LOGO_SIZE - lw) // 2
-            ly = start_y + 25 + (_LOGO_SIZE - lh) // 2
+            ly = start_y + 25 * s + (_LOGO_SIZE - lh) // 2
             _paste_logo(Himage, away_logo, (lx, ly))
-            abbr_x = start_x + logo_x_offset + _LOGO_SIZE + 2
-            abbr_y = start_y + 25 + (_LOGO_SIZE - 14) // 2
-            draw.text((abbr_x, abbr_y), away_team_name, font=font14, fill=0)
-            draw.text((abbr_x + 1, abbr_y), away_team_name, font=font14, fill=0)
+            abbr_x = start_x + logo_x_offset + _LOGO_SIZE + 2 * s
+            abbr_y = start_y + 25 * s + (_LOGO_SIZE - 14 * s) // 2
+            draw.text((abbr_x,         abbr_y), away_team_name, font=font14, fill=0)
+            draw.text((abbr_x + 1 * s, abbr_y), away_team_name, font=font14, fill=0)
         else:
-            draw.text((start_x + 5, start_y + 25), away_team_name, font=font24, fill=0)
+            draw.text((start_x + 5 * s, start_y + 25 * s), away_team_name, font=font24, fill=0)
         if home_logo:
             lw, lh = home_logo.size
             lx = start_x + logo_x_offset + (_LOGO_SIZE - lw) // 2
-            ly = start_y + 55 + (_LOGO_SIZE - lh) // 2
+            ly = start_y + 55 * s + (_LOGO_SIZE - lh) // 2
             _paste_logo(Himage, home_logo, (lx, ly))
-            abbr_x = start_x + logo_x_offset + _LOGO_SIZE + 2
-            abbr_y = start_y + 55 + (_LOGO_SIZE - 14) // 2
-            draw.text((abbr_x, abbr_y), home_team_name, font=font14, fill=0)
-            draw.text((abbr_x + 1, abbr_y), home_team_name, font=font14, fill=0)
+            abbr_x = start_x + logo_x_offset + _LOGO_SIZE + 2 * s
+            abbr_y = start_y + 55 * s + (_LOGO_SIZE - 14 * s) // 2
+            draw.text((abbr_x,         abbr_y), home_team_name, font=font14, fill=0)
+            draw.text((abbr_x + 1 * s, abbr_y), home_team_name, font=font14, fill=0)
         else:
-            draw.text((start_x + 5, start_y + 55), home_team_name, font=font24, fill=0)
+            draw.text((start_x + 5 * s, start_y + 55 * s), home_team_name, font=font24, fill=0)
     else:
-        draw.text((start_x + 5, start_y + 25), away_team_name, font=font24, fill=0)
-        draw.text((start_x + 5, start_y + 55), home_team_name, font=font24, fill=0)
+        draw.text((start_x + 5 * s, start_y + 25 * s), away_team_name, font=font24, fill=0)
+        draw.text((start_x + 5 * s, start_y + 55 * s), home_team_name, font=font24, fill=0)
         # Bold-offset re-draw to emphasise winner name (text mode only)
         if game_data.get('away_team_is_winner'):
-            draw.text((start_x + 7, start_y + 25), away_team_name, font=font24, fill=0)
+            draw.text((start_x + 7 * s, start_y + 25 * s), away_team_name, font=font24, fill=0)
         if game_data.get('home_team_is_winner'):
-            draw.text((start_x + 7, start_y + 55), home_team_name, font=font24, fill=0)
+            draw.text((start_x + 7 * s, start_y + 55 * s), home_team_name, font=font24, fill=0)
 
     # Bold-offset score for winner (both modes)
     if game_data.get('away_team_is_winner'):
-        draw.text((start_x + 67 + check_if_two_chars(away_runs), start_y + 25), away_runs, font=font24, fill=0)
+        draw.text((start_x + 67 * s + check_if_two_chars(away_runs), start_y + 25 * s), away_runs, font=font24, fill=0)
     if game_data.get('home_team_is_winner'):
-        draw.text((start_x + 67 + check_if_two_chars(home_runs), start_y + 55), home_runs, font=font24, fill=0)
+        draw.text((start_x + 67 * s + check_if_two_chars(home_runs), start_y + 55 * s), home_runs, font=font24, fill=0)
 
     # Invert header to indicate a score change during an active game
     if score_changed and is_game_started and not is_game_finished:
-        header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1, start_y + 21))
+        header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
     # Invert header for special states: walk-off, no-hitter, perfect game
     if (is_game_finished and game_data.get('walk_off')) or \
        ((game_data.get('no_hitter') or game_data.get('perfect_game')) and
         (is_game_finished or _active_no_no)):
-        header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1, start_y + 21))
+        header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
     return Himage

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -315,7 +315,7 @@ def _draw_weather_footer(draw, start_x, start_y, horiz_len, game_data, fnt, show
                 return
 
 
-def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None):
+def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True):
     # Normalize early-completion states (e.g. spring training games called after 6 innings)
     if game_data.get('detailed_state', '').startswith('Completed Early'):
         game_data = dict(game_data)
@@ -431,7 +431,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             draw = ImageDraw.Draw(Himage)
 
     # Winner ghost logo — drawn first so all text/scores render on top of it
-    if use_logos and game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied'):
+    if show_winner_logo and use_logos and game_data['detailed_state'] in ('Final', 'Game Over', 'Final: Tied'):
         winner_abbr = winner_id = None
         if game_data.get('away_team_is_winner'):
             winner_abbr, winner_id = away_team_name, away_team_id

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -33,6 +33,12 @@ _WC_LOGO_SZ     = _SIDEBAR_LOGO_SIZE              # same 20px as the sidebar
 _AL_DIVISIONS = ['American League East', 'American League Central', 'American League West']
 _NL_DIVISIONS = ['National League East', 'National League Central', 'National League West']
 
+# Fullscreen sidebar — 3 division columns side-by-side, full content-area height
+_FS_SIDEBAR_W   = 175   # left sidebar width (= game cell paste_x); game cell = 450px
+_FS_COL_W       = _FS_SIDEBAR_W // 3   # 58px per division column
+_FS_LOGO_SZ     = 44    # default logo size (fits in 58px col with 7px padding each side)
+_FS_LABEL_H     = 14    # px reserved for E/C/W label at top of each column
+
 _WC_WILDCARD_SPOTS = 3   # number of wildcard playoff berths per league
 _WC_MAX_TEAMS      = 12  # max eligible per league (15 teams - 3 division leaders)
 
@@ -355,3 +361,84 @@ def draw_standings_sidebar(Himage, standings_data, team_data, side='left', leagu
         save_off_results(_movement_data, 'standings_movement')
 
     return Himage
+
+
+def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='left', league_mode='mlb',
+                                      y_start=_WC_STRIP_H, height=450,
+                                      x_anchor=None, sidebar_w=None, logo_sz=None):
+    """Draw AL or NL divisions (E/C/W) as 3 side-by-side columns for the fullscreen game layout.
+
+    Left side = AL, right side = NL.  x_anchor / sidebar_w / logo_sz can be overridden by the
+    caller so each side uses the space actually available (the right sidebar starts where the
+    scoreboard box's horizontal line stops, not at the far right edge of the game cell image).
+    """
+    if league_mode == 'aaa':
+        divisions = _aaa_divisions(standings_data, side)[:3]
+    else:
+        divisions = _AL_DIV_ORDER if side == 'left' else _NL_DIV_ORDER
+
+    abbr_map = {**standings_data.get('team_abbreviation', {}),
+                **team_data.get('team_abbreviation', {})}
+
+    if x_anchor is None:
+        x_anchor = 0 if side == 'left' else (800 - _FS_SIDEBAR_W)
+    if sidebar_w is None:
+        sidebar_w = _FS_SIDEBAR_W
+    col_w = sidebar_w // 3
+    if logo_sz is None:
+        logo_sz = _FS_LOGO_SZ
+
+    n_teams     = 5
+    team_area_h = height - _FS_LABEL_H
+    slot_h      = team_area_h // n_teams   # 87 px
+
+    draw       = ImageDraw.Draw(canvas)
+    font_label = _get_font(9)
+
+    for col_idx, div_name in enumerate(divisions[:3]):
+        col_x = x_anchor + col_idx * col_w
+
+        # Division label: first letter of direction word (East→E, Central→C, West→W)
+        label = div_name.split()[-1][0]
+        lw = int(font_label.getlength(label))
+        draw.text((col_x + (col_w - lw) // 2, y_start + 2), label, font=font_label, fill=0)
+
+        teams = standings_data.get('standings', {}).get(div_name, [])
+        teams = sorted(teams, key=lambda t: int(t.get('divisionRank', 99)))
+
+        for slot_idx, team in enumerate(teams[:n_teams]):
+            team_id = str(team.get('team_id', ''))
+            abbr    = abbr_map.get(team_id, f'T{team_id}')
+
+            slot_y = y_start + _FS_LABEL_H + slot_idx * slot_h
+            logo_x = col_x + (col_w - logo_sz) // 2
+            logo_y = slot_y + (slot_h - logo_sz) // 2
+
+            logo_img = _logo_small(abbr, team_id, size=logo_sz)
+            if logo_img:
+                lw2, lh = logo_img.size
+                canvas.paste(logo_img, (logo_x + (logo_sz - lw2) // 2,
+                                        logo_y + (logo_sz - lh) // 2))
+            else:
+                font9 = _get_font(9)
+                tw = int(font9.getlength(abbr[:3]))
+                draw.text((logo_x + (logo_sz - tw) // 2, logo_y + (logo_sz - 9) // 2),
+                          abbr[:3], font=font9, fill=0)
+
+            # Clinch indicator
+            clinch = (team.get('clinch_indicator') or '').lower()
+            if clinch in ('y', 'z'):
+                box_w = 2 if clinch == 'z' else 1
+                draw.rectangle([logo_x, logo_y, logo_x + logo_sz - 1, logo_y + logo_sz - 1],
+                               outline=0, width=box_w)
+
+        # Vertical separator between columns (not after the last one)
+        if col_idx < 2:
+            sep_x = col_x + col_w
+            draw.line((sep_x, y_start, sep_x, y_start + height - 1), fill=0, width=1)
+
+    # Outer separator: right edge of left sidebar or left edge of right sidebar
+    edge_x = x_anchor + sidebar_w - 1 if side == 'left' else x_anchor
+    draw.line((edge_x, y_start, edge_x, y_start + height - 1), fill=0, width=1)
+
+    return canvas


### PR DESCRIPTION
## Summary

- **Morning alternating (7am–9am)**: every 5-minute block alternates between yesterday's final scores and today's upcoming schedule. Before 7am stays on yesterday; after 9am stays on today. Controlled by `morning_alternate_games: true` (default on) in config.yaml.

- **Featured team fullscreen**: new `featured_team_fullscreen: false` config key. When enabled, the primary team's game fills the entire 800×480 display instead of the 15-game grid. Three render modes:
  - **Scheduled/Pre-Game**: `TEAM @ TEAM` header, probable pitchers with stats right-aligned, weather + venue
  - **In Progress**: 72-px scores, full linescore grid, count (B/S/O) + last play
  - **Final**: 72-px scores, full inning-by-inning linescore (R/H/E), WP/LP/SV

Game selection priority: first Scheduled/Pre-Game game → first In Progress → most recent Final.

## Test plan
- [ ] Verify `morning_alternate_games: true` flips date correctly at 5-min boundaries between 7–9am
- [ ] Enable `featured_team_fullscreen: true`, confirm NYY game renders full screen
- [ ] Test with Final, In Progress, and Scheduled game states
- [ ] Confirm normal scoreboard grid still renders when `featured_team_fullscreen: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)