### PR TITLE
Fix ABS dots scaling, 60min throttle for static states, bigger fullscreen date

### DIFF
--- a/main.py
+++ b/main.py
@@ -304,9 +304,9 @@ def _should_skip_poll(date_str, config, sched):
     if any_final_undecided:
         interval_min = 2
     elif all_done:
-        interval_min = 15
+        interval_min = 60
     elif not cached_games or all_pregame:
-        interval_min = 15
+        interval_min = 60
     else:
         interval_min = config.get('update_interval', 15)
 
@@ -320,7 +320,7 @@ def _should_skip_poll(date_str, config, sched):
                     'final_undecided' if any_final_undecided
                     else 'all_done' if all_done
                     else 'pregame' if all_pregame
-                    else 'pre-game'
+                    else 'mixed'
                 )
                 return True, f"Throttled — {mins}min since last fetch (interval={interval_min}min, state={state_label})"
         except Exception:

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -909,19 +909,36 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
                 canvas, standings_data, team_data, side='right', league_mode=league_mode,
                 x_anchor=_right_sb_x, sidebar_w=_right_sb_w, logo_sz=_sb_logo_sz)
 
-    # Date label centered in the top strip between wildcard teams
+    # Date label centered in the top strip — use the largest font that fits
     _gd_str = (game_data.get('game_date') or '')[:10]
     if _gd_str:
         try:
             _gd = datetime.strptime(_gd_str, '%Y-%m-%d')
-            _date_label = _gd.strftime('%B %-d, %Y')
+            _date_label_full  = _gd.strftime('%A, %B %-d, %Y')   # Monday, May 11, 2026
+            _date_label_short = _gd.strftime('%a · %b %-d, %Y')  # Mon · May 11, 2026
         except Exception:
-            _date_label = _gd_str
+            _date_label_full = _date_label_short = _gd_str
         _date_draw = ImageDraw.Draw(canvas)
+        # Center over the 405px content area (paste_x … paste_x+_box_w)
+        _center_x = paste_x + _box_w // 2
+        _MAX_DATE_W = _box_w - 8  # leave a small margin
         _date_font = _get_font(14)
+        _date_label = _date_label_short
+        _fsize_used = 14
+        for _fsize in (20, 18, 16, 14):
+            _f = _get_font(_fsize)
+            for _candidate in (_date_label_full, _date_label_short):
+                if int(_f.getlength(_candidate)) <= _MAX_DATE_W:
+                    _date_font = _f
+                    _date_label = _candidate
+                    _fsize_used = _fsize
+                    break
+            else:
+                continue
+            break
         _dw = int(_date_font.getlength(_date_label))
-        _dx = (800 - _dw) // 2
-        _dy = max(0, (_WC_STRIP_H - 14) // 2)
+        _dx = _center_x - _dw // 2
+        _dy = max(0, (_WC_STRIP_H - _fsize_used) // 2)
         _date_draw.text((_dx,     _dy), _date_label, font=_date_font, fill=0)
         _date_draw.text((_dx + 1, _dy), _date_label, font=_date_font, fill=0)
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -204,29 +204,30 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
 _ABS_CHALLENGE_MAX = 2
 
 
-def _draw_challenge_dots(draw, start_x, start_y, game_data, use_logos=False, logo_x_offset=2):
+def _draw_challenge_dots(draw, start_x, start_y, game_data, use_logos=False, logo_x_offset=2, scale=1):
     """ABS dots at original position beside the team row; replay dot below the abbreviation."""
-    _LOGO_SIZE = 28
-    r = 3
-    dot_spacing = 8
+    s = scale
+    _LOGO_SIZE = 28 * s
+    r = 3 * s
+    dot_spacing = 8 * s
 
     if use_logos:
         # x: immediately right of logo + abbr (original position)
-        dot_x = start_x + logo_x_offset + _LOGO_SIZE + 2 + 3
+        dot_x = start_x + logo_x_offset + _LOGO_SIZE + 2 * s + 3 * s
         # ABS y: original positions, vertically centred in each team row
-        away_abs_y    = start_y + 30
-        home_abs_y    = start_y + 60
-        # Replay y: below the abbr text (abbr at row_base+7, font14 14px tall → bottom at row_base+21)
+        away_abs_y    = start_y + 30 * s
+        home_abs_y    = start_y + 60 * s
+        # Replay y: below the abbr text (abbr at row_base+7*s, font14 14*s px tall → bottom at row_base+21*s)
         # Add a small gap so it doesn't touch the text
-        away_replay_y = start_y + 25 + 7 + 14 + 4   # = start_y + 50
-        home_replay_y = start_y + 55 + 7 + 14 + 4   # = start_y + 80
+        away_replay_y = start_y + (25 + 7 + 14 + 4) * s   # = start_y + 50*s
+        home_replay_y = start_y + (55 + 7 + 14 + 4) * s   # = start_y + 80*s
     else:
-        dot_x = start_x + 5 + 3
-        away_abs_y    = start_y + 30
-        home_abs_y    = start_y + 60
+        dot_x = start_x + (5 + 3) * s
+        away_abs_y    = start_y + 30 * s
+        home_abs_y    = start_y + 60 * s
         # font24 glyph height ~17px, top offset ~6px → bottom at row_base + 23
-        away_replay_y = start_y + 25 + 23 + 4        # = start_y + 52
-        home_replay_y = start_y + 55 + 23 + 4        # = start_y + 82
+        away_replay_y = start_y + (25 + 23 + 4) * s        # = start_y + 52*s
+        home_replay_y = start_y + (55 + 23 + 4) * s        # = start_y + 82*s
 
     abs_max = game_data.get('abs_challenge_max') or _ABS_CHALLENGE_MAX
 
@@ -1156,7 +1157,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
 
     # ABS challenges remaining — small stacked dots to the left of each team's logo
     if game_data['detailed_state'] == 'In Progress':
-        _draw_challenge_dots(draw, start_x, start_y, game_data, use_logos=use_logos, logo_x_offset=logo_x_offset)
+        _draw_challenge_dots(draw, start_x, start_y, game_data, use_logos=use_logos, logo_x_offset=logo_x_offset, scale=s)
 
     # horizontal line
     end_x = start_x + horizonta_len


### PR DESCRIPTION
## Summary
- Fix ABS challenge dots and manager challenge replay dots not scaling in the 3× fullscreen big cell — all pixel offsets now multiply by the `scale` parameter
- Throttle API polling to 60 min (was 15 min) when all games are scheduled/pre-game or all games are final
- Fullscreen big cell date label now picks the largest font (up to 20px) that fits the content area width, with day-of-week added (`Mon · May 11, 2026` / `Monday, May 11, 2026`)

## Test plan
- [ ] Confirm ABS/challenge dots appear at correct positions in fullscreen mode during a live game
- [ ] Confirm on Pi that pregame/done days no longer refresh every minute (check `schedule_state.json` `last_game_fetch` timestamps)
- [ ] Confirm date in fullscreen big cell is visibly larger and shows day-of-week

🤖 Generated with [Claude Code](https://claude.com/claude-code)