### PR TITLE
Constrain fullscreen date width when wildcard strip is active

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -919,9 +919,12 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
         except Exception:
             _date_label_full = _date_label_short = _gd_str
         _date_draw = ImageDraw.Draw(canvas)
-        # Center over the 405px content area (paste_x … paste_x+_box_w)
-        _center_x = paste_x + _box_w // 2
-        _MAX_DATE_W = _box_w - 8  # leave a small margin
+        # When wildcard standings are shown they fill the strip leaving only ~155px
+        # clear in the center (same constraint as the normal scoreboard header).
+        # Without wildcard the full strip is free so the content-area width applies.
+        _show_wc = config.get('show_wildcard_standings', False)
+        _MAX_DATE_W = 151 if _show_wc else (_box_w - 8)
+        _center_x = 400  # midpoint of the 800px display (matches _WC_MID = 399)
         _date_font = _get_font(14)
         _date_label = _date_label_short
         _fsize_used = 14


### PR DESCRIPTION
## Summary
- Fullscreen big-cell date was overlapping wildcard team logos because it used the full 405px content-area width as its max
- When `show_wildcard_standings` is true the AL/NL teams fill the strip leaving only ~155px clear in the center — now the date respects the same 151px constraint the normal scoreboard header uses
- Without wildcard standings the full content-area width (397px) still applies so the date can still be as large as possible

## Test plan
- [ ] With `show_wildcard_standings: true` — date sits cleanly between the AL and NL wildcard logos in the top strip
- [ ] With `show_wildcard_standings: false` — date still fills the available space at the largest fitting font

🤖 Generated with [Claude Code](https://claude.com/claude-code)