### PR TITLE
Fullscreen standings L-bracket mover indicator

### DIFF
--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -519,7 +519,7 @@ def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='l
             # AL (left): vertical on left + horizontal at bottom-left
             # NL (right): vertical on right + horizontal at bottom-right
             if team_id in display_movers:
-                _arm  = logo_sz // 3
+                _arm  = logo_sz
                 _lw   = 4
                 _foot = logo_y + logo_sz + 6   # 6px below logo bottom
                 if side == 'left':

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -515,10 +515,20 @@ def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='l
                 draw.text((logo_x + (logo_sz - tw) // 2, logo_y + (logo_sz - 9) // 2),
                           abbr[:3], font=font9, fill=0)
 
-            # Movement indicator: AL left edge, NL right edge of each column
+            # Movement indicator: L-bracket around logo corner
+            # AL (left): vertical on left + horizontal at bottom-left
+            # NL (right): vertical on right + horizontal at bottom-right
             if team_id in display_movers:
-                ind_x = col_x if side == 'left' else col_x + col_w - 1
-                draw.line((ind_x, logo_y, ind_x, logo_y + logo_sz - 1), fill=0, width=4)
+                _arm = logo_sz // 3
+                _lw  = 4
+                if side == 'left':
+                    _vx = col_x
+                    draw.line((_vx, logo_y, _vx, logo_y + logo_sz - 1), fill=0, width=_lw)
+                    draw.line((_vx, logo_y + logo_sz - 1, _vx + _arm, logo_y + logo_sz - 1), fill=0, width=_lw)
+                else:
+                    _vx = col_x + col_w - 1
+                    draw.line((_vx, logo_y, _vx, logo_y + logo_sz - 1), fill=0, width=_lw)
+                    draw.line((_vx - _arm, logo_y + logo_sz - 1, _vx, logo_y + logo_sz - 1), fill=0, width=_lw)
 
             # Clinch indicator
             clinch = (team.get('clinch_indicator') or '').lower()

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -519,16 +519,17 @@ def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='l
             # AL (left): vertical on left + horizontal at bottom-left
             # NL (right): vertical on right + horizontal at bottom-right
             if team_id in display_movers:
-                _arm = logo_sz // 3
-                _lw  = 4
+                _arm  = logo_sz // 3
+                _lw   = 4
+                _foot = logo_y + logo_sz + 6   # 6px below logo bottom
                 if side == 'left':
                     _vx = col_x
-                    draw.line((_vx, logo_y, _vx, logo_y + logo_sz - 1), fill=0, width=_lw)
-                    draw.line((_vx, logo_y + logo_sz - 1, _vx + _arm, logo_y + logo_sz - 1), fill=0, width=_lw)
+                    draw.line((_vx, logo_y, _vx, _foot), fill=0, width=_lw)
+                    draw.line((_vx, _foot, _vx + _arm, _foot), fill=0, width=_lw)
                 else:
                     _vx = col_x + col_w - 1
-                    draw.line((_vx, logo_y, _vx, logo_y + logo_sz - 1), fill=0, width=_lw)
-                    draw.line((_vx - _arm, logo_y + logo_sz - 1, _vx, logo_y + logo_sz - 1), fill=0, width=_lw)
+                    draw.line((_vx, logo_y, _vx, _foot), fill=0, width=_lw)
+                    draw.line((_vx - _arm, _foot, _vx, _foot), fill=0, width=_lw)
 
             # Clinch indicator
             clinch = (team.get('clinch_indicator') or '').lower()

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -521,14 +521,15 @@ def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='l
             if team_id in display_movers:
                 _arm  = logo_sz
                 _lw   = 4
-                _foot = logo_y + logo_sz + 6   # 6px below logo bottom
+                _foot = logo_y + logo_sz + 6        # 6px below logo bottom
+                _vtop = _foot - logo_sz // 3         # vertical spans bottom 1/3 only
                 if side == 'left':
                     _vx = col_x
-                    draw.line((_vx, logo_y, _vx, _foot), fill=0, width=_lw)
+                    draw.line((_vx, _vtop, _vx, _foot), fill=0, width=_lw)
                     draw.line((_vx, _foot, _vx + _arm, _foot), fill=0, width=_lw)
                 else:
                     _vx = col_x + col_w - 1
-                    draw.line((_vx, logo_y, _vx, _foot), fill=0, width=_lw)
+                    draw.line((_vx, _vtop, _vx, _foot), fill=0, width=_lw)
                     draw.line((_vx - _arm, _foot, _vx, _foot), fill=0, width=_lw)
 
             # Clinch indicator


### PR DESCRIPTION
## Summary
- Replaces the plain `|` in fullscreen standings with an L-bracket: short vertical stub (bottom 1/3 of logo height) + full-logo-width horizontal foot, 6px below the logo
- AL columns: L opens right (vertical on left edge, foot goes right)
- NL columns: mirrored L (vertical on right edge, foot goes left)

## Test plan
- [ ] Render fullscreen cell with a moved team — verify L-bracket appears below logo, clears it cleanly
- [ ] Verify AL and NL sides mirror correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)