### PR TITLE
Fielder notation for outs + team label on challenges

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -133,13 +133,13 @@ def _attach_pregame_weather(game_dict, schedule_game, config):
     game_dict['weather_precip_pct'] = forecast.get('precip_pct')
 
 def fetch_win_probability(game_pk):
-    """Return (away_wp, home_wp, last_play, last_play_inning, last_play_is_top, last_play_rbi) or (None,)*6."""
+    """Return (away_wp, home_wp, last_play, last_play_inning, last_play_is_top, last_play_rbi, last_play_description)."""
     try:
         url = f'https://statsapi.mlb.com/api/v1/game/{game_pk}/winProbability'
         response = requests.get(url, timeout=5)
         data = response.json()
         if not isinstance(data, list) or not data:
-            return None, None, None, None, None, 0
+            return None, None, None, None, None, 0, ''
         last = data[-1]
         away_wp = last.get('awayTeamWinProbability')
         home_wp = last.get('homeTeamWinProbability')
@@ -148,12 +148,14 @@ def fetch_win_probability(game_pk):
         last_play_inning = None
         last_play_is_top = None
         last_play_rbi = 0
+        last_play_description = ''
         for entry in reversed(data):
             event_type = (entry.get('result', {}).get('eventType') or '').lower()
             event = entry.get('result', {}).get('event') or ''
             if event and not any(s in event_type for s in _SUBSTITUTION_TYPES):
                 last_play = event
                 last_play_rbi = int(entry.get('result', {}).get('rbi') or 0)
+                last_play_description = entry.get('result', {}).get('description') or ''
                 about = entry.get('about', {})
                 last_play_inning = about.get('inning')
                 last_play_is_top = about.get('isTopInning')
@@ -166,9 +168,31 @@ def fetch_win_probability(game_pk):
                 home_wp *= 100
         else:
             away_wp, home_wp = None, None
-        return away_wp, home_wp, last_play, last_play_inning, last_play_is_top, last_play_rbi
+        return away_wp, home_wp, last_play, last_play_inning, last_play_is_top, last_play_rbi, last_play_description
     except Exception:
-        return None, None, None, None, None, 0
+        return None, None, None, None, None, 0, ''
+
+
+def _fetch_challenge_team_abbr(game_pk, away_team_id, home_team_id, away_abbr, home_abbr):
+    """Return the abbreviation of the team that initiated an active challenge, or ''."""
+    try:
+        url = (
+            f'https://statsapi.mlb.com/api/v1.1/game/{game_pk}/feed/live'
+            '?fields=liveData,plays,currentPlay,playEvents,reviewDetails,challengeTeamId,inProgress'
+        )
+        resp = requests.get(url, timeout=5)
+        plays = resp.json().get('liveData', {}).get('plays', {})
+        for ev in reversed(plays.get('currentPlay', {}).get('playEvents', [])):
+            rd = ev.get('reviewDetails')
+            if rd and rd.get('inProgress'):
+                team_id = rd.get('challengeTeamId')
+                if team_id == away_team_id:
+                    return away_abbr or ''
+                if team_id == home_team_id:
+                    return home_abbr or ''
+    except Exception:
+        pass
+    return ''
 
 
 def _fetch_mlb_odds(api_key):
@@ -606,12 +630,17 @@ def parse_games(data, sport_id=None, config=None):
             team_abbreviations.get(str(home_team_id), ''),
         ))
         if _is_featured and game_dict.get('detailed_state') in ('In Progress', 'Player challenge', 'Manager challenge') and live_calls_made < max_live_calls:
-            away_wp, home_wp, last_play, last_play_inning, last_play_is_top, last_play_rbi = fetch_win_probability(game_id)
+            away_wp, home_wp, last_play, last_play_inning, last_play_is_top, last_play_rbi, last_play_desc = fetch_win_probability(game_id)
             live_calls_made += 1
             game_dict['last_play'] = last_play
             game_dict['last_play_inning'] = last_play_inning
             game_dict['last_play_is_top'] = last_play_is_top
             game_dict['last_play_rbi'] = last_play_rbi
+            game_dict['last_play_description'] = last_play_desc
+            if game_dict.get('detailed_state') in ('Player challenge', 'Manager challenge'):
+                game_dict['challenge_team_abbr'] = _fetch_challenge_team_abbr(
+                    game_id, away_team_id, home_team_id, away_abbreviation, home_abbreviation,
+                )
             if config.get('scoreboard_win_probability', False):
                 game_dict['away_win_probability'] = away_wp
                 game_dict['home_win_probability'] = home_wp

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -210,44 +210,52 @@ def _last_name_simple(full_name):
 
 
 def _find_recent_sub_event(plays):
-    """Return 'PC: Lastname', 'PH: Lastname', or None for the most recent pitching
-    change or pinch hitter within the last 3 plays.
+    """Return 'PC: Lastname', 'PH: Lastname', or None for a fresh pitching change
+    or pinch hitter.
+
+    A substitution is considered fresh only while no pitch has been thrown in the
+    current at-bat since the change occurred.  This mirrors the freshness guard used
+    by _find_recent_review_result and prevents the label from persisting for 3+ ABs.
 
     Pitching changes between at-bats appear as standalone top-level allPlays entries
     (result.eventType = 'pitching_substitution').  Mid-at-bat subs appear as action
-    events inside a play's playEvents list.  We check both.
+    events inside a play's playEvents list.
     """
     all_plays = plays.get('allPlays') or []
-    recent = all_plays[-3:] if len(all_plays) >= 3 else all_plays
+    current_events = plays.get('currentPlay', {}).get('playEvents', [])
+    current_has_pitches = any(ev.get('isPitch') for ev in current_events)
 
-    # 1. Top-level allPlays substitution entries (between-at-bat pitching changes)
-    for play in reversed(recent):
-        result_et = (play.get('result', {}).get('eventType') or '').lower()
-        result_desc = (play.get('result', {}).get('description') or '').lower()
+    # 1. Mid-at-bat subs inside currentPlay — fresh only if no pitch thrown after the sub.
+    for ev in reversed(current_events):
+        if ev.get('isPitch'):
+            break  # pitch thrown after sub — stale
+        et = (ev.get('details', {}).get('eventType') or '').lower()
+        player_name = (ev.get('player', {}).get('fullName') or '').strip()
+        if not player_name:
+            continue
+        last = _last_name_simple(player_name)
+        if 'pitching_substitution' in et:
+            return f'PC: {last}'
+        if 'offensive_substitution' in et:
+            desc = (ev.get('details', {}).get('description') or '').lower()
+            if 'pinch' in desc:
+                return f'PH: {last}'
+
+    # 2. Between-at-bat substitution (standalone allPlays entry) — fresh only if the
+    # new pitcher/batter hasn't faced a pitch yet in the current at-bat.
+    if not current_has_pitches and all_plays:
+        last_play = all_plays[-1]
+        result_et = (last_play.get('result', {}).get('eventType') or '').lower()
+        result_desc = (last_play.get('result', {}).get('description') or '').lower()
         if 'pitching_substitution' in result_et:
-            pitcher = play.get('matchup', {}).get('pitcher', {}).get('fullName') or ''
+            pitcher = last_play.get('matchup', {}).get('pitcher', {}).get('fullName') or ''
             last = _last_name_simple(pitcher)
             return f'PC: {last}' if last else None
         if 'offensive_substitution' in result_et and 'pinch' in result_desc:
-            batter = play.get('matchup', {}).get('batter', {}).get('fullName') or ''
+            batter = last_play.get('matchup', {}).get('batter', {}).get('fullName') or ''
             last = _last_name_simple(batter)
             return f'PH: {last}' if last else None
 
-    # 2. Action events inside currentPlay or last completed play (mid-at-bat subs)
-    sources = [p for p in [plays.get('currentPlay')] + ([all_plays[-1]] if all_plays else []) if p]
-    for play in sources:
-        for ev in reversed(play.get('playEvents', [])):
-            et = (ev.get('details', {}).get('eventType') or '').lower()
-            player_name = (ev.get('player', {}).get('fullName') or '').strip()
-            if not player_name:
-                continue
-            last = _last_name_simple(player_name)
-            if 'pitching_substitution' in et:
-                return f'PC: {last}'
-            if 'offensive_substitution' in et:
-                desc = (ev.get('details', {}).get('description') or '').lower()
-                if 'pinch' in desc:
-                    return f'PH: {last}'
     return None
 
 

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -900,6 +900,8 @@ def _build_scorecard_notation(play):
         return '-'.join(pos_seq) + dp_suffix
 
     # Credits absent — parse fielder positions from the play description.
+    # Find every occurrence of each position keyword so repeated touches
+    # (e.g. catcher in a rundown) are captured; cap at 5 fielders.
     _desc = result.get('description', '')
     if _desc:
         _dl = _desc.lower()
@@ -908,10 +910,18 @@ def _build_scorecard_notation(play):
             ('first baseman', '3'), ('second baseman', '4'), ('third baseman', '5'),
             ('shortstop', '6'), ('catcher', '2'), ('pitcher', '1'),
         ]
-        _hits = sorted(((_dl.find(kw), code) for kw, code in _pos_kws if kw in _dl))
+        _hits = []
+        for _kw, _code in _pos_kws:
+            _start = 0
+            while True:
+                _idx = _dl.find(_kw, _start)
+                if _idx < 0:
+                    break
+                _hits.append((_idx, _code))
+                _start = _idx + 1
+        _hits.sort()
         if _hits:
-            _max = 3 if (is_dp or is_tp) else 2
-            _seq = '-'.join(c for _, c in _hits[:_max])
+            _seq = '-'.join(c for _, c in _hits[:5])
             return _seq + dp_suffix
 
     # Fallbacks when credits are absent.

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -899,6 +899,21 @@ def _build_scorecard_notation(play):
     if pos_seq:
         return '-'.join(pos_seq) + dp_suffix
 
+    # Credits absent — parse fielder positions from the play description.
+    _desc = result.get('description', '')
+    if _desc:
+        _dl = _desc.lower()
+        _pos_kws = [
+            ('center fielder', '8'), ('right fielder', '9'), ('left fielder', '7'),
+            ('first baseman', '3'), ('second baseman', '4'), ('third baseman', '5'),
+            ('shortstop', '6'), ('catcher', '2'), ('pitcher', '1'),
+        ]
+        _hits = sorted(((_dl.find(kw), code) for kw, code in _pos_kws if kw in _dl))
+        if _hits:
+            _max = 3 if (is_dp or is_tp) else 2
+            _seq = '-'.join(c for _, c in _hits[:_max])
+            return _seq + dp_suffix
+
     # Fallbacks when credits are absent.
     if event.startswith('Caught Stealing'):
         return 'CS'

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -96,16 +96,24 @@ def _fielder_from_desc(description):
     return ''
 
 
-def _fielder_seq_from_desc(description, max_pos=2):
-    """Return a fielder position sequence (e.g. '6-3', '4-6-3') from a play description."""
+def _fielder_seq_from_desc(description, max_pos=5):
+    """Return a fielder position sequence from a play description (up to max_pos fielders).
+
+    Finds every occurrence of each position keyword in order so repeated touches
+    (e.g. catcher in a rundown) are captured correctly.
+    """
     if not description:
         return ''
     dl = description.lower()
     hits = []
     for kw, code in _POS_KEYWORDS:
-        idx = dl.find(kw)
-        if idx >= 0:
+        start = 0
+        while True:
+            idx = dl.find(kw, start)
+            if idx < 0:
+                break
             hits.append((idx, code))
+            start = idx + 1
     hits.sort()
     if hits:
         return '-'.join(h[1] for h in hits[:max_pos])
@@ -1058,11 +1066,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 if _fp:
                     play_display = f'SF{_fp}'
             elif play_display == 'GO':
-                _fseq = _fielder_seq_from_desc(_lp_desc, max_pos=2)
+                _fseq = _fielder_seq_from_desc(_lp_desc)
                 if _fseq:
                     play_display = f'{_fseq} GO'
             elif play_display in ('GDP', 'DP'):
-                _fseq = _fielder_seq_from_desc(_lp_desc, max_pos=3)
+                _fseq = _fielder_seq_from_desc(_lp_desc)
                 if _fseq:
                     play_display = f'{_fseq} GDP'
         # Bare fielder-sequence groundouts (e.g. "6-3", "5-3") get a GO suffix

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -96,8 +96,8 @@ def _fielder_from_desc(description):
     return ''
 
 
-def _fielder_seq_from_desc(description):
-    """Return a fielder position sequence (e.g. '6-3') from a groundout description."""
+def _fielder_seq_from_desc(description, max_pos=2):
+    """Return a fielder position sequence (e.g. '6-3', '4-6-3') from a play description."""
     if not description:
         return ''
     dl = description.lower()
@@ -107,10 +107,8 @@ def _fielder_seq_from_desc(description):
         if idx >= 0:
             hits.append((idx, code))
     hits.sort()
-    if len(hits) >= 2:
-        return '-'.join(h[1] for h in hits[:2])
     if hits:
-        return hits[0][1]
+        return '-'.join(h[1] for h in hits[:max_pos])
     return ''
 
 
@@ -1060,9 +1058,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 if _fp:
                     play_display = f'SF{_fp}'
             elif play_display == 'GO':
-                _fseq = _fielder_seq_from_desc(_lp_desc)
+                _fseq = _fielder_seq_from_desc(_lp_desc, max_pos=2)
                 if _fseq:
                     play_display = f'{_fseq} GO'
+            elif play_display in ('GDP', 'DP'):
+                _fseq = _fielder_seq_from_desc(_lp_desc, max_pos=3)
+                if _fseq:
+                    play_display = f'{_fseq} GDP'
         # Bare fielder-sequence groundouts (e.g. "6-3", "5-3") get a GO suffix
         # so the play type is clear alongside the position sequence.
         if play_display and _re.match(r'^\d(-\d)+$', play_display):

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -375,7 +375,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         game_data = dict(game_data)
         _prefix = 'P CHAL' if game_data['detailed_state'] == 'Player challenge' else 'M CHAL'
         _chal_abbr = game_data.get('challenge_team_abbr', '')
-        game_data['last_play'] = f'{_prefix} {_chal_abbr}'.strip() if _chal_abbr else _prefix
+        _chal_label = f'{_prefix} {_chal_abbr}'.strip() if _chal_abbr else _prefix
+        # Write into sub_event so the challenge label has highest display priority
+        # (sub_event wins over last_play, preventing "PC: Name" from overriding it).
+        game_data['sub_event'] = _chal_label
+        game_data['last_play'] = _chal_label
         game_data['detailed_state'] = 'In Progress'
 
     # Delayed Start = game hasn't begun yet; treat like Pre-Game (show pitcher probables)

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -71,6 +71,49 @@ def _abbr_play(raw):
     return raw
 
 
+# Ordered longest-first so "left fielder" matches before "fielder", etc.
+_POS_KEYWORDS = [
+    ('center fielder',  '8'),
+    ('right fielder',   '9'),
+    ('left fielder',    '7'),
+    ('first baseman',   '3'),
+    ('second baseman',  '4'),
+    ('third baseman',   '5'),
+    ('shortstop',       '6'),
+    ('catcher',         '2'),
+    ('pitcher',         '1'),
+]
+
+
+def _fielder_from_desc(description):
+    """Return the primary (putout) fielder position code from a play description."""
+    if not description:
+        return ''
+    dl = description.lower()
+    for kw, code in _POS_KEYWORDS:
+        if kw in dl:
+            return code
+    return ''
+
+
+def _fielder_seq_from_desc(description):
+    """Return a fielder position sequence (e.g. '6-3') from a groundout description."""
+    if not description:
+        return ''
+    dl = description.lower()
+    hits = []
+    for kw, code in _POS_KEYWORDS:
+        idx = dl.find(kw)
+        if idx >= 0:
+            hits.append((idx, code))
+    hits.sort()
+    if len(hits) >= 2:
+        return '-'.join(h[1] for h in hits[:2])
+    if hits:
+        return hits[0][1]
+    return ''
+
+
 def set_historical_mode(enabled=True):
     global _historical_mode
     _historical_mode = enabled
@@ -330,7 +373,9 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     # Normalize mid-game review/challenge states to In Progress
     if game_data.get('detailed_state') in ('Player challenge', 'Manager challenge'):
         game_data = dict(game_data)
-        game_data['last_play'] = 'P Challenge' if game_data['detailed_state'] == 'Player challenge' else 'M Challenge'
+        _prefix = 'P CHAL' if game_data['detailed_state'] == 'Player challenge' else 'M CHAL'
+        _chal_abbr = game_data.get('challenge_team_abbr', '')
+        game_data['last_play'] = f'{_prefix} {_chal_abbr}'.strip() if _chal_abbr else _prefix
         game_data['detailed_state'] = 'In Progress'
 
     # Delayed Start = game hasn't begun yet; treat like Pre-Game (show pitcher probables)
@@ -988,6 +1033,32 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             raw_play = (_sub_ev or game_data.get('last_review_result') or _last_play_val or '').replace('**', '').strip()
         # Abbreviate verbose play names so they fit cleanly without truncation
         play_display = _abbr_play(raw_play) if raw_play else ''
+        # Enhance bare out-type abbreviations with fielder position from description.
+        # Only applies when last_play came from the winProbability endpoint (e.g. "Flyout"→"FO").
+        # When the live-feed path already returned scorecard notation (e.g. "F7"), _abbr_play
+        # leaves it unchanged and it won't match any of the bare types below.
+        _lp_desc = game_data.get('last_play_description', '') or ''
+        if _lp_desc and not _sub_ev and not game_data.get('last_review_result'):
+            if play_display == 'FO':
+                _fp = _fielder_from_desc(_lp_desc)
+                if _fp:
+                    play_display = f'F{_fp}'
+            elif play_display == 'LO':
+                _fp = _fielder_from_desc(_lp_desc)
+                if _fp:
+                    play_display = f'L{_fp}'
+            elif play_display == 'PO':
+                _fp = _fielder_from_desc(_lp_desc)
+                if _fp:
+                    play_display = f'P{_fp}'
+            elif play_display == 'SF':
+                _fp = _fielder_from_desc(_lp_desc)
+                if _fp:
+                    play_display = f'SF{_fp}'
+            elif play_display == 'GO':
+                _fseq = _fielder_seq_from_desc(_lp_desc)
+                if _fseq:
+                    play_display = f'{_fseq} GO'
         # Bare fielder-sequence groundouts (e.g. "6-3", "5-3") get a GO suffix
         # so the play type is clear alongside the position sequence.
         if play_display and _re.match(r'^\d(-\d)+$', play_display):


### PR DESCRIPTION
## Summary

- **FO / LO / PO / GO** now show the fielder position alongside the abbreviation (e.g. `F7`, `L8`, `P2`, `6-3 GO`, `F8`) by parsing the play description from the winProbability endpoint
- **Player challenge** label changes from `P Challenge` → `P CHAL NYY` (includes abbreviation of the challenging team via `challengeTeamId` from the live feed)
- **Manager challenge** label changes from `M Challenge` → `M CHAL NYY`

## How it works

- `fetch_win_probability` now returns a 7th value — the raw play `description` string (e.g. `"Randy Arozarena flies out to left fielder Aaron Hicks."`)
- New helpers `_fielder_from_desc` / `_fielder_seq_from_desc` in `image_box.py` parse position keywords (`left fielder`→7, `shortstop`→6, etc.) in longest-first order to avoid partial matches
- For groundouts with two fielders in the description the sequence is extracted by string position order (earlier mention = first in sequence), giving `6-3`, `4-3`, `1-3`, etc.
- When the live-feed path (`scoreboard_live_details: true`) already provided proper scorecard notation (e.g. `F7`), `_abbr_play` leaves it unchanged and the description parser skips it (only activates on bare `FO`/`GO`/`LO`/`PO`/`SF`)
- `_fetch_challenge_team_abbr` makes a fields-limited live feed call only for challenge states, extracting `reviewDetails.challengeTeamId` from the current play

## Test plan

- [ ] Live flyout shows `F7` / `F8` / `F9` in header (not plain `FO`)
- [ ] Live groundout shows `6-3 GO` / `5-3 GO` etc. in header
- [ ] Pop out shows `P5`, `P2`, etc.
- [ ] Line out shows `L6`, `L8`, etc.
- [ ] Manager challenge shows `M CHAL NYY` (or whichever team)
- [ ] Player challenge shows `P CHAL NYY`
- [ ] No regression when `scoreboard_live_details: true` (live-feed path already returns `F7`)
- [ ] `scoreboard_generate.py` still works (uses `*_` wildcard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)