### PR TITLE
Implement full scorecard play notation for event header

### DIFF
--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -860,9 +860,11 @@ _EVENT_CODE_MAP = {
     'Field Error': 'E',
     'Catcher Interf': 'CI',
     'Batter Interference': 'BI',
+    'Interference': 'INT',
     'Runner Out': 'RO',
-    'Force Out': 'FO',
+    'Force Out': 'FOUT',
     'Field Out': 'FO',
+    'Infield Fly': 'IF',
 }
 
 
@@ -879,7 +881,7 @@ def _build_scorecard_notation(play):
     credits = play.get('credits', [])
 
     _SIMPLE = {
-        'Strikeout': 'K', 'Strikeout Looking': 'Kl', 'Strikeout Double Play': 'K',
+        'Strikeout': 'K', 'Strikeout Looking': 'Kl',
         'Walk': 'BB', 'Intent Walk': 'IBB', 'Hit By Pitch': 'HBP',
         'Runner Placed On Base': 'PR',
         'Single': '1B', 'Double': '2B', 'Triple': '3B', 'Home Run': 'HR',
@@ -891,11 +893,22 @@ def _build_scorecard_notation(play):
         return _SIMPLE[event]
 
     if event == 'Field Error':
+        assists = []
+        error_pos = ''
         for cr in credits:
-            if 'error' in (cr.get('credit') or '').lower():
-                pos = cr.get('position', {}).get('code', '')
-                if pos and pos.isdigit():
-                    return f'E{pos}'
+            credit = (cr.get('credit') or '').lower()
+            pos = cr.get('position', {}).get('code', '')
+            if not (pos and pos.isdigit()):
+                continue
+            if 'error' in credit:
+                error_pos = pos
+            elif 'assist' in credit:
+                if not assists or assists[-1] != pos:
+                    assists.append(pos)
+        if assists and error_pos:
+            return f'{"-".join(assists)} E{error_pos}'
+        if error_pos:
+            return f'E{error_pos}'
         return 'E'
 
     is_dp = 'double_play' in et or event in (
@@ -946,9 +959,17 @@ def _build_scorecard_notation(play):
         seq = '-'.join(pos_seq) if pos_seq else ''
         return f'{seq} FC{dp_suffix}' if seq else 'FC'
 
+    _is_cs  = event.startswith('Caught Stealing')
+    _is_pk  = event.startswith('Pickoff')
+    _is_sdp = event == 'Strikeout Double Play'
+
     # All out events: return fielder sequence from credits.
     if pos_seq:
-        return '-'.join(pos_seq) + dp_suffix
+        seq = '-'.join(pos_seq) + dp_suffix
+        if _is_cs:  return f'CS {seq}'
+        if _is_pk:  return f'PO {seq}'
+        if _is_sdp: return f'K {"-".join(pos_seq)}'
+        return seq
 
     # Credits absent — parse fielder positions from the play description.
     # Find every occurrence of each position keyword so repeated touches
@@ -972,14 +993,16 @@ def _build_scorecard_notation(play):
                 _start = _idx + 1
         _hits.sort()
         if _hits:
-            _seq = '-'.join(c for _, c in _hits[:5])
-            return _seq + dp_suffix
+            _seq = '-'.join(c for _, c in _hits[:5]) + dp_suffix
+            if _is_cs:  return f'CS {_seq}'
+            if _is_pk:  return f'PO {_seq}'
+            if _is_sdp: return f'K {_seq}'
+            return _seq
 
     # Fallbacks when credits are absent.
-    if event.startswith('Caught Stealing'):
-        return 'CS'
-    if event.startswith('Pickoff'):
-        return 'PK'
+    if _is_cs:  return 'CS'
+    if _is_pk:  return 'PO'
+    if _is_sdp: return 'K'
     return _EVENT_CODE_MAP.get(event, event[:3] if event else '')
 
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -54,9 +54,12 @@ _PLAY_ABBR = {
     'popout':           'PO',
     'pickoff':          'PK',
     'balk':             'BLK',
-    'force out':        'FO',
+    'forceout':         'FOUT',
+    'force out':        'FOUT',
     'field out':        'FO',
     'runner out':       'RO',
+    'infield fly':      'IF',
+    'interference':     'INT',
 }
 
 
@@ -776,7 +779,8 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         # In Progress (and any other live state not matched above)
         _inn_state = game_data.get('inningState') or ''
         _inn_label = {'Top': 'Top', 'Bottom': 'Bot', 'Middle': 'Mid', 'End': 'End'}.get(_inn_state, _inn_state[:3].capitalize() if _inn_state else '')
-        _inn_ord = game_data.get('currentInningOrdinal') or str(game_data.get('current_inning') or 1)
+        _inn_ord_raw = game_data.get('currentInningOrdinal') or str(game_data.get('current_inning') or 1)
+        _inn_ord = _re.sub(r'(?:st|nd|rd|th)$', '', _inn_ord_raw, flags=_re.IGNORECASE)
         game_state_str = (f'{_inn_label} {_inn_ord}').strip()
 
     # Pre-draw SWEEP ghost before header text so Final / logo sit on top
@@ -1066,25 +1070,36 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 _fp = _fielder_from_desc(_lp_desc)
                 if _fp:
                     play_display = f'SF{_fp}'
-            elif play_display == 'GO':
+            elif play_display in ('GO', 'FOUT'):
                 _fseq = _fielder_seq_from_desc(_lp_desc)
                 if _fseq:
-                    play_display = f'{_fseq} GO'
+                    play_display = f'{_fseq}'
             elif play_display in ('GDP', 'DP'):
                 _fseq = _fielder_seq_from_desc(_lp_desc)
                 if _fseq:
-                    play_display = f'{_fseq} GDP'
-        # Bare fielder-sequence groundouts (e.g. "6-3", "5-3", "3") get a GO suffix.
-        # The regex matches both single-fielder (unassisted "3") and multi-fielder sequences.
-        if play_display and _re.match(r'^\d(-\d)*$', play_display):
-            play_display = play_display + ' GO'
+                    play_display = f'{_fseq} DP'
+            elif play_display == 'TP':
+                _fseq = _fielder_seq_from_desc(_lp_desc)
+                if _fseq:
+                    play_display = f'{_fseq} TP'
+            elif play_display == 'CS':
+                _fseq = _fielder_seq_from_desc(_lp_desc)
+                if _fseq:
+                    play_display = f'CS {_fseq}'
+            elif play_display == 'PK':
+                _fseq = _fielder_seq_from_desc(_lp_desc)
+                play_display = f'PO {_fseq}' if _fseq else 'PO'
         # Prepend RBI count when the play drove in runs.
-        # Between innings the inning ended on an out — only tag-out plays (CS/PK/RO) can
+        # Between innings the inning ended on an out — only tag-out plays (CS/PO/RO) can
         # legitimately have an RBI credited on the same play as the final out.
+        # Errors never receive RBI credit.
         _rbi = int(game_data.get('last_play_rbi') or 0)
-        _TAG_OUT_PLAYS = {'CS', 'PK', 'RO'}
-        if _rbi > 0 and play_display and not _sub_ev and not game_data.get('last_review_result'):
-            if not _between_innings or play_display in _TAG_OUT_PLAYS:
+        _is_error = bool(play_display) and (
+            play_display.startswith('E') or ' E' in play_display
+        )
+        _is_tag_out = bool(play_display) and play_display.startswith(('CS', 'PO', 'RO'))
+        if _rbi > 0 and play_display and not _sub_ev and not game_data.get('last_review_result') and not _is_error:
+            if not _between_innings or _is_tag_out:
                 play_display = f'RBI {play_display}' if _rbi == 1 else f'{_rbi}R {play_display}'
         _header_right = _ser_content_left_x - 2 * s
 

--- a/tests/test_scoreboard_rules.py
+++ b/tests/test_scoreboard_rules.py
@@ -33,6 +33,7 @@ from generate_image import (
 )
 from image_utils import _format_player_name
 from image_box import _abbr_play, _fielder_from_desc, _fielder_seq_from_desc
+from game_detail_fetch import _build_scorecard_notation
 from fetch_games import _pick_tv_channel
 
 try:
@@ -2021,7 +2022,7 @@ class TestAbbrPlay:
         assert _abbr_play('Balk') == 'BLK'
 
     def test_force_out(self):
-        assert _abbr_play('Force Out') == 'FO'
+        assert _abbr_play('Force Out') == 'FOUT'
 
     def test_runner_out(self):
         assert _abbr_play('Runner Out') == 'RO'
@@ -2177,3 +2178,249 @@ class TestFielderSeqFromDesc:
         """max_pos=0 means no fielders are kept → empty string."""
         desc = 'Groundout to third baseman to first baseman'
         assert _fielder_seq_from_desc(desc, max_pos=0) == ''
+
+
+# ===========================================================================
+# 20. ABBR_PLAY — new play types added alongside scorecard notation overhaul
+# ===========================================================================
+
+class TestAbbrPlayNewTypes:
+    """_abbr_play() maps the new and corrected play-type tokens."""
+
+    def test_forceout_no_space(self):
+        """API sometimes returns 'Forceout' (one word) — must map to FOUT."""
+        assert _abbr_play('Forceout') == 'FOUT'
+
+    def test_force_out_with_space(self):
+        assert _abbr_play('Force Out') == 'FOUT'
+
+    def test_force_out_in_sentence(self):
+        assert _abbr_play('Forceout, shortstop to first baseman') == 'FOUT'
+
+    def test_forceout_distinct_from_flyout(self):
+        """Force out and flyout must produce different tokens."""
+        assert _abbr_play('Forceout') != _abbr_play('Flyout to left fielder')
+
+    def test_infield_fly(self):
+        assert _abbr_play('Infield Fly') == 'IF'
+
+    def test_infield_fly_in_sentence(self):
+        assert _abbr_play('Infield fly rule applied') == 'IF'
+
+    def test_interference(self):
+        assert _abbr_play('Interference') == 'INT'
+
+    def test_interference_in_sentence(self):
+        assert _abbr_play('Batter interference called') == 'INT'
+
+
+# ===========================================================================
+# 21. _build_scorecard_notation — live-feed credit-based scorecard notation
+# ===========================================================================
+
+def _make_play(event, event_type='', credits=None, description=''):
+    """Build a minimal play dict for _build_scorecard_notation."""
+    return {
+        'result': {
+            'event': event,
+            'eventType': event_type,
+            'description': description,
+        },
+        'credits': credits or [],
+    }
+
+
+def _credit(position_code, credit_type):
+    return {'position': {'code': position_code}, 'credit': credit_type}
+
+
+class TestBuildScorecardNotation:
+
+    # --- Ground outs (no suffix) ---
+
+    def test_groundout_6_3(self):
+        play = _make_play('Groundout', credits=[
+            _credit('6', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == '6-3'
+
+    def test_groundout_5_3(self):
+        play = _make_play('Groundout', credits=[
+            _credit('5', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == '5-3'
+
+    def test_unassisted_out_first_baseman(self):
+        play = _make_play('Groundout', credits=[_credit('3', 'f_putout')])
+        assert _build_scorecard_notation(play) == '3'
+
+    # --- Force out (same notation as ground out, no suffix) ---
+
+    def test_force_out_6_3(self):
+        play = _make_play('Force Out', credits=[
+            _credit('6', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == '6-3'
+
+    def test_force_out_no_suffix(self):
+        """Force out must never produce a FO/FOUT suffix."""
+        play = _make_play('Force Out', credits=[
+            _credit('4', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        result = _build_scorecard_notation(play)
+        assert result == '4-3'
+        assert 'FOUT' not in result
+        assert 'FO' not in result
+
+    # --- Flyout (F + fielder number, never confused with force out) ---
+
+    def test_flyout_left_field(self):
+        play = _make_play('Flyout', credits=[_credit('7', 'f_putout')])
+        assert _build_scorecard_notation(play) == 'F7'
+
+    def test_flyout_center_field(self):
+        play = _make_play('Flyout', credits=[_credit('8', 'f_putout')])
+        assert _build_scorecard_notation(play) == 'F8'
+
+    def test_flyout_distinct_from_force_out(self):
+        flyout = _make_play('Flyout', credits=[_credit('7', 'f_putout')])
+        force  = _make_play('Force Out', credits=[
+            _credit('6', 'f_assist'), _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(flyout) != _build_scorecard_notation(force)
+
+    # --- Double play ---
+
+    def test_gdp_6_4_3(self):
+        play = _make_play('Grounded Into DP', 'double_play', credits=[
+            _credit('6', 'f_assist'),
+            _credit('4', 'f_putout'),
+            _credit('4', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == '6-4-3 DP'
+
+    def test_dp_5_4_3(self):
+        play = _make_play('Double Play', 'double_play', credits=[
+            _credit('5', 'f_assist'),
+            _credit('4', 'f_putout'),
+            _credit('4', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == '5-4-3 DP'
+
+    # --- Triple play ---
+
+    def test_triple_play_5_4_3(self):
+        play = _make_play('Triple Play', 'triple_play', credits=[
+            _credit('5', 'f_assist'),
+            _credit('4', 'f_putout'),
+            _credit('4', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == '5-4-3 TP'
+
+    # --- Field error ---
+
+    def test_field_error_simple(self):
+        """No assist — plain E + position."""
+        play = _make_play('Field Error', credits=[_credit('6', 'f_error')])
+        assert _build_scorecard_notation(play) == 'E6'
+
+    def test_field_error_with_assist_sequence(self):
+        """Shortstop throws to first, first baseman drops it → 6 E3."""
+        play = _make_play('Field Error', credits=[
+            _credit('6', 'f_assist'),
+            _credit('3', 'f_error'),
+        ])
+        assert _build_scorecard_notation(play) == '6 E3'
+
+    def test_field_error_no_credits_returns_E(self):
+        play = _make_play('Field Error')
+        assert _build_scorecard_notation(play) == 'E'
+
+    # --- Caught stealing ---
+
+    def test_caught_stealing_2_6(self):
+        play = _make_play('Caught Stealing 2B', credits=[
+            _credit('2', 'f_assist'),
+            _credit('6', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == 'CS 2-6'
+
+    def test_caught_stealing_prefix_always_present(self):
+        play = _make_play('Caught Stealing 3B', credits=[
+            _credit('2', 'f_assist'),
+            _credit('5', 'f_putout'),
+        ])
+        result = _build_scorecard_notation(play)
+        assert result.startswith('CS ')
+
+    def test_caught_stealing_no_credits_returns_CS(self):
+        play = _make_play('Caught Stealing 2B')
+        assert _build_scorecard_notation(play) == 'CS'
+
+    # --- Pickoff ---
+
+    def test_pickoff_1_3(self):
+        play = _make_play('Pickoff 1B', credits=[
+            _credit('1', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert _build_scorecard_notation(play) == 'PO 1-3'
+
+    def test_pickoff_prefix_always_PO(self):
+        play = _make_play('Pickoff 2B', credits=[
+            _credit('1', 'f_assist'),
+            _credit('4', 'f_putout'),
+        ])
+        result = _build_scorecard_notation(play)
+        assert result.startswith('PO ')
+
+    def test_pickoff_no_credits_returns_PO(self):
+        play = _make_play('Pickoff 1B')
+        assert _build_scorecard_notation(play) == 'PO'
+
+    def test_pickoff_never_returns_PK(self):
+        play = _make_play('Pickoff 1B', credits=[
+            _credit('1', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        assert 'PK' not in _build_scorecard_notation(play)
+
+    # --- Strikeout double play (dropped third strike) ---
+
+    def test_strikeout_double_play_k_2_3(self):
+        """Catcher (2) throws to first (3) after dropped third strike."""
+        play = _make_play('Strikeout Double Play', 'strikeout', credits=[
+            _credit('2', 'f_assist'),
+            _credit('3', 'f_putout'),
+        ])
+        result = _build_scorecard_notation(play)
+        assert result == 'K 2-3'
+
+    def test_strikeout_double_play_no_credits(self):
+        play = _make_play('Strikeout Double Play')
+        assert _build_scorecard_notation(play) == 'K'
+
+    # --- Simple events unchanged ---
+
+    def test_strikeout_swinging(self):
+        play = _make_play('Strikeout')
+        assert _build_scorecard_notation(play) == 'K'
+
+    def test_strikeout_looking(self):
+        play = _make_play('Strikeout Looking')
+        assert _build_scorecard_notation(play) == 'Kl'
+
+    def test_home_run(self):
+        play = _make_play('Home Run')
+        assert _build_scorecard_notation(play) == 'HR'
+
+    def test_walk(self):
+        play = _make_play('Walk')
+        assert _build_scorecard_notation(play) == 'BB'


### PR DESCRIPTION
## Summary

- **Force out**: distinct `FOUT` token, never conflated with flyout (`FO`). Both `Forceout` and `Force Out` API spellings handled. Renders as fielder sequence only (e.g. `6-3`)
- **Ground out**: no trailing `GO` suffix — sequence only (`6-3`, not `6-3 GO`)
- **Double/triple play**: `6-4-3 DP` / `5-4-3 TP`
- **Caught stealing**: `CS 2-6` (prefix + fielder sequence from credits or description)
- **Pickoff**: `PO 1-3` (retired the `PK` token; now always renders as `PO`)
- **Strikeout double play** (dropped 3rd strike): `K 2-3`
- **Field error**: `E6` for a simple bobble; `6 E3` when an assist preceded the error
- **Infield fly**: `IF`; **Interference**: `INT`
- **RBI suppression**: errors never show RBI credit; between-inning tag-out check updated for new CS/PO prefixes
- **Inning ordinal**: suffix stripped (`7th` → `7`, `3rd` → `3`)

## Test plan

- [x] 35 new unit tests added across `TestAbbrPlayNewTypes` and `TestBuildScorecardNotation`
- [x] All 284 tests pass (`poetry run pytest`)
- [x] Force out / flyout distinctness verified by dedicated test
- [x] Pickoff verified to never return `PK`
- [x] Field error with and without assist sequence covered
- [x] Caught stealing and pickoff no-credits fallbacks tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)