### PR TITLE
Improve challenge/review display and backwards K rendering

### DIFF
--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -167,13 +167,21 @@ def _count_replay_challenges_used(plays, away_id, home_id):
     return away_used, home_used
 
 
-def _find_recent_review_result(plays):
-    """Return 'Call Overturned', 'Call Stands', or None if a review just resolved.
+def _find_recent_review_result(plays, away_id=None, home_id=None, away_abbr='', home_abbr=''):
+    """Return a formatted review result string, or None if no review just resolved.
 
-    A review is considered fresh if no pitch has been thrown since it completed:
-    - ABS challenge mid-AB: check currentPlay events from the end
-    - Play-ending challenge: check allPlays[-1] when currentPlay has no pitches yet
+    Format: 'OVERTURN {team}' or 'STANDS {team}' when team is known, else bare.
+    A review is considered fresh if no pitch has been thrown since it completed.
     """
+    def _fmt(rd):
+        result = 'OVERTURN' if rd.get('isOverturned') else 'STANDS'
+        cid = rd.get('challengeTeamId')
+        if cid and away_id and home_id:
+            abbr = away_abbr if cid == away_id else (home_abbr if cid == home_id else '')
+            if abbr:
+                return f'{result} {abbr}'
+        return result
+
     current_events = plays.get('currentPlay', {}).get('playEvents', [])
     current_has_pitches = any(ev.get('isPitch') for ev in current_events)
 
@@ -183,7 +191,7 @@ def _find_recent_review_result(plays):
             return None  # pitch thrown after review — stale
         rd = ev.get('reviewDetails')
         if rd and not rd.get('inProgress'):
-            return 'Call Overturned' if rd.get('isOverturned') else 'Call Stands'
+            return _fmt(rd)
 
     # If current AB has no pitches yet, check the last completed play
     if not current_has_pitches:
@@ -192,7 +200,7 @@ def _find_recent_review_result(plays):
             for ev in reversed(all_plays[-1].get('playEvents', [])):
                 rd = ev.get('reviewDetails')
                 if rd and not rd.get('inProgress'):
-                    return 'Call Overturned' if rd.get('isOverturned') else 'Call Stands'
+                    return _fmt(rd)
 
     return None
 
@@ -403,7 +411,13 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             'runner_first_number': runner_first_number,
             'runner_second_number': runner_second_number,
             'runner_third_number': runner_third_number,
-            'last_review_result': _find_recent_review_result(plays),
+            'last_review_result': _find_recent_review_result(
+                plays,
+                away_id=away_id,
+                home_id=home_id,
+                away_abbr=data.get('gameData', {}).get('teams', {}).get('away', {}).get('abbreviation', ''),
+                home_abbr=data.get('gameData', {}).get('teams', {}).get('home', {}).get('abbreviation', ''),
+            ),
             'last_play': live_last_play,
             'last_play_rbi': live_last_play_rbi,
             'last_play_inning': live_last_play_inning,

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -44,6 +44,8 @@ _PLAY_ABBR = {
     "fielder's choice": 'FC',
     'fielders choice':  'FC',
     'field error':      'E',
+    'call overturned':  'OVERTURN',
+    'call stands':      'STANDS',
     'flyout':           'FO',
     'fly out':          'FO',
     'lineout':          'LO',
@@ -128,11 +130,15 @@ def _draw_backwards_k(img, x, y, fnt):
     bbox = fnt.getbbox('K')
     ox, oy, ox2, oy2 = bbox
     gw, gh = ox2 - ox, oy2 - oy
-    pad = 1
-    tmp = Image.new('L', (gw + 2 * pad, gh + 2 * pad), 255)
+    pad = 2
+    # Render in mode '1' to match the main image — avoids anti-aliasing artifacts
+    tmp = Image.new('1', (gw + 2 * pad, gh + 2 * pad), 255)
     ImageDraw.Draw(tmp).text((-ox + pad, -oy + pad), 'K', font=fnt, fill=0)
     tmp = tmp.transpose(Image.FLIP_LEFT_RIGHT)
-    img.paste(0, (x + ox - pad, y + oy - pad), ImageOps.invert(tmp))
+    # Build mask: 255 where glyph is black, 0 where background is white
+    mask = ImageOps.invert(tmp.convert('L'))
+    px, py = x + ox - pad, y + oy - pad
+    img.paste(0, (px, py, px + gw + 2 * pad, py + gh + 2 * pad), mask)
 
 
 def set_historical_mode(enabled=True):
@@ -394,7 +400,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     # Normalize mid-game review/challenge states to In Progress
     if game_data.get('detailed_state') in ('Player challenge', 'Manager challenge'):
         game_data = dict(game_data)
-        _prefix = 'P CHAL' if game_data['detailed_state'] == 'Player challenge' else 'M CHAL'
+        _prefix = 'ABS CHAL' if game_data['detailed_state'] == 'Player challenge' else 'M CHAL'
         _chal_abbr = game_data.get('challenge_team_abbr', '')
         _chal_label = f'{_prefix} {_chal_abbr}'.strip() if _chal_abbr else _prefix
         # Write into sub_event so the challenge label has highest display priority


### PR DESCRIPTION
## Summary
- **ABS challenge**: label changed from `P CHAL ATL` → `ABS CHAL ATL`
- **Review results**: now include the challenging team abbreviation — `OVERTURN OAK` / `STANDS ATL` (sourced from `reviewDetails.challengeTeamId` matched against game team IDs)
- **Backwards K**: fixed rendering quality by using mode `'1'` temp image instead of `'L'`, eliminating anti-aliasing artifacts on the e-ink display
- **Legacy strings**: `'Call Overturned'` / `'Call Stands'` mapped in `_abbr_play` as a fallback for the win-probability code path

## Test plan
- [x] 284 `test_scoreboard_rules.py` tests pass
- [ ] Visually verify `ABS CHAL` label during an active ABS challenge
- [ ] Verify `OVERTURN {team}` / `STANDS {team}` appear after challenge resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)