### PR TITLE
Fix backwards K, PC outs circles, RBI format, trailing frame

### DIFF
--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -904,7 +904,16 @@ def _build_scorecard_notation(play):
         'Stolen Base 2B': 'SB', 'Stolen Base 3B': 'SB', 'Stolen Base Home': 'SB',
     }
     if event in _SIMPLE:
-        return _SIMPLE[event]
+        code = _SIMPLE[event]
+        # MLB API sometimes returns 'Strikeout' for both swinging and looking.
+        # Fall back to checking the last pitch call code: 'C' = called strike.
+        if code == 'K':
+            for pe in reversed(play.get('playEvents', [])):
+                if pe.get('isPitch'):
+                    if (pe.get('details', {}).get('call', {}).get('code') or '').upper() == 'C':
+                        code = 'Kl'
+                    break
+        return code
 
     if event == 'Field Error':
         assists = []

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -32,6 +32,7 @@ _PLAY_ABBR = {
     'intentional walk': 'IBB',
     'hit by pitch':     'HBP',
     'walk':             'BB',
+    'strikeout looking': 'Kl',
     'strikeout':        'K',
     'sac fly':          'SF',
     'sacrifice fly':    'SF',
@@ -1122,7 +1123,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         _is_tag_out = bool(play_display) and play_display.startswith(('CS', 'PO', 'RO'))
         if _rbi > 0 and play_display and not _sub_ev and not game_data.get('last_review_result') and not _is_error:
             if not _between_innings or _is_tag_out:
-                play_display = f'{_rbi}RBI {play_display}'
+                if play_display == 'HR':
+                    if _rbi >= 2:
+                        play_display = f'{_rbi}R HR'
+                    # solo HR: no prefix
+                elif _rbi == 1:
+                    play_display = f'RBI {play_display}'
+                else:
+                    play_display = f'{_rbi}RBI {play_display}'
         _header_right = _ser_content_left_x - 2 * s
 
         def _draw_play_right(text, fnt=None, y_off=4):
@@ -1493,9 +1501,12 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _sep_y = _name_y + 5 * s
             draw.line((start_x + 87 * s, _sep_y, _right_x, _sep_y), fill=0)
             _pc_outs = game_data.get('num_of_outs') or 0
-            _pc_outs_str = f'{_pc_outs} out{"s" if _pc_outs != 1 else ""}'
-            _pc_outs_w = int(font9.getlength(_pc_outs_str))
-            _pc_name_max = max(0, _max_name_w - _pc_outs_w - 3 * s)
+            # Three out circles (radius 4) right-aligned; 10px spacing between centers.
+            _pc_circ_r = 4 * s
+            _pc_circ_spacing = 10 * s
+            _pc_circ_y = _sep_y + _pc_circ_r + 3 * s
+            _pc_circ_total_w = 2 * _pc_circ_spacing + 2 * _pc_circ_r
+            _pc_name_max = max(0, _max_name_w - _pc_circ_total_w - 4 * s)
             if _pc_name:
                 _pit_fnt = font14
                 if int(font14.getlength(_pc_name)) > _pc_name_max:
@@ -1505,7 +1516,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                         while _pc_name and int(font9.getlength(_pc_name)) > _pc_name_max:
                             _pc_name = _pc_name[:-1]
                 draw.text((_left_x, _sep_y + 2 * s), _pc_name, font=_pit_fnt, fill=0)
-            draw.text((_right_x - _pc_outs_w, _sep_y + 4 * s), _pc_outs_str, font=font9, fill=0)
+            _pc_c3x = _right_x - _pc_circ_r
+            _pc_c2x = _pc_c3x - _pc_circ_spacing
+            _pc_c1x = _pc_c2x - _pc_circ_spacing
+            Himage = draw_circle(Himage, (_pc_c1x, _pc_circ_y), _pc_circ_r, _pc_outs >= 1, outline_width=2)
+            Himage = draw_circle(Himage, (_pc_c2x, _pc_circ_y), _pc_circ_r, _pc_outs >= 2, outline_width=2)
+            Himage = draw_circle(Himage, (_pc_c3x, _pc_circ_y), _pc_circ_r, _pc_outs >= 3, outline_width=2)
+            draw = ImageDraw.Draw(Himage)
         else:
             _hi_third = isinstance(game_data['runner_on_third'], str)
             _hi_second = isinstance(game_data['runner_on_second'], str)

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -1474,7 +1474,13 @@ def _generate_gif(date_str, gif_start, gif_end, output_path, interval_min, frame
     # --- Step 4b: Trailing final frame — all games in their end state ---
     # Use a target time well past all last plays so every game enters the Final
     # branch of _game_state_at_time (requires target > last_play + 5 min).
-    if all_last_plays:
+    # Skip when any game is still active (no last_play_utc) — generating a
+    # "final" frame with in-progress games would misrepresent the scoreboard.
+    _any_active = any(
+        game_timelines.get(str(g.get('game_pk', '')), {}).get('last_play_utc') is None
+        for g in base_games if str(g.get('game_pk', '')) in game_timelines
+    )
+    if all_last_plays and not _any_active:
         final_utc = max(all_last_plays) + timedelta(minutes=10)
         print("  [final ] rendering trailing end-state frame...", end=' ', flush=True)
         final_games = []


### PR DESCRIPTION
## Summary

- **Backwards K**: `_build_scorecard_notation` now checks the last pitch call code (`C` = called strike) as a fallback when the MLB API returns `Strikeout` instead of `Strikeout Looking`. Also added `'strikeout looking': 'Kl'` to `_PLAY_ABBR` for the win-probability fallback path. Together these cover all code paths (live feed + win prob endpoint).
- **RBI prefix format**: Split out the HR case (no prefix for solo, `NR` prefix for multi-run), and use `RBI` prefix for single-RBI plays instead of the old catch-all `NRBI` format.
- **Mid-inning PC display**: Replaced the text `"N outs"` with three graphical out circles (radius 4, right-aligned, outline-only = empty, filled = recorded out). Matches the visual language of the normal in-progress view.
- **Trailing final frame**: Skip the end-state GIF frame when any game still has no `last_play_utc` (avoids rendering in-progress games as Final).

## Test plan

- [ ] Watch a looking strikeout live — backwards K should appear in the game tile header
- [ ] Compare swinging strikeout header (regular K) vs looking strikeout (backwards K)
- [ ] Trigger a mid-inning pitching change — linescore grid + PC name in header + out circles (right side)
- [ ] Verify RBI formatting: solo HR (no prefix), 1-RBI single (RBI 1B), 3-RBI HR (3R HR)
- [ ] Run `auto_generate_video` when some games are final and some in-progress — confirm no trailing frame generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)