### PR TITLE
Fix backwards K detection across all API inconsistency paths (#118)

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -647,6 +647,11 @@ def parse_games(data, sport_id=None, config=None):
             if config.get('scoreboard_live_details', False):
                 from game_detail_fetch import fetch_scoreboard_live_extras
                 extras = fetch_scoreboard_live_extras(game_id, away_team_id, home_team_id)
+                # Don't clobber a valid last_play from the win-probability endpoint with None
+                # (can happen in the brief window between a play completing and allPlays updating).
+                if extras.get('last_play') is None:
+                    for _k in ('last_play', 'last_play_inning', 'last_play_is_top', 'last_play_rbi'):
+                        extras.pop(_k, None)
                 game_dict.update(extras)
                 # Between-innings PC: inningState may flip to Top/Bottom before the first pitch.
                 # Restore it so the break is still treated as active and fetch_between_inning_info runs.
@@ -670,6 +675,10 @@ def parse_games(data, sport_id=None, config=None):
                 from game_detail_fetch import fetch_between_inning_info
                 bi_info = fetch_between_inning_info(game_id, game_dict['inningState'])
                 live_calls_made += 1
+                # Don't clobber an existing last_play with None if between-inning fetch didn't find one.
+                if bi_info.get('last_play') is None:
+                    for _k in ('last_play', 'last_play_inning', 'last_play_is_top'):
+                        bi_info.pop(_k, None)
                 game_dict.update(bi_info)
         elif _is_featured and game_dict.get('detailed_state') == 'Delayed' and (game_dict.get('current_inning') or 0) > 0 and live_calls_made < max_live_calls:
             # Fetch upcoming batters/pitcher so the delay screen can show who's due up

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -913,6 +913,11 @@ def _build_scorecard_notation(play):
                     if (pe.get('details', {}).get('call', {}).get('code') or '').upper() == 'C':
                         code = 'Kl'
                     break
+            # Final fallback: check the play description when pitch data is absent or incomplete.
+            if code == 'K':
+                _desc = (result.get('description') or '').lower()
+                if 'called out on strikes' in _desc or 'strikes out looking' in _desc:
+                    code = 'Kl'
         return code
 
     if event == 'Field Error':

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1112,6 +1112,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                 _ep = _fielder_from_desc(_lp_desc)
                 if _ep:
                     play_display = f'E{_ep}'
+            elif play_display == 'K':
+                # Win-probability endpoint sometimes returns 'Strikeout' for called strikeouts.
+                # When the description says "called out on strikes" / "strikes out looking",
+                # upgrade to 'Kl' so the backwards K is rendered.
+                _dl = _lp_desc.lower()
+                if 'called out on strikes' in _dl or 'strikes out looking' in _dl:
+                    play_display = 'Kl'
         # Prepend RBI count when the play drove in runs.
         # Between innings the inning ended on an out — only tag-out plays (CS/PO/RO) can
         # legitimately have an RBI credited on the same play as the final out.

--- a/tests/test_scoreboard_rules.py
+++ b/tests/test_scoreboard_rules.py
@@ -1931,6 +1931,17 @@ class TestAbbrPlay:
     def test_strikeout_case_insensitive(self):
         assert _abbr_play('STRIKEOUT') == 'K'
 
+    def test_strikeout_looking(self):
+        assert _abbr_play('Strikeout Looking') == 'Kl'
+
+    def test_strikeout_looking_before_strikeout(self):
+        """'strikeout looking' must be checked before 'strikeout' to avoid early match."""
+        assert _abbr_play('Strikeout Looking') == 'Kl'
+
+    def test_kl_passthrough(self):
+        """'Kl' (already scorecard notation from live feed) passes through unchanged."""
+        assert _abbr_play('Kl') == 'Kl'
+
     def test_home_run(self):
         assert _abbr_play('Home Run') == 'HR'
 
@@ -2416,6 +2427,55 @@ class TestBuildScorecardNotation:
     def test_strikeout_looking(self):
         play = _make_play('Strikeout Looking')
         assert _build_scorecard_notation(play) == 'Kl'
+
+    def test_strikeout_looking_via_call_code(self):
+        """event='Strikeout' + last pitch call code 'C' → 'Kl'."""
+        play = {
+            'result': {'event': 'Strikeout', 'eventType': 'strikeout'},
+            'credits': [],
+            'playEvents': [
+                {'isPitch': True, 'details': {'call': {'code': 'B'}}},
+                {'isPitch': True, 'details': {'call': {'code': 'S'}}},
+                {'isPitch': True, 'details': {'call': {'code': 'C'}}},
+            ],
+        }
+        assert _build_scorecard_notation(play) == 'Kl'
+
+    def test_strikeout_looking_via_description(self):
+        """event='Strikeout' + 'called out on strikes' description → 'Kl' even with no pitch data."""
+        play = {
+            'result': {
+                'event': 'Strikeout',
+                'description': 'Aaron Judge called out on strikes.',
+            },
+            'credits': [],
+            'playEvents': [],
+        }
+        assert _build_scorecard_notation(play) == 'Kl'
+
+    def test_strikeout_looking_via_description_strikes_out_looking(self):
+        """event='Strikeout' + 'strikes out looking' description → 'Kl'."""
+        play = {
+            'result': {
+                'event': 'Strikeout',
+                'description': 'Ronald Acuña Jr. strikes out looking.',
+            },
+            'credits': [],
+            'playEvents': [],
+        }
+        assert _build_scorecard_notation(play) == 'Kl'
+
+    def test_strikeout_swinging_description_not_upgraded(self):
+        """event='Strikeout' + 'strikes out swinging' description stays 'K'."""
+        play = {
+            'result': {
+                'event': 'Strikeout',
+                'description': 'Aaron Judge strikes out swinging.',
+            },
+            'credits': [],
+            'playEvents': [],
+        }
+        assert _build_scorecard_notation(play) == 'K'
 
     def test_home_run(self):
         play = _make_play('Home Run')


### PR DESCRIPTION
Three independent failure modes prevented looking strikeouts from displaying as backwards K in the play header:

1. _build_scorecard_notation: add description-based fallback when playEvents call codes are absent or incomplete. If the play result description contains "called out on strikes" or "strikes out looking", return 'Kl' regardless of pitch data availability.

2. fetch_games.py: don't overwrite a valid last_play from the win- probability endpoint with None from live extras or between-inning info. Occurs during the brief API timing gap after a play completes but before allPlays reflects it as isComplete.

3. image_box.py: when play_display=='K' and the win-probability description says "called out on strikes"/"strikes out looking", upgrade to 'Kl' as a rendering-level safety net.

Add tests covering all three detection paths (call code, description "called out on strikes", description "strikes out looking") and verify swinging strikeouts are not upgraded.