### PR TITLE
Add batting team indicator dot and GIF runner state tracking

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1639,6 +1639,18 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         if game_data.get('home_team_is_winner'):
             draw.text((start_x + 7 * s, start_y + 55 * s), home_team_name, font=font24, fill=0)
 
+    # Batting team indicator: ▲ left of away logo row when top half (away batting),
+    # ▼ left of home logo row when bottom half (home batting). Live games only.
+    _bi_state = game_data.get('inningState') or ''
+    if game_data['detailed_state'] == 'In Progress' and _bi_state in ('Top', 'Bottom'):
+        _r = 4 * s
+        _bi_cx = start_x + _r - 6
+        if _bi_state == 'Top':
+            _bi_cy = start_y + 25 * s + 14 * s  # vertical center of away logo row
+        else:
+            _bi_cy = start_y + 55 * s + 14 * s  # vertical center of home logo row
+        draw.ellipse([_bi_cx - _r, _bi_cy - _r, _bi_cx + _r, _bi_cy + _r], fill=0)
+
     # Bold-offset score for winner (both modes)
     if game_data.get('away_team_is_winner'):
         draw.text((start_x + 67 * s + check_if_two_chars(away_runs), start_y + 25 * s), away_runs, font=font24, fill=0)

--- a/src/scoreboard_generate.py
+++ b/src/scoreboard_generate.py
@@ -822,9 +822,10 @@ def _fetch_game_timeline(game_pk):
     except Exception:
         pass
 
-    # Running score: score after last completed play (used for pitch events mid-at-bat)
+    # Running score/runners: state after last completed play (used for pitch events mid-at-bat)
     running_away = 0
     running_home = 0
+    running_runners = {'first': None, 'second': None, 'third': None}
     cumulative_last_play      = None  # last non-substitution event name seen so far
     cumulative_last_play_inn  = None  # inning of that event
     cumulative_last_play_top  = None  # True if top half, False if bottom
@@ -853,6 +854,8 @@ def _fetch_game_timeline(game_pk):
         at_bat_pitcher   = matchup.get('pitcher', {}).get('fullName') or ''
         at_bat_batter    = matchup.get('batter',  {}).get('fullName') or ''
         at_bat_batter_id = matchup.get('batter',  {}).get('id')
+        # Runners at START of this at-bat = running_runners before the play completes
+        at_bat_runners = dict(running_runners)
 
         for ev in play.get('playEvents', []):
             # ABS challenge tracking
@@ -874,16 +877,19 @@ def _fetch_game_timeline(game_pk):
                 continue
             count = ev.get('count', {})
             pitch_events.append({
-                'time':        ev_time,
-                'balls':       count.get('balls', 0) or 0,
-                'strikes':     count.get('strikes', 0) or 0,
-                'outs':        count.get('outs', about.get('outs', 0)) or 0,
-                'inning':      inning,
-                'half_inning': half_inning,
-                'away_score':  at_bat_away,
-                'home_score':  at_bat_home,
-                'pitcher':     at_bat_pitcher,
-                'batter':      at_bat_batter,
+                'time':             ev_time,
+                'balls':            count.get('balls', 0) or 0,
+                'strikes':          count.get('strikes', 0) or 0,
+                'outs':             count.get('outs', about.get('outs', 0)) or 0,
+                'inning':           inning,
+                'half_inning':      half_inning,
+                'away_score':       at_bat_away,
+                'home_score':       at_bat_home,
+                'pitcher':          at_bat_pitcher,
+                'batter':           at_bat_batter,
+                'runner_on_first':  at_bat_runners['first'],
+                'runner_on_second': at_bat_runners['second'],
+                'runner_on_third':  at_bat_runners['third'],
             })
 
         # --- Completed-play timeline (for score/inning snapshots) ---
@@ -900,17 +906,25 @@ def _fetch_game_timeline(game_pk):
         away_score = result.get('awayScore', 0) or 0
         home_score = result.get('homeScore', 0) or 0
 
+        post_first  = (matchup.get('postOnFirst')  or {}).get('fullName') or None
+        post_second = (matchup.get('postOnSecond') or {}).get('fullName') or None
+        post_third  = (matchup.get('postOnThird')  or {}).get('fullName') or None
+        running_runners = {'first': post_first, 'second': post_second, 'third': post_third}
+
         timeline.append({
-            'end_time':    end_time,
-            'away_score':  away_score,
-            'home_score':  home_score,
-            'inning':      inning,
-            'half_inning': half_inning,
-            'outs':        about.get('outs', 0),
-            'outs_after':  play.get('count', {}).get('outs', 0) or 0,
-            'pitcher':     at_bat_pitcher,
-            'batter':      at_bat_batter,
-            'batter_id':   at_bat_batter_id,
+            'end_time':         end_time,
+            'away_score':       away_score,
+            'home_score':       home_score,
+            'inning':           inning,
+            'half_inning':      half_inning,
+            'outs':             about.get('outs', 0),
+            'outs_after':       play.get('count', {}).get('outs', 0) or 0,
+            'pitcher':          at_bat_pitcher,
+            'batter':           at_bat_batter,
+            'batter_id':        at_bat_batter_id,
+            'runner_on_first':  post_first,
+            'runner_on_second': post_second,
+            'runner_on_third':  post_third,
         })
 
         if away_chal_used > 0 or home_chal_used > 0:
@@ -1237,9 +1251,20 @@ def _game_state_at_time(base_game, tl, target_utc):
         state['last_play_is_top']      = None
         state['last_play_description'] = ''
 
-    state.update({
-        'runner_on_first': None, 'runner_on_second': None, 'runner_on_third': None,
-    })
+    # Runner state: use last_event (mid-at-bat) or last_play (between at-bats).
+    # During an inning break (outs_after >= 3) bases are empty.
+    if last_event and not between_plays:
+        state['runner_on_first']  = last_event.get('runner_on_first')
+        state['runner_on_second'] = last_event.get('runner_on_second')
+        state['runner_on_third']  = last_event.get('runner_on_third')
+    elif between_plays and last_play and last_play.get('outs_after', 0) < 3:
+        state['runner_on_first']  = last_play.get('runner_on_first')
+        state['runner_on_second'] = last_play.get('runner_on_second')
+        state['runner_on_third']  = last_play.get('runner_on_third')
+    else:
+        state['runner_on_first']  = None
+        state['runner_on_second'] = None
+        state['runner_on_third']  = None
 
     # ABS challenges: replay cumulative state up to target_utc.
     # Default to full allotment when no challenges have been used yet.


### PR DESCRIPTION
## Summary
- Draws a filled circle beside the batting team's logo row during live play (▲ side = top/away batting, ▼ side = bottom/home batting); automatically hidden during inning breaks (Middle/End inning state)
- Tracks runner state (postOnFirst/Second/Third) per pitch event and per completed play in the GIF generator so base diamonds are populated correctly mid-at-bat and between plate appearances

## Test plan
- [ ] Generate a GIF for a game with runners on base mid-inning and confirm bases populate correctly
- [ ] Verify live scoreboard shows the indicator dot beside the correct team row during active innings
- [ ] Confirm the dot disappears during between-inning breaks (Middle/End)
- [ ] Confirm no indicator shown for Final/Scheduled/Pre-Game states

🤖 Generated with [Claude Code](https://claude.com/claude-code)