### PR TITLE
Invert header on stolen base events

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1869,6 +1869,15 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
+    # Invert header for stolen base events
+    _sb_event = (
+        is_game_started and not is_game_finished and not _between_innings and not _pitching_change and
+        'stolen base' in (game_data.get('last_play') or '').lower()
+    )
+    if _sb_event:
+        header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
+        Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
+
     # Invert header for mid-inning pitching changes to draw attention
     if _pitching_change:
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))


### PR DESCRIPTION
## Summary
- Stolen bases already rendered `SB` right-aligned in the header via the existing play-event path.
- Now also inverts the header (white-on-black) when `last_play` contains a stolen base, matching the visual treatment of run-scoring plays and pitching changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)