### PR TITLE
Invert header during challenges and on review results

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1878,6 +1878,20 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
+    # Invert header during an active challenge (ABS or manager) and after review results
+    _chal_sub = (game_data.get('sub_event') or '')
+    _challenge_active = (
+        is_game_started and not is_game_finished and
+        (_chal_sub.startswith('ABS CHAL') or _chal_sub.startswith('M CHAL'))
+    )
+    _review_result_active = (
+        is_game_started and not is_game_finished and
+        bool(game_data.get('last_review_result'))
+    )
+    if _challenge_active or _review_result_active:
+        header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
+        Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
+
     # Invert header for mid-inning pitching changes to draw attention
     if _pitching_change:
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))


### PR DESCRIPTION
## Summary
- Active challenges (ABS or manager) already display the challenge label in the header — now also inverts the header white-on-black to call it out.
- Review results (OVERTURN / STANDS) already displayed via `last_review_result` — now also inverts the header.
- Both triggers are independent so they stack cleanly with the existing SB, P.CHG, and run-score inversions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)