### PR TITLE
Show OVERTURN/STANDS as text only, no header inversion

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1878,17 +1878,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
-    # Invert header during an active challenge (ABS or manager) and after review results
+    # Invert header during an active challenge (ABS or manager) only — review result shows text only, no invert
     _chal_sub = (game_data.get('sub_event') or '')
     _challenge_active = (
         is_game_started and not is_game_finished and
         (_chal_sub.startswith('ABS CHAL') or _chal_sub.startswith('M CHAL'))
     )
-    _review_result_active = (
-        is_game_started and not is_game_finished and
-        bool(game_data.get('last_review_result'))
-    )
-    if _challenge_active or _review_result_active:
+    if _challenge_active:
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 


### PR DESCRIPTION
## Summary
- Review results (OVERTURN / STANDS) now display as plain text in the header only — no white-on-black inversion.
- The inverted header is kept for the active challenge state (while the review is ongoing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)