### PR TITLE
Drop misleading '0/X' series label on postponed games

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1183,16 +1183,12 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         _ppd_is_tied = 'tied' in _ppd_sr.lower()
         _ppd_sw = game_data.get('series_wins') or 0
         _ppd_sl = game_data.get('series_losses') or 0
-        _ppd_total = game_data.get('series_total_games') or 1
         _rx = start_x + horizonta_len - 2 * s
 
         if (_ppd_sw + _ppd_sl) == 0:
-            # Series hasn't started — show "0/X"
-            _ppd_score = f'0/{_ppd_total}'
-            _ppd_score_w = int(font11.getlength(_ppd_score))
-            _ppd_score_x = _rx - _ppd_score_w
-            draw.text((_ppd_score_x, start_y + 5 * s), _ppd_score, font=font11, fill=0)
-            _ser_content_left_x = _ppd_score_x
+            # Series hasn't started (or API returned stale 0-0 data for a mid-series PPD).
+            # Don't show "0/X" — the count is unreliable; teams may have played yesterday.
+            pass
         elif not _ppd_is_tied and len(_ppd_parts) >= 3 and _ppd_parts[1] == 'leads':
             _ppd_score = _ppd_parts[2]
             _ppd_leader_str = _ppd_parts[0].upper()


### PR DESCRIPTION
## Summary
- The MLB API often returns `series_wins=0 / series_losses=0` for postponed games even mid-series — e.g. TB @ NYY today showed **0/4** in the header despite having played yesterday
- Removed the `0/X` display entirely for the no-games-recorded case; show nothing rather than a count that may be stale or incorrect
- Also removed the now-unused `_ppd_total` variable

## Test plan
- [ ] Postponed game where series truly hasn't started: header should show no series indicator (acceptable — better than wrong data)
- [ ] Postponed game mid-series with a leader (e.g. DET @ BAL "BAL leads 1-0"): still shows logo + score correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)