### PR TITLE
Hide tomorrow preview until final_linescore_minutes expires (#131)

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1638,19 +1638,19 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     end_y = start_y + vertical_len + 20 * s
     draw.line((start_x, start_y + vertical_len + 20 * s, end_x, end_y), fill=0)
 
-    # Next game preview — shown in the win-prob strip for Final games 1+ hour after end
+    # Next game preview — shown in the win-prob strip for Final games after final_linescore_minutes expires
     if _game_is_final and not _historical_mode:
-        _one_hour = False
+        _window_expired = False
         if _end_utc_str:
             try:
                 _end_utc = pytz.utc.localize(_datetime.strptime(_end_utc_str[:19], '%Y-%m-%dT%H:%M:%S'))
-                _one_hour = (_datetime.now(pytz.utc) - _end_utc).total_seconds() >= 3600
+                _window_expired = (_datetime.now(pytz.utc) - _end_utc).total_seconds() >= _FINAL_LINESCORE_SECS
             except Exception:
                 pass
-        if not _one_hour:
+        if not _window_expired:
             _fts = _get_or_set_final_time(game_data.get('game_pk'))
-            _one_hour = (_time.time() - _fts) >= 3600
-        if _one_hour:
+            _window_expired = (_time.time() - _fts) >= _FINAL_LINESCORE_SECS
+        if _window_expired:
             _tmrw = _load_tomorrow_games()
             if _tmrw and _tmrw.get('games'):
                 # Compute how far left the "Game X" doubleheader label extends so the


### PR DESCRIPTION
## Summary
- The next-game (tomorrow) preview in the win-prob strip was gated on a hardcoded 1-hour (3600 s) threshold, completely independent of `final_linescore_minutes`
- Now it uses the same `_FINAL_LINESCORE_SECS` value already computed from config, so the preview stays hidden for the full configured window (e.g. 160 min)
- Renamed `_one_hour` → `_window_expired` to reflect the new semantics

## Test plan
- [ ] Set `final_linescore_minutes: 10` and verify the tomorrow preview does NOT appear for at least 10 minutes after a game goes Final
- [ ] After the window expires, confirm the tomorrow preview appears normally in the win-prob strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)