### PR TITLE
Fix tomorrow's games showing instead of today's in morning window

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -414,9 +414,9 @@ def _load_tomorrow_games():
 
     try:
         data = load_json_file('tomorrow_games.json') or {}
-        if data.get('date') in (today, tomorrow) and data.get('games') is not None:
+        if data.get('date') == _target and data.get('games') is not None:
             return data
-        # Cache is missing, wrong date, or empty — fetch for the right target date
+        # Cache is missing or has wrong date — fetch for the right target date
         from fetch_games import fetch_tomorrow_games
         fetch_tomorrow_games(for_date=_target)
         data = load_json_file('tomorrow_games.json') or {}


### PR DESCRIPTION
## Root cause

`_load_tomorrow_games()` used `data.get('date') in (today, tomorrow)` to validate the cache. In the morning window, if `tomorrow_games.json` still held the previous evening's cache (`date = May 29`), this matched `tomorrow` and returned the wrong schedule — one day too far ahead.

## Fix

Change the acceptance check to `data.get('date') == _target`, where `_target` is `today` before 9am and `tomorrow` at/after 9am. If the cached date doesn't match exactly, we fetch fresh data for the correct target date. No stale evening cache can slip through.

## Test plan
- [ ] Morning run (<9am): bottom strip of yesterday's Final boxes shows today's games (not tomorrow's)
- [ ] Evening run (≥9am): bottom strip shows tomorrow's upcoming games as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)