### PR TITLE
Make morning cutoff hour configurable (morning_end)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,9 +54,11 @@ night_mode: true
 night_start: 2   # midnight (hour in 24h, local timezone)
 night_end: 7     # 7am
 
-# Morning alternating mode: between 7am and 9am, alternate between yesterday's results and
-# today's schedule every 5 minutes. Before 7am always shows yesterday; after 9am always today.
+# Morning alternating mode: between night_end and morning_end, alternate between yesterday's
+# results and today's schedule every 5 minutes. Before night_end always shows yesterday;
+# at/after morning_end always shows today.
 morning_alternate_games: true
+morning_end: 9   # hour (24h) when "yesterday" mode ends and today's games take over
 
 
 # Team emoji overrides: display emoji instead of logo for these teams

--- a/main.py
+++ b/main.py
@@ -472,10 +472,12 @@ Examples:
     else:
         tz = config.get('timezone', 'America/Chicago')
         _now = datetime.now(pytz.timezone(tz))
-        if _now.hour >= 9:
+        _morning_end  = config.get('morning_end', 9)
+        _morning_start = config.get('night_end', 7)
+        if _now.hour >= _morning_end:
             date_str = _now.date().strftime('%Y-%m-%d')
             print(f"Using today's date: {date_str}")
-        elif _now.hour >= 7 and config.get('morning_alternate_games', True):
+        elif _now.hour >= _morning_start and config.get('morning_alternate_games', True):
             # 7am–9am: alternate between yesterday and today every 5 minutes
             _pre9am = True
             _morning_block = (_now.hour * 60 + _now.minute) // 5

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -402,12 +402,13 @@ def _load_tomorrow_games():
     today    = _date.today().strftime('%Y-%m-%d')
     tomorrow = (_date.today() + _td(days=1)).strftime('%Y-%m-%d')
 
-    # Determine whether we're in the morning window (before 9am local)
+    # Determine whether we're in the morning window (before morning_end local)
     try:
         _cfg = load_yaml_file('config.yaml')
         _tz_str = _cfg.get('timezone', 'America/Chicago')
+        _morning_end = _cfg.get('morning_end', 9)
         _now_local = _dt.now(pytz.timezone(_tz_str))
-        _is_morning = _now_local.hour < 9
+        _is_morning = _now_local.hour < _morning_end
     except Exception:
         _is_morning = False
     _target = today if _is_morning else tomorrow


### PR DESCRIPTION
## Summary

The 9am threshold that controls when the display switches from "yesterday's results" mode to "today's games" mode was hard-coded in two places. Similarly, the 7am lower bound of the morning alternating window was also hard-coded even though `night_end: 7` already exists in config for exactly that purpose.

- **`config/config.yaml`**: Added `morning_end: 9` — hour (24h) when yesterday-mode ends and today's games take over. Updated the comment to reference both `night_end` and `morning_end` instead of the literal times.
- **`main.py`**: Reads `morning_end` and `night_end` from config instead of hard-coded `9` and `7`.
- **`image_box._load_tomorrow_games`**: Reads `morning_end` from config instead of hard-coded `9` for the morning-window detection that controls whether to fetch today's or tomorrow's schedule.

## Test plan
- [ ] Default (`morning_end: 9`) behaves identically to before
- [ ] Changing `morning_end: 10` in config shifts the cutoff to 10am — yesterday's Final boxes show today's games until 10am instead of 9am

🤖 Generated with [Claude Code](https://claude.com/claude-code)