### PR TITLE
Live fullscreen v4: B/S/O, last event, pitcher/batter + preview strip polish

### DIFF
--- a/main.py
+++ b/main.py
@@ -539,15 +539,21 @@ Examples:
         config['_featured_abbr'] = config.get('primary', '')
     fetch_scoreboard_for_date(date_str, sport_id, config)
 
-    # 6b. Fetch tomorrow's schedule for next-game preview (cached, refreshes hourly)
+    # 6b. Fetch the "next-day" schedule for next-game preview strips (cached, refreshes hourly).
+    # In morning mode (showing yesterday's games) the "next" day relative to last night is
+    # today, so we fetch today instead of actual tomorrow — keeping image_box._load_tomorrow_games
+    # in sync and avoiding a silent cache-miss every render.
     if not args.date:
         import time as _tm_mod
         _tmrw_cache = load_json_file('tomorrow_games.json') or {}
-        _tmrw_target = (datetime.now().date() + timedelta(days=1)).strftime('%Y-%m-%d')
+        _today_str  = datetime.now().date().strftime('%Y-%m-%d')
+        _tmrw_str   = (datetime.now().date() + timedelta(days=1)).strftime('%Y-%m-%d')
+        _tmrw_target = _today_str if _pre9am else _tmrw_str
+        _for_date_arg = _today_str if _pre9am else None   # None → fetch_tomorrow_games uses tomorrow
         _tmrw_age = _tm_mod.time() - _tmrw_cache.get('fetched_at', 0)
         if _tmrw_cache.get('date') != _tmrw_target or _tmrw_age > 3600:
             try:
-                fetch_tomorrow_games(config)
+                fetch_tomorrow_games(config, for_date=_for_date_arg)
             except Exception as _e:
                 print(f"Warning: fetch_tomorrow_games failed: {_e}")
 

--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -794,19 +794,26 @@ def parse_games(data, sport_id=None, config=None):
     save_off_results({'team_abbreviation': team_abbreviations}, 'teams')
 
 
-def fetch_tomorrow_games(config=None):
-    """Fetch tomorrow's schedule and save minimal data to data/tomorrow_games.json."""
+def fetch_tomorrow_games(config=None, for_date=None):
+    """Fetch a day's schedule and save minimal data to data/tomorrow_games.json.
+
+    Args:
+        config: Config dict (loaded from config.yaml if None).
+        for_date: Date string 'YYYY-MM-DD' to fetch. Defaults to tomorrow when None.
+                  Pass today's date in morning mode to populate the preview strips
+                  on yesterday's Final game boxes with today's upcoming schedule.
+    """
     import time as _tm
     if config is None:
         config = load_config()
 
     from datetime import date as _date
-    tomorrow = (_date.today() + timedelta(days=1)).strftime('%Y-%m-%d')
+    target_date = for_date or (_date.today() + timedelta(days=1)).strftime('%Y-%m-%d')
 
     sport_id_priority = config.get('sport_id_priority', [1])
     sport_id = None
     for sid in sport_id_priority:
-        cnt = check_games_for_sport(tomorrow, sid)
+        cnt = check_games_for_sport(target_date, sid)
         if cnt > 0:
             sport_id = sid
             break
@@ -815,18 +822,18 @@ def fetch_tomorrow_games(config=None):
 
     endpoint = (
         f'https://statsapi.mlb.com/api/v1/schedule?'
-        f'startDate={tomorrow}&endDate={tomorrow}&sportId={sport_id}'
+        f'startDate={target_date}&endDate={target_date}&sportId={sport_id}'
         f'&hydrate=team'
     )
     try:
         resp = requests.get(endpoint, timeout=10)
         if resp.status_code != 200:
-            print(f"Warning: tomorrow's schedule fetch returned {resp.status_code}")
+            print(f"Warning: schedule fetch for {target_date} returned {resp.status_code}")
             return
         data = resp.json()
         game_dates = data.get('dates', [])
         if not game_dates:
-            save_off_results({'date': tomorrow, 'fetched_at': _tm.time(), 'games': []}, 'tomorrow_games')
+            save_off_results({'date': target_date, 'fetched_at': _tm.time(), 'games': []}, 'tomorrow_games')
             return
 
         games_raw = game_dates[0].get('games', [])
@@ -847,10 +854,10 @@ def fetch_tomorrow_games(config=None):
                 'game_pk': g.get('gamePk'),
             })
 
-        save_off_results({'date': tomorrow, 'fetched_at': _tm.time(), 'games': games}, 'tomorrow_games')
-        print(f"✓ Tomorrow's games ({len(games)}) written to data/tomorrow_games.json")
+        save_off_results({'date': target_date, 'fetched_at': _tm.time(), 'games': games}, 'tomorrow_games')
+        print(f"✓ Schedule for {target_date} ({len(games)} games) written to data/tomorrow_games.json")
     except Exception as e:
-        print(f"Warning: failed to fetch tomorrow's games: {e}")
+        print(f"Warning: failed to fetch schedule for {target_date}: {e}")
 
 
 def fetch_scoreboard_for_date(date, sport_id=None, config=None):

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -15,13 +15,14 @@ from image_utils import (
     normalize_dict, standings_dict,
     draw_diamond, draw_circle, check_if_two_chars,
     _last_name, _pitcher_line, _clean_venue_name, _is_game_effectively_over,
+    _format_player_name,
 )
 from image_standings import (
     _WC_STRIP_H,
     derive_wildcard_from_standings, draw_wildcard_header, draw_standings_sidebar,
     draw_standings_sidebar_fullscreen,
 )
-from image_box import draw_box
+from image_box import draw_box, _abbr_play, _draw_linescore_grid
 
 # ---------------------------------------------------------------------------
 # logging.basicConfig(level=logging.DEBUG)
@@ -845,6 +846,396 @@ def _find_featured_game(game_state_data, team_data, primary_abbr):
     return primary_games[-1]
 
 
+def draw_live_fullscreen_game(game_data, team_data, config=None):
+    """Full 800×480 canvas for a live (In Progress) featured game.
+
+    Called from draw_featured_game_fullscreen when the featured game is
+    actively In Progress (any sub-state: active pitch, between innings, or
+    pitching change).  No standings sidebars — the game fills the entire
+    display.
+
+    Layout (top → bottom)
+    ---------------------
+    y=0..29    Header strip  : inning label | last play | matchup + date
+    y=30..47   R / H / E column labels
+    y=48..146  Away team row : logo  abbr  R  H  E
+    y=147..245 Home team row : logo  abbr  R  H  E
+    y=246      Divider line
+    y=247..479 Situation (233 px):
+        Active pitch    : bases diamond (left)  +  B/S/O circles (right)
+                          pitcher / batter info at bottom
+        Between innings : upcoming batters + pitcher (left)
+                          outs + per-inning linescore (right)
+    """
+    import re as _re_lf
+
+    if config is None:
+        config = load_yaml_file('config.yaml')
+
+    use_logos = config.get('use_team_logos', False)
+
+    # Normalise mid-game review/challenge states
+    if game_data.get('detailed_state') in ('Player challenge', 'Manager challenge'):
+        game_data = dict(game_data)
+        game_data['sub_event'] = (
+            'ABS CHAL' if game_data['detailed_state'] == 'Player challenge' else 'M CHAL'
+        )
+        game_data['detailed_state'] = 'In Progress'
+
+    canvas = Image.new('1', (800, 480), 255)
+    draw   = ImageDraw.Draw(canvas)
+
+    # ── Fonts ─────────────────────────────────────────────────────────────────
+    f11 = _get_font(11)   # runner jersey numbers inside bases
+    f14 = _get_font(14)   # header detail, column labels, pitch info
+    f20 = _get_font(20)   # pitcher / batter lines
+    f28 = _get_font(28)   # between-innings batter / pitcher names
+    f36 = _get_font(36)   # errors column value
+    f42 = _get_font(42)   # team abbreviations + B/S/O labels (= draw_box scale×3 font14)
+    f48 = _get_font(48)   # hits column value
+    f72 = _get_font(72)   # runs column value  (= draw_box scale×3 font24)
+
+    # ── Team identifiers ──────────────────────────────────────────────────────
+    abbr_map  = team_data.get('team_abbreviation', {})
+    away_id   = str(game_data.get('away_team_id', ''))
+    home_id   = str(game_data.get('home_team_id', ''))
+    away_abbr = abbr_map.get(away_id, f'T{away_id}')
+    home_abbr = abbr_map.get(home_id, f'T{home_id}')
+
+    # ── Inning state ──────────────────────────────────────────────────────────
+    _inn_state   = game_data.get('inningState') or ''
+    _cur_inn     = game_data.get('current_inning') or 1
+    _inn_ord_raw = game_data.get('currentInningOrdinal') or str(_cur_inn)
+    _inn_ord     = _re_lf.sub(r'(?:st|nd|rd|th)$', '', _inn_ord_raw, flags=_re_lf.IGNORECASE)
+    _lbl_map     = {'Top': '▲', 'Bottom': '▼', 'Middle': 'Mid', 'End': 'End'}
+    _inn_lbl     = _lbl_map.get(_inn_state, (_inn_state[:3] if _inn_state else ''))
+    inning_str   = f'{_inn_lbl} {_inn_ord}'.strip()
+
+    _between_innings = _inn_state in ('Middle', 'End')
+    _pitching_change = (game_data.get('sub_event') or '').startswith('PC:')
+
+    # ── Layout constants ──────────────────────────────────────────────────────
+    HEADER_H   = 30
+    LABEL_H    = 18
+    TEAM_ROW_H = 99           # tall enough for 84 px logo + 7 px margin each side
+    AWAY_Y     = HEADER_H + LABEL_H          # y = 48
+    HOME_Y     = AWAY_Y + TEAM_ROW_H         # y = 147
+    DIV_Y      = HOME_Y + TEAM_ROW_H         # y = 246
+    SIT_Y      = DIV_Y + 1                   # y = 247
+
+    LOGO_SZ  = 84             # matches draw_box scale=3 logo size
+    LOGO_X   = 14
+    ABBR_X   = LOGO_X + LOGO_SZ + 6          # x = 104
+
+    R_CX = 310                # x-centre of Runs column
+    H_CX = 490                # x-centre of Hits column
+    E_CX = 655                # x-centre of Errors column
+
+    # Situation: bases diamond (left half of situation area)
+    # 2nd-base top  = DIAMOND_CY - BASE_DIST - BASE_SZ = 360-55-28 = 277 > SIT_Y ✓
+    # home-base bot = DIAMOND_CY + BASE_DIST + BASE_SZ = 360+55+28 = 443 < 480 ✓
+    DIAMOND_CX = 170
+    DIAMOND_CY = 360
+    BASE_DIST  = 55
+    BASE_SZ    = 28
+
+    # Situation: B/S/O circles — 20 % larger than the normal 3× scale view
+    # Normal 3× = r12 balls/strikes, r18 outs → +25 %/+17 % → r15/r21
+    BSO_Y = DIAMOND_CY        # same vertical centre as diamond
+    B_R   = 15
+    O_R   = 21
+    C_GAP = 6
+
+    INFO_Y = 402              # y-start for pitcher / batter text
+
+    # ── HEADER ────────────────────────────────────────────────────────────────
+    draw.text((10, 5), inning_str, font=f20, fill=0)
+    draw.text((11, 5), inning_str, font=f20, fill=0)   # pseudo-bold
+
+    _gd_str = (game_data.get('game_date') or '')[:10]
+    _date_lbl = ''
+    if _gd_str:
+        try:
+            _gd_dt = datetime.strptime(_gd_str, '%Y-%m-%d')
+            _date_lbl = _gd_dt.strftime('%b %-d')
+        except Exception:
+            _date_lbl = _gd_str
+    _hdr_right = f'{away_abbr} @ {home_abbr}' + (f'  ·  {_date_lbl}' if _date_lbl else '')
+    _hrw = int(f14.getlength(_hdr_right))
+    draw.text((800 - _hrw - 8, 8), _hdr_right, font=f14, fill=0)
+
+    # Last play / sub-event centred in header (active pitch only)
+    if not _between_innings:
+        _sub_ev_hdr = (game_data.get('sub_event') or '').strip()
+        _lp_hdr     = game_data.get('last_play') or ''
+        _play_raw   = _sub_ev_hdr or _lp_hdr
+        if _play_raw:
+            _pd = _abbr_play(_play_raw)
+            _rbi = int(game_data.get('last_play_rbi') or 0)
+            if _rbi > 0 and not _sub_ev_hdr:
+                if _pd == 'HR':
+                    if _rbi >= 2:
+                        _pd = f'{_rbi}R HR'
+                elif _rbi == 1:
+                    _pd = f'RBI {_pd}'
+                else:
+                    _pd = f'{_rbi}RBI {_pd}'
+            _inn_end_x  = 10 + int(f20.getlength(inning_str)) + 10
+            _hdr_x_end  = 800 - _hrw - 16
+            _pw         = int(f14.getlength(_pd))
+            _avail      = _hdr_x_end - _inn_end_x - 4
+            if _avail > 0 and _pw <= _avail:
+                _ppx = _inn_end_x + (_avail - _pw) // 2
+                draw.text((_ppx,     8), _pd, font=f14, fill=0)
+                draw.text((_ppx + 1, 8), _pd, font=f14, fill=0)
+
+    draw.line((0, HEADER_H - 1, 799, HEADER_H - 1), fill=0)
+
+    # ── R / H / E COLUMN LABELS ───────────────────────────────────────────────
+    for _lbl2, _cx2 in (('R', R_CX), ('H', H_CX), ('E', E_CX)):
+        _lw2 = int(f14.getlength(_lbl2))
+        draw.text((_cx2 - _lw2 // 2,     HEADER_H + 2), _lbl2, font=f14, fill=0)
+        draw.text((_cx2 - _lw2 // 2 + 1, HEADER_H + 2), _lbl2, font=f14, fill=0)
+
+    # ── SCORE DATA ────────────────────────────────────────────────────────────
+    away_runs = str(game_data.get('away_runs') or 0)
+    home_runs = str(game_data.get('home_runs') or 0)
+    away_hits = str(game_data.get('away_hits') or 0)
+    home_hits = str(game_data.get('home_hits') or 0)
+    away_errs = str(game_data.get('away_errors') or 0)
+    home_errs = str(game_data.get('home_errors') or 0)
+
+    _away_ahead = (game_data.get('away_runs') or 0) > (game_data.get('home_runs') or 0)
+    _home_ahead = (game_data.get('home_runs') or 0) > (game_data.get('away_runs') or 0)
+
+    def _draw_team_row(abbr, tid, row_y, runs, hits, errs, bold_score=False, batting=False):
+        nonlocal draw, canvas
+        # Batting indicator: filled dot at far-left edge
+        if batting:
+            _bi_r  = 7
+            _bi_cy = row_y + TEAM_ROW_H // 2
+            draw.ellipse([5 - _bi_r, _bi_cy - _bi_r,
+                          5 + _bi_r, _bi_cy + _bi_r], fill=0)
+        # Logo (84 px square, vertically centred in 99 px row)
+        if use_logos:
+            _lg = _logo_small(abbr, tid, size=LOGO_SZ)
+            if _lg:
+                _lw3, _lh3 = _lg.size
+                _paste_logo(canvas, _lg,
+                            (LOGO_X + (LOGO_SZ - _lw3) // 2,
+                             row_y  + (TEAM_ROW_H - _lh3) // 2))
+                draw = ImageDraw.Draw(canvas)
+        # Abbreviation (f42, vertically centred)
+        _abbr_y = row_y + (TEAM_ROW_H - 42) // 2
+        draw.text((ABBR_X,     _abbr_y), abbr, font=f42, fill=0)
+        draw.text((ABBR_X + 1, _abbr_y), abbr, font=f42, fill=0)
+        # Runs (f72, centred in R column)
+        _rw3 = int(f72.getlength(runs))
+        _rx  = R_CX - _rw3 // 2
+        _ry  = row_y + (TEAM_ROW_H - 72) // 2
+        draw.text((_rx,     _ry), runs, font=f72, fill=0)
+        if bold_score:
+            draw.text((_rx + 1, _ry), runs, font=f72, fill=0)
+        # Hits (f48, centred in H column)
+        _hw4 = int(f48.getlength(hits))
+        draw.text((H_CX - _hw4 // 2, row_y + (TEAM_ROW_H - 48) // 2), hits, font=f48, fill=0)
+        # Errors (f36, centred in E column)
+        _ew3 = int(f36.getlength(errs))
+        draw.text((E_CX - _ew3 // 2, row_y + (TEAM_ROW_H - 36) // 2), errs, font=f36, fill=0)
+
+    _draw_team_row(away_abbr, away_id, AWAY_Y, away_runs, away_hits, away_errs,
+                   bold_score=_away_ahead, batting=(_inn_state == 'Top'))
+    _draw_team_row(home_abbr, home_id,  HOME_Y, home_runs, home_hits, home_errs,
+                   bold_score=_home_ahead, batting=(_inn_state == 'Bottom'))
+
+    draw.line((0, DIV_Y, 799, DIV_Y), fill=0)
+
+    # ── SITUATION AREA ────────────────────────────────────────────────────────
+    if _between_innings or _pitching_change:
+        # ── Between innings / pitching change ─────────────────────────────────
+        _batter_names = [
+            _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
+            _last_name(game_data.get('next_batter_2') or game_data.get('due_up')         or ''),
+            _last_name(game_data.get('next_batter_3') or game_data.get('in_hole')        or ''),
+        ]
+        _pc_raw = (game_data.get('sub_event') or '')[3:].strip() if _pitching_change else ''
+        _pit_nm = _pc_raw or _last_name(
+            game_data.get('next_pitcher') or game_data.get('current_pitcher') or ''
+        )
+
+        # Left side: next three batters + pitcher (f28)
+        _ny = SIT_Y + 12
+        for _nm in _batter_names:
+            if _nm:
+                draw.text((20, _ny), _nm, font=f28, fill=0)
+            _ny += 34
+        _sep_y = _ny + 6
+        draw.line((20, _sep_y, 290, _sep_y), fill=0)
+        if _pit_nm:
+            draw.text((20, _sep_y + 8), _pit_nm, font=f28, fill=0)
+
+        # Outs indicator (right side, above linescore)
+        _outs  = game_data.get('num_of_outs') or 0
+        _oc_cy = SIT_Y + 55          # ≈ y=302; circles span 281..323
+        _o_lbl_y = _oc_cy - O_R - 10
+        draw.text((392, _o_lbl_y), 'O', font=f28, fill=0)
+        draw.text((393, _o_lbl_y), 'O', font=f28, fill=0)
+        for i in range(3):
+            _ocx = 414 + i * (2 * O_R + C_GAP) + O_R
+            canvas = draw_circle(canvas, (_ocx, _oc_cy), O_R, i < _outs, outline_width=2)
+        draw = ImageDraw.Draw(canvas)
+
+        # Per-inning linescore (scale=2, right panel beginning at x=340)
+        # grid top = _ls_sy + 83*2; target grid top ≈ SIT_Y + 100 = 347
+        _ls_sy = SIT_Y + 100 - 83 * 2
+        draw, canvas = _draw_linescore_grid(
+            draw, canvas, 340, _ls_sy,
+            game_data, team_data, use_logos, scale=2,
+        )
+
+    else:
+        # ── Active pitch ──────────────────────────────────────────────────────
+
+        # Bases diamond (centred at DIAMOND_CX=170, DIAMOND_CY=360)
+        _hi_third  = isinstance(game_data.get('runner_on_third'),  str)
+        _hi_second = isinstance(game_data.get('runner_on_second'), str)
+        _hi_first  = isinstance(game_data.get('runner_on_first'),  str)
+
+        _b3 = (DIAMOND_CX - BASE_DIST, DIAMOND_CY)
+        _b2 = (DIAMOND_CX,             DIAMOND_CY - BASE_DIST)
+        _b1 = (DIAMOND_CX + BASE_DIST, DIAMOND_CY)
+
+        canvas = draw_diamond(canvas, _b3, BASE_SZ, _hi_third)
+        canvas = draw_diamond(canvas, _b2, BASE_SZ, _hi_second)
+        canvas = draw_diamond(canvas, _b1, BASE_SZ, _hi_first)
+        draw   = ImageDraw.Draw(canvas)
+
+        # Runner jersey numbers (white text inside filled base diamonds)
+        for _bfill, _bc, _bkey in (
+            (_hi_third,  _b3, 'runner_third_number'),
+            (_hi_second, _b2, 'runner_second_number'),
+            (_hi_first,  _b1, 'runner_first_number'),
+        ):
+            if _bfill:
+                _raw  = game_data.get(_bkey)
+                _bnum = str(_raw) if _raw is not None else ''
+                if _bnum:
+                    _bnw = int(f11.getlength(_bnum))
+                    draw.text((_bc[0] - _bnw // 2, _bc[1] - 7), _bnum, font=f11, fill=255)
+
+        # ── B / S / O circles ─────────────────────────────────────────────────
+        # Horizontal layout, vertically centred at BSO_Y=360, starting at x=295.
+        # B label(f42~28px) + gap8 + 4×(2×15+6) → right≈469
+        # S label + gap8 + 2×(2×15+6) → right≈585
+        # O label + gap8 + 3×(2×21+6) → right≈773  (fits within 800)
+        _bx = 295
+
+        # B label + 4 ball circles
+        draw.text((_bx, BSO_Y - 21), 'B', font=f42, fill=0)
+        draw.text((_bx + 1, BSO_Y - 21), 'B', font=f42, fill=0)
+        _bx += int(f42.getlength('B')) + 8
+        _balls = game_data.get('balls') or 0
+        for i in range(4):
+            _cx = _bx + B_R
+            canvas = draw_circle(canvas, (_cx, BSO_Y), B_R, i < _balls)
+            _bx += 2 * B_R + C_GAP
+        draw = ImageDraw.Draw(canvas)
+
+        # S label + 2 strike circles
+        _sx = _bx + 14
+        draw.text((_sx, BSO_Y - 21), 'S', font=f42, fill=0)
+        draw.text((_sx + 1, BSO_Y - 21), 'S', font=f42, fill=0)
+        _sx += int(f42.getlength('S')) + 8
+        _strikes = game_data.get('strikes') or 0
+        _scalls  = game_data.get('strike_calls', [])
+        for i in range(2):
+            _cx   = _sx + B_R
+            _call = _scalls[i] if i < len(_scalls) else None
+            if i < _strikes and _call in ('S', 'F'):
+                # Swinging / foul: ring outline with solid centre dot
+                canvas = draw_circle(canvas, (_cx, BSO_Y), B_R, False)
+                draw   = ImageDraw.Draw(canvas)
+                draw.ellipse([_cx - 5, BSO_Y - 5, _cx + 5, BSO_Y + 5],
+                             fill='black', outline='black')
+            else:
+                canvas = draw_circle(canvas, (_cx, BSO_Y), B_R, i < _strikes)
+                draw   = ImageDraw.Draw(canvas)
+            _sx += 2 * B_R + C_GAP
+
+        # O label + 3 out circles
+        _ox = _sx + 14
+        draw.text((_ox, BSO_Y - 21), 'O', font=f42, fill=0)
+        draw.text((_ox + 1, BSO_Y - 21), 'O', font=f42, fill=0)
+        _ox += int(f42.getlength('O')) + 8
+        _outs2 = game_data.get('num_of_outs') or 0
+        for i in range(3):
+            _cx = _ox + O_R
+            canvas = draw_circle(canvas, (_cx, BSO_Y), O_R, i < _outs2, outline_width=2)
+            _ox += 2 * O_R + C_GAP
+        draw = ImageDraw.Draw(canvas)
+
+        # Pitch info (count · speed · type) — just below circles
+        _lps = game_data.get('last_pitch_speed')
+        _pt  = game_data.get('last_pitch_type', '')
+        _pc  = game_data.get('pitch_count')
+        _pitch_parts = []
+        if _pc is not None:
+            _pitch_parts.append(f'{_pc}P')
+        if _lps:
+            _pitch_parts.append(f'{int(_lps)}mph')
+        if _pt:
+            _pitch_parts.append(_pt)
+        if _pitch_parts:
+            draw.text((295, BSO_Y + O_R + 8), '  '.join(_pitch_parts), font=f14, fill=0)
+
+        # Save situation indicator (above BSO row)
+        if game_data.get('save_situation'):
+            draw.text((295,     BSO_Y - O_R - 28), 'SV', font=f14, fill=0)
+            draw.text((295 + 1, BSO_Y - O_R - 28), 'SV', font=f14, fill=0)
+
+        # ── Pitcher / batter info ─────────────────────────────────────────────
+        _pitcher = _format_player_name(game_data.get('current_pitcher') or '')
+        if _pitcher:
+            draw.text((12, INFO_Y), f'P: {_pitcher}', font=f20, fill=0)
+
+        _bh      = game_data.get('batter_hits')
+        _ba      = game_data.get('batter_at_bats')
+        _ba_str2 = f'({_bh}-{_ba})' if _bh is not None and _ba is not None else ''
+        _ab_done = game_data.get('current_at_bat_complete', False)
+        if _ab_done and not _is_game_effectively_over(game_data):
+            _batter  = _format_player_name(
+                game_data.get('due_up') or game_data.get('next_batter_1') or ''
+            )
+            _bat_lbl = 'Next'
+        else:
+            _batter  = _format_player_name(game_data.get('current_hitter') or '')
+            _bat_lbl = 'AB'
+        if _batter:
+            _bat_str2 = f'{_bat_lbl}: {_batter}  {_ba_str2}'.strip()
+            draw.text((12, INFO_Y + 26), _bat_str2, font=f20, fill=0)
+
+        # Last play — right-aligned beside pitcher/batter lines
+        _sub_ev2 = (game_data.get('sub_event') or '').strip()
+        _lp_val  = game_data.get('last_play') or ''
+        _play_f  = _sub_ev2 or _lp_val
+        if _play_f:
+            _pd2  = _abbr_play(_play_f) if not _sub_ev2 else _play_f
+            _rbi2 = int(game_data.get('last_play_rbi') or 0)
+            if _rbi2 > 0 and not _sub_ev2:
+                if _pd2 == 'HR':
+                    if _rbi2 >= 2:
+                        _pd2 = f'{_rbi2}R HR'
+                elif _rbi2 == 1:
+                    _pd2 = f'RBI {_pd2}'
+                else:
+                    _pd2 = f'{_rbi2}RBI {_pd2}'
+            _pdw = int(f20.getlength(_pd2))
+            draw.text((799 - _pdw - 10, INFO_Y), _pd2, font=f20, fill=0)
+            draw.text((800 - _pdw - 10, INFO_Y), _pd2, font=f20, fill=0)
+
+    return canvas
+
+
 def draw_featured_game_fullscreen(game_data, team_data, config=None):
     """Enlarge a single scoreboard cell while preserving its 1:1 aspect ratio.
 
@@ -854,6 +1245,9 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
     """
     if config is None:
         config = load_yaml_file('config.yaml')
+
+    _ds = game_data.get('detailed_state', '')
+    _is_live = _ds in ('In Progress', 'Player challenge', 'Manager challenge')
 
     use_logos   = config.get('use_team_logos', False)
     logo_offset = config.get('small_logo_x_offset', 2)
@@ -924,8 +1318,8 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
     _right_sb_w = 800 - _right_sb_x  # 198
     _sb_logo_sz = 52
 
-    # Overlay wildcard header and standings sidebars (standings_data already loaded above)
-    if standings_data and 'standings' in standings_data:
+    # Overlay wildcard header and standings sidebars (skipped for live games)
+    if not _is_live and standings_data and 'standings' in standings_data:
         if config.get('show_wildcard_standings', False) and league_mode != 'aaa':
             wildcard_data = derive_wildcard_from_standings(standings_data)
             canvas = draw_wildcard_header(canvas, wildcard_data)

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -847,25 +847,19 @@ def _find_featured_game(game_state_data, team_data, primary_abbr):
 
 
 def draw_live_fullscreen_game(game_data, team_data, config=None):
-    """Full 800×480 canvas for a live (In Progress) featured game.
+    """Full 800x480 canvas for a live (In Progress) featured game.
 
-    Called from draw_featured_game_fullscreen when the featured game is
-    actively In Progress (any sub-state: active pitch, between innings, or
-    pitching change).  No standings sidebars — the game fills the entire
-    display.
-
-    Layout (top → bottom)
-    ---------------------
-    y=0..29    Header strip  : inning label | last play | matchup + date
-    y=30..47   R / H / E column labels
-    y=48..146  Away team row : logo  abbr  R  H  E
-    y=147..245 Home team row : logo  abbr  R  H  E
-    y=246      Divider line
-    y=247..479 Situation (233 px):
-        Active pitch    : bases diamond (left)  +  B/S/O circles (right)
-                          pitcher / batter info at bottom
-        Between innings : upcoming batters + pitcher (left)
-                          outs + per-inning linescore (right)
+    Layout v4
+    ---------
+    y=0..91    Header  : inning (f80, left)  matchup (f56, right)  [thick line below]
+    y=92..111  R / H / E column labels (f14)
+    y=112..191 Away row : logo  abbr  R  H  E  |  bases diamond (right, spans rows)
+    y=192..271 Home row : logo  abbr  R  H  E  |
+    y=272..307 [blank left]  |  outs circles (right, under bases)
+    y=308      Divider line
+    y=309..479 Bottom :
+        Live           : B/S/O circles + pitch info + last event (f36) + pitcher/batter (f28)
+        Between-innings: last event (f36) + due-up batters (f24) + pitcher (f24)
     """
     import re as _re_lf
 
@@ -885,24 +879,25 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     canvas = Image.new('1', (800, 480), 255)
     draw   = ImageDraw.Draw(canvas)
 
-    # ── Fonts ─────────────────────────────────────────────────────────────────
-    f11 = _get_font(11)   # runner jersey numbers inside bases
-    f14 = _get_font(14)   # header detail, column labels, pitch info
-    f20 = _get_font(20)   # pitcher / batter lines
-    f28 = _get_font(28)   # between-innings batter / pitcher names
-    f36 = _get_font(36)   # errors column value
-    f42 = _get_font(42)   # team abbreviations + B/S/O labels (= draw_box scale×3 font14)
-    f48 = _get_font(48)   # hits column value
-    f72 = _get_font(72)   # runs column value  (= draw_box scale×3 font24)
+    # ---- Fonts ---------------------------------------------------------------
+    f11  = _get_font(11)    # runner jersey numbers inside bases
+    f14  = _get_font(14)    # pitch info / column labels
+    f24  = _get_font(24)    # between-innings batter/pitcher names
+    f28  = _get_font(28)    # pitcher / batter line (bottom, live)
+    f36  = _get_font(36)    # last event  (prominent)
+    f42  = _get_font(42)    # BSO labels + team abbreviations
+    f56  = _get_font(56)    # matchup header (4x f14)
+    f72  = _get_font(72)    # R / H / E values
+    f80  = _get_font(80)    # inning text (4x f20)
 
-    # ── Team identifiers ──────────────────────────────────────────────────────
+    # ---- Team identifiers ----------------------------------------------------
     abbr_map  = team_data.get('team_abbreviation', {})
     away_id   = str(game_data.get('away_team_id', ''))
     home_id   = str(game_data.get('home_team_id', ''))
     away_abbr = abbr_map.get(away_id, f'T{away_id}')
     home_abbr = abbr_map.get(home_id, f'T{home_id}')
 
-    # ── Inning state ──────────────────────────────────────────────────────────
+    # ---- Inning state --------------------------------------------------------
     _inn_state   = game_data.get('inningState') or ''
     _cur_inn     = game_data.get('current_inning') or 1
     _inn_ord_raw = game_data.get('currentInningOrdinal') or str(_cur_inn)
@@ -914,90 +909,93 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     _between_innings = _inn_state in ('Middle', 'End')
     _pitching_change = (game_data.get('sub_event') or '').startswith('PC:')
 
-    # ── Layout constants ──────────────────────────────────────────────────────
-    HEADER_H   = 30
-    LABEL_H    = 18
-    TEAM_ROW_H = 99           # tall enough for 84 px logo + 7 px margin each side
-    AWAY_Y     = HEADER_H + LABEL_H          # y = 48
-    HOME_Y     = AWAY_Y + TEAM_ROW_H         # y = 147
-    DIV_Y      = HOME_Y + TEAM_ROW_H         # y = 246
-    SIT_Y      = DIV_Y + 1                   # y = 247
+    # ---- Layout constants ----------------------------------------------------
+    HEADER_H   = 92           # big header (f80 inning + breathing room)
+    LABEL_H    = 20           # R/H/E column label row
+    TEAM_ROW_H = 80           # away/home score rows
+    AWAY_Y     = HEADER_H + LABEL_H          # 112
+    HOME_Y     = AWAY_Y  + TEAM_ROW_H        # 192
+    OUTS_Y_TOP = HOME_Y  + TEAM_ROW_H        # 272  (outs circles here)
+    OUTS_H     = 36
+    DIV_Y      = OUTS_Y_TOP + OUTS_H         # 308
+    SIT_Y      = DIV_Y + 1                   # 309
 
-    LOGO_SZ  = 84             # matches draw_box scale=3 logo size
-    LOGO_X   = 14
-    ABBR_X   = LOGO_X + LOGO_SZ + 6          # x = 104
+    # Team row layout
+    LOGO_SZ  = 72
+    LOGO_X   = 2
+    ABBR_X   = LOGO_X + LOGO_SZ + 6         # 80
 
-    R_CX = 310                # x-centre of Runs column
-    H_CX = 490                # x-centre of Hits column
-    E_CX = 655                # x-centre of Errors column
+    # R/H/E column centres
+    R_CX = 240
+    H_CX = 360
+    E_CX = 480
 
-    # Situation: bases diamond (left half of situation area)
-    # 2nd-base top  = DIAMOND_CY - BASE_DIST - BASE_SZ = 360-55-28 = 277 > SIT_Y ✓
-    # home-base bot = DIAMOND_CY + BASE_DIST + BASE_SZ = 360+55+28 = 443 < 480 ✓
-    DIAMOND_CX = 170
-    DIAMOND_CY = 360
-    BASE_DIST  = 55
-    BASE_SZ    = 28
+    # Bases: right side, centre at the boundary between the two score rows
+    DIAMOND_CX = 645
+    DIAMOND_CY = HOME_Y                      # 192
+    BASE_DIST  = 52
+    BASE_SZ    = 24
+    BASE_OW    = 3
 
-    # Situation: B/S/O circles — 20 % larger than the normal 3× scale view
-    # Normal 3× = r12 balls/strikes, r18 outs → +25 %/+17 % → r15/r21
-    BSO_Y = DIAMOND_CY        # same vertical centre as diamond
-    B_R   = 15
-    O_R   = 21
-    C_GAP = 6
+    # BSO circles (bottom half)
+    B_R   = 12
+    O_R   = 16
+    C_GAP = 5
 
-    INFO_Y = 402              # y-start for pitcher / batter text
+    # ---- Last-event helper ---------------------------------------------------
+    def _build_last_event():
+        _sub_ev = (game_data.get('sub_event') or '').strip()
+        _lp     = game_data.get('last_play') or ''
+        _raw    = _sub_ev or _lp
+        if not _raw:
+            return ''
+        _pd  = _abbr_play(_raw)
+        _rbi = int(game_data.get('last_play_rbi') or 0)
+        if _rbi > 0 and not _sub_ev:
+            if _pd == 'HR':
+                if _rbi >= 2:
+                    _pd = f'{_rbi}R HR'
+            elif _rbi == 1:
+                _pd = f'RBI {_pd}'
+            else:
+                _pd = f'{_rbi}RBI {_pd}'
+        return _pd
 
-    # ── HEADER ────────────────────────────────────────────────────────────────
-    draw.text((10, 5), inning_str, font=f20, fill=0)
-    draw.text((11, 5), inning_str, font=f20, fill=0)   # pseudo-bold
+    # ---- HEADER (full-width thick line below) --------------------------------
+    # Inning: f80, top-left
+    draw.text((8, 4),  inning_str, font=f80, fill=0)
+    draw.text((9, 4),  inning_str, font=f80, fill=0)   # pseudo-bold
 
-    _gd_str = (game_data.get('game_date') or '')[:10]
+    # Matchup + date: f56, right-aligned, vertically centred in header
+    _gd_str   = (game_data.get('game_date') or '')[:10]
     _date_lbl = ''
     if _gd_str:
         try:
-            _gd_dt = datetime.strptime(_gd_str, '%Y-%m-%d')
+            _gd_dt    = datetime.strptime(_gd_str, '%Y-%m-%d')
             _date_lbl = _gd_dt.strftime('%b %-d')
         except Exception:
             _date_lbl = _gd_str
-    _hdr_right = f'{away_abbr} @ {home_abbr}' + (f'  ·  {_date_lbl}' if _date_lbl else '')
-    _hrw = int(f14.getlength(_hdr_right))
-    draw.text((800 - _hrw - 8, 8), _hdr_right, font=f14, fill=0)
+    _hdr_right = f'{away_abbr} @ {home_abbr}' + (f'  {_date_lbl}' if _date_lbl else '')
+    _inn_w     = int(f80.getlength(inning_str)) + 8 + 16   # min gap after inning
+    _hrw       = int(f56.getlength(_hdr_right))
+    _hdr_x     = 800 - _hrw - 8
+    if _hdr_x < _inn_w:
+        # Fall back to teams-only if date makes it too wide
+        _hdr_right = f'{away_abbr} @ {home_abbr}'
+        _hrw       = int(f56.getlength(_hdr_right))
+        _hdr_x     = 800 - _hrw - 8
+    if _hdr_x > _inn_w:
+        _hry = max(4, (HEADER_H - 56) // 2)
+        draw.text((_hdr_x, _hry), _hdr_right, font=f56, fill=0)
 
-    # Last play / sub-event centred in header (active pitch only)
-    if not _between_innings:
-        _sub_ev_hdr = (game_data.get('sub_event') or '').strip()
-        _lp_hdr     = game_data.get('last_play') or ''
-        _play_raw   = _sub_ev_hdr or _lp_hdr
-        if _play_raw:
-            _pd = _abbr_play(_play_raw)
-            _rbi = int(game_data.get('last_play_rbi') or 0)
-            if _rbi > 0 and not _sub_ev_hdr:
-                if _pd == 'HR':
-                    if _rbi >= 2:
-                        _pd = f'{_rbi}R HR'
-                elif _rbi == 1:
-                    _pd = f'RBI {_pd}'
-                else:
-                    _pd = f'{_rbi}RBI {_pd}'
-            _inn_end_x  = 10 + int(f20.getlength(inning_str)) + 10
-            _hdr_x_end  = 800 - _hrw - 16
-            _pw         = int(f14.getlength(_pd))
-            _avail      = _hdr_x_end - _inn_end_x - 4
-            if _avail > 0 and _pw <= _avail:
-                _ppx = _inn_end_x + (_avail - _pw) // 2
-                draw.text((_ppx,     8), _pd, font=f14, fill=0)
-                draw.text((_ppx + 1, 8), _pd, font=f14, fill=0)
+    draw.line((0, HEADER_H - 1, 799, HEADER_H - 1), fill=0, width=2)
 
-    draw.line((0, HEADER_H - 1, 799, HEADER_H - 1), fill=0)
-
-    # ── R / H / E COLUMN LABELS ───────────────────────────────────────────────
+    # ---- R / H / E COLUMN LABELS --------------------------------------------
     for _lbl2, _cx2 in (('R', R_CX), ('H', H_CX), ('E', E_CX)):
         _lw2 = int(f14.getlength(_lbl2))
-        draw.text((_cx2 - _lw2 // 2,     HEADER_H + 2), _lbl2, font=f14, fill=0)
-        draw.text((_cx2 - _lw2 // 2 + 1, HEADER_H + 2), _lbl2, font=f14, fill=0)
+        draw.text((_cx2 - _lw2 // 2, HEADER_H + 3), _lbl2, font=f14, fill=0)
 
-    # ── SCORE DATA ────────────────────────────────────────────────────────────
+    # ---- SCORE DATA ---------------------------------------------------------
     away_runs = str(game_data.get('away_runs') or 0)
     home_runs = str(game_data.get('home_runs') or 0)
     away_hits = str(game_data.get('away_hits') or 0)
@@ -1010,13 +1008,10 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
 
     def _draw_team_row(abbr, tid, row_y, runs, hits, errs, bold_score=False, batting=False):
         nonlocal draw, canvas
-        # Batting indicator: filled dot at far-left edge
         if batting:
             _bi_r  = 7
             _bi_cy = row_y + TEAM_ROW_H // 2
-            draw.ellipse([5 - _bi_r, _bi_cy - _bi_r,
-                          5 + _bi_r, _bi_cy + _bi_r], fill=0)
-        # Logo (84 px square, vertically centred in 99 px row)
+            draw.ellipse([-_bi_r, _bi_cy - _bi_r, _bi_r, _bi_cy + _bi_r], fill=0)
         if use_logos:
             _lg = _logo_small(abbr, tid, size=LOGO_SZ)
             if _lg:
@@ -1025,34 +1020,81 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
                             (LOGO_X + (LOGO_SZ - _lw3) // 2,
                              row_y  + (TEAM_ROW_H - _lh3) // 2))
                 draw = ImageDraw.Draw(canvas)
-        # Abbreviation (f42, vertically centred)
         _abbr_y = row_y + (TEAM_ROW_H - 42) // 2
         draw.text((ABBR_X,     _abbr_y), abbr, font=f42, fill=0)
         draw.text((ABBR_X + 1, _abbr_y), abbr, font=f42, fill=0)
-        # Runs (f72, centred in R column)
-        _rw3 = int(f72.getlength(runs))
-        _rx  = R_CX - _rw3 // 2
-        _ry  = row_y + (TEAM_ROW_H - 72) // 2
-        draw.text((_rx,     _ry), runs, font=f72, fill=0)
-        if bold_score:
-            draw.text((_rx + 1, _ry), runs, font=f72, fill=0)
-        # Hits (f48, centred in H column)
-        _hw4 = int(f48.getlength(hits))
-        draw.text((H_CX - _hw4 // 2, row_y + (TEAM_ROW_H - 48) // 2), hits, font=f48, fill=0)
-        # Errors (f36, centred in E column)
-        _ew3 = int(f36.getlength(errs))
-        draw.text((E_CX - _ew3 // 2, row_y + (TEAM_ROW_H - 36) // 2), errs, font=f36, fill=0)
+        _ry = row_y + (TEAM_ROW_H - 72) // 2
+        for val, cx, bold in ((runs, R_CX, bold_score), (hits, H_CX, False), (errs, E_CX, False)):
+            _vw = int(f72.getlength(val))
+            _vx = cx - _vw // 2
+            draw.text((_vx,     _ry), val, font=f72, fill=0)
+            if bold:
+                draw.text((_vx + 1, _ry), val, font=f72, fill=0)
 
     _draw_team_row(away_abbr, away_id, AWAY_Y, away_runs, away_hits, away_errs,
                    bold_score=_away_ahead, batting=(_inn_state == 'Top'))
     _draw_team_row(home_abbr, home_id,  HOME_Y, home_runs, home_hits, home_errs,
                    bold_score=_home_ahead, batting=(_inn_state == 'Bottom'))
 
-    draw.line((0, DIV_Y, 799, DIV_Y), fill=0)
+    # ---- BASES (right side, spanning both score rows) -----------------------
+    _hi_third  = isinstance(game_data.get('runner_on_third'),  str)
+    _hi_second = isinstance(game_data.get('runner_on_second'), str)
+    _hi_first  = isinstance(game_data.get('runner_on_first'),  str)
 
-    # ── SITUATION AREA ────────────────────────────────────────────────────────
+    _b3 = (DIAMOND_CX - BASE_DIST, DIAMOND_CY)
+    _b2 = (DIAMOND_CX,             DIAMOND_CY - BASE_DIST)
+    _b1 = (DIAMOND_CX + BASE_DIST, DIAMOND_CY)
+    _bH = (DIAMOND_CX,             DIAMOND_CY + BASE_DIST)   # home plate
+
+    canvas = draw_diamond(canvas, _b3, BASE_SZ, _hi_third,  outline_width=BASE_OW)
+    canvas = draw_diamond(canvas, _b2, BASE_SZ, _hi_second, outline_width=BASE_OW)
+    canvas = draw_diamond(canvas, _b1, BASE_SZ, _hi_first,  outline_width=BASE_OW)
+    canvas = draw_diamond(canvas, _bH, BASE_SZ - 8, False,  outline_width=BASE_OW)  # home plate
+    draw   = ImageDraw.Draw(canvas)
+
+    # Runner jersey numbers in white inside filled bases
+    for _bfill, _bc, _bkey in (
+        (_hi_third,  _b3, 'runner_third_number'),
+        (_hi_second, _b2, 'runner_second_number'),
+        (_hi_first,  _b1, 'runner_first_number'),
+    ):
+        if _bfill:
+            _raw  = game_data.get(_bkey)
+            _bnum = str(_raw) if _raw is not None else ''
+            if _bnum:
+                _bnw = int(f11.getlength(_bnum))
+                draw.text((_bc[0] - _bnw // 2, _bc[1] - 7), _bnum, font=f11, fill=255)
+
+    # ---- OUTS circles (right side, under bases) -----------------------------
+    _outs = game_data.get('num_of_outs') or 0
+    _or   = 14
+    _ogap = 8
+    _otw  = 3 * (2 * _or) + 2 * _ogap    # total width = 100px
+    _oxs  = DIAMOND_CX - _otw // 2       # x-start = 595
+    _ocy  = OUTS_Y_TOP + _or + 4          # circle centres y
+    for i in range(3):
+        _ocx = _oxs + _or + i * (2 * _or + _ogap)
+        canvas = draw_circle(canvas, (_ocx, _ocy), _or, i < _outs, outline_width=2)
+    draw = ImageDraw.Draw(canvas)
+
+    # ---- DIVIDER (full width, thick) ----------------------------------------
+    draw.line((0, DIV_Y, 799, DIV_Y), fill=0, width=2)
+
+    # ---- BOTTOM SITUATION AREA ----------------------------------------------
+    _last_ev = _build_last_event()
+
     if _between_innings or _pitching_change:
-        # ── Between innings / pitching change ─────────────────────────────────
+        # ---- Between innings: last event  +  due-up batters  +  pitcher ----
+        _by = SIT_Y + 8   # 317
+
+        if _last_ev:
+            draw.text((16, _by),     _last_ev, font=f36, fill=0)
+            draw.text((17, _by),     _last_ev, font=f36, fill=0)
+            _by += 40
+
+        draw.line((16, _by, 420, _by), fill=0, width=1)
+        _by += 10
+
         _batter_names = [
             _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
             _last_name(game_data.get('next_batter_2') or game_data.get('due_up')         or ''),
@@ -1063,88 +1105,39 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             game_data.get('next_pitcher') or game_data.get('current_pitcher') or ''
         )
 
-        # Left side: next three batters + pitcher (f28)
-        _ny = SIT_Y + 12
         for _nm in _batter_names:
-            if _nm:
-                draw.text((20, _ny), _nm, font=f28, fill=0)
-            _ny += 34
-        _sep_y = _ny + 6
-        draw.line((20, _sep_y, 290, _sep_y), fill=0)
-        if _pit_nm:
-            draw.text((20, _sep_y + 8), _pit_nm, font=f28, fill=0)
+            if _nm and _by + 28 <= 476:
+                draw.text((16, _by), _nm, font=f24, fill=0)
+                _by += 28
 
-        # Outs indicator (right side, above linescore)
-        _outs  = game_data.get('num_of_outs') or 0
-        _oc_cy = SIT_Y + 55          # ≈ y=302; circles span 281..323
-        _o_lbl_y = _oc_cy - O_R - 10
-        draw.text((392, _o_lbl_y), 'O', font=f28, fill=0)
-        draw.text((393, _o_lbl_y), 'O', font=f28, fill=0)
-        for i in range(3):
-            _ocx = 414 + i * (2 * O_R + C_GAP) + O_R
-            canvas = draw_circle(canvas, (_ocx, _oc_cy), O_R, i < _outs, outline_width=2)
-        draw = ImageDraw.Draw(canvas)
-
-        # Per-inning linescore (scale=2, right panel beginning at x=340)
-        # grid top = _ls_sy + 83*2; target grid top ≈ SIT_Y + 100 = 347
-        _ls_sy = SIT_Y + 100 - 83 * 2
-        draw, canvas = _draw_linescore_grid(
-            draw, canvas, 340, _ls_sy,
-            game_data, team_data, use_logos, scale=2,
-        )
+        if _pit_nm and _by + 8 <= 476:
+            draw.line((16, _by + 4, 320, _by + 4), fill=0, width=1)
+            _by += 12
+            if _by + 24 <= 476:
+                draw.text((16, _by), _pit_nm, font=f24, fill=0)
 
     else:
-        # ── Active pitch ──────────────────────────────────────────────────────
+        # ---- Active pitch: B/S/O  +  pitch info  +  last event  +  pitcher/batter ----
 
-        # Bases diamond (centred at DIAMOND_CX=170, DIAMOND_CY=360)
-        _hi_third  = isinstance(game_data.get('runner_on_third'),  str)
-        _hi_second = isinstance(game_data.get('runner_on_second'), str)
-        _hi_first  = isinstance(game_data.get('runner_on_first'),  str)
+        _bso_y  = SIT_Y + 6    # 315  — top of BSO label text
+        _bso_cy = _bso_y + 21  # 336  — circle centres (vertically centred in f42 cap-height)
 
-        _b3 = (DIAMOND_CX - BASE_DIST, DIAMOND_CY)
-        _b2 = (DIAMOND_CX,             DIAMOND_CY - BASE_DIST)
-        _b1 = (DIAMOND_CX + BASE_DIST, DIAMOND_CY)
-
-        canvas = draw_diamond(canvas, _b3, BASE_SZ, _hi_third)
-        canvas = draw_diamond(canvas, _b2, BASE_SZ, _hi_second)
-        canvas = draw_diamond(canvas, _b1, BASE_SZ, _hi_first)
-        draw   = ImageDraw.Draw(canvas)
-
-        # Runner jersey numbers (white text inside filled base diamonds)
-        for _bfill, _bc, _bkey in (
-            (_hi_third,  _b3, 'runner_third_number'),
-            (_hi_second, _b2, 'runner_second_number'),
-            (_hi_first,  _b1, 'runner_first_number'),
-        ):
-            if _bfill:
-                _raw  = game_data.get(_bkey)
-                _bnum = str(_raw) if _raw is not None else ''
-                if _bnum:
-                    _bnw = int(f11.getlength(_bnum))
-                    draw.text((_bc[0] - _bnw // 2, _bc[1] - 7), _bnum, font=f11, fill=255)
-
-        # ── B / S / O circles ─────────────────────────────────────────────────
-        # Horizontal layout, vertically centred at BSO_Y=360, starting at x=295.
-        # B label(f42~28px) + gap8 + 4×(2×15+6) → right≈469
-        # S label + gap8 + 2×(2×15+6) → right≈585
-        # O label + gap8 + 3×(2×21+6) → right≈773  (fits within 800)
-        _bx = 295
-
-        # B label + 4 ball circles
-        draw.text((_bx, BSO_Y - 21), 'B', font=f42, fill=0)
-        draw.text((_bx + 1, BSO_Y - 21), 'B', font=f42, fill=0)
+        # Balls
+        _bx = 16
+        draw.text((_bx,     _bso_y), 'B', font=f42, fill=0)
+        draw.text((_bx + 1, _bso_y), 'B', font=f42, fill=0)
         _bx += int(f42.getlength('B')) + 8
         _balls = game_data.get('balls') or 0
         for i in range(4):
             _cx = _bx + B_R
-            canvas = draw_circle(canvas, (_cx, BSO_Y), B_R, i < _balls)
+            canvas = draw_circle(canvas, (_cx, _bso_cy), B_R, i < _balls)
             _bx += 2 * B_R + C_GAP
         draw = ImageDraw.Draw(canvas)
 
-        # S label + 2 strike circles
-        _sx = _bx + 14
-        draw.text((_sx, BSO_Y - 21), 'S', font=f42, fill=0)
-        draw.text((_sx + 1, BSO_Y - 21), 'S', font=f42, fill=0)
+        # Strikes
+        _sx = _bx + 16
+        draw.text((_sx,     _bso_y), 'S', font=f42, fill=0)
+        draw.text((_sx + 1, _bso_y), 'S', font=f42, fill=0)
         _sx += int(f42.getlength('S')) + 8
         _strikes = game_data.get('strikes') or 0
         _scalls  = game_data.get('strike_calls', [])
@@ -1152,55 +1145,61 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             _cx   = _sx + B_R
             _call = _scalls[i] if i < len(_scalls) else None
             if i < _strikes and _call in ('S', 'F'):
-                # Swinging / foul: ring outline with solid centre dot
-                canvas = draw_circle(canvas, (_cx, BSO_Y), B_R, False)
+                canvas = draw_circle(canvas, (_cx, _bso_cy), B_R, False)
                 draw   = ImageDraw.Draw(canvas)
-                draw.ellipse([_cx - 5, BSO_Y - 5, _cx + 5, BSO_Y + 5],
+                draw.ellipse([_cx - 5, _bso_cy - 5, _cx + 5, _bso_cy + 5],
                              fill='black', outline='black')
             else:
-                canvas = draw_circle(canvas, (_cx, BSO_Y), B_R, i < _strikes)
+                canvas = draw_circle(canvas, (_cx, _bso_cy), B_R, i < _strikes)
                 draw   = ImageDraw.Draw(canvas)
             _sx += 2 * B_R + C_GAP
 
-        # O label + 3 out circles
-        _ox = _sx + 14
-        draw.text((_ox, BSO_Y - 21), 'O', font=f42, fill=0)
-        draw.text((_ox + 1, BSO_Y - 21), 'O', font=f42, fill=0)
+        # Outs
+        _ox = _sx + 16
+        draw.text((_ox,     _bso_y), 'O', font=f42, fill=0)
+        draw.text((_ox + 1, _bso_y), 'O', font=f42, fill=0)
         _ox += int(f42.getlength('O')) + 8
         _outs2 = game_data.get('num_of_outs') or 0
         for i in range(3):
-            _cx = _ox + O_R
-            canvas = draw_circle(canvas, (_cx, BSO_Y), O_R, i < _outs2, outline_width=2)
+            _cx2 = _ox + O_R
+            canvas = draw_circle(canvas, (_cx2, _bso_cy), O_R, i < _outs2, outline_width=2)
             _ox += 2 * O_R + C_GAP
         draw = ImageDraw.Draw(canvas)
 
-        # Pitch info (count · speed · type) — just below circles
+        # Save situation badge
+        if game_data.get('save_situation'):
+            _sv_x = 800 - int(f28.getlength('SV')) - 16
+            draw.text((_sv_x,     _bso_y + 6), 'SV', font=f28, fill=0)
+            draw.text((_sv_x + 1, _bso_y + 6), 'SV', font=f28, fill=0)
+
+        # Pitch info: count / speed / type  (f14, below circles)
         _lps = game_data.get('last_pitch_speed')
         _pt  = game_data.get('last_pitch_type', '')
         _pc  = game_data.get('pitch_count')
         _pitch_parts = []
-        if _pc is not None:
-            _pitch_parts.append(f'{_pc}P')
-        if _lps:
-            _pitch_parts.append(f'{int(_lps)}mph')
-        if _pt:
-            _pitch_parts.append(_pt)
+        if _pc  is not None: _pitch_parts.append(f'{_pc}P')
+        if _lps:             _pitch_parts.append(f'{int(_lps)}mph')
+        if _pt:              _pitch_parts.append(_pt)
         if _pitch_parts:
-            draw.text((295, BSO_Y + O_R + 8), '  '.join(_pitch_parts), font=f14, fill=0)
+            draw.text((16, _bso_y + 46), '  '.join(_pitch_parts), font=f14, fill=0)
 
-        # Save situation indicator (above BSO row)
-        if game_data.get('save_situation'):
-            draw.text((295,     BSO_Y - O_R - 28), 'SV', font=f14, fill=0)
-            draw.text((295 + 1, BSO_Y - O_R - 28), 'SV', font=f14, fill=0)
+        # Last event  (f36, prominent)
+        _ev_y = _bso_y + 62   # 377
+        if _last_ev:
+            draw.text((16, _ev_y),     _last_ev, font=f36, fill=0)
+            draw.text((17, _ev_y),     _last_ev, font=f36, fill=0)
 
-        # ── Pitcher / batter info ─────────────────────────────────────────────
+        # Pitcher  (f28)
+        _pb_y = _bso_y + 104  # 419
         _pitcher = _format_player_name(game_data.get('current_pitcher') or '')
-        if _pitcher:
-            draw.text((12, INFO_Y), f'P: {_pitcher}', font=f20, fill=0)
+        if _pitcher and _pb_y + 28 <= 478:
+            draw.text((16, _pb_y), f'P: {_pitcher}', font=f28, fill=0)
 
-        _bh      = game_data.get('batter_hits')
-        _ba      = game_data.get('batter_at_bats')
-        _ba_str2 = f'({_bh}-{_ba})' if _bh is not None and _ba is not None else ''
+        # Batter  (f28)
+        _pb_y2  = _pb_y + 32  # 451
+        _bh     = game_data.get('batter_hits')
+        _ba     = game_data.get('batter_at_bats')
+        _ba_str = f'({_bh}-{_ba})' if _bh is not None and _ba is not None else ''
         _ab_done = game_data.get('current_at_bat_complete', False)
         if _ab_done and not _is_game_effectively_over(game_data):
             _batter  = _format_player_name(
@@ -1210,28 +1209,8 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
         else:
             _batter  = _format_player_name(game_data.get('current_hitter') or '')
             _bat_lbl = 'AB'
-        if _batter:
-            _bat_str2 = f'{_bat_lbl}: {_batter}  {_ba_str2}'.strip()
-            draw.text((12, INFO_Y + 26), _bat_str2, font=f20, fill=0)
-
-        # Last play — right-aligned beside pitcher/batter lines
-        _sub_ev2 = (game_data.get('sub_event') or '').strip()
-        _lp_val  = game_data.get('last_play') or ''
-        _play_f  = _sub_ev2 or _lp_val
-        if _play_f:
-            _pd2  = _abbr_play(_play_f) if not _sub_ev2 else _play_f
-            _rbi2 = int(game_data.get('last_play_rbi') or 0)
-            if _rbi2 > 0 and not _sub_ev2:
-                if _pd2 == 'HR':
-                    if _rbi2 >= 2:
-                        _pd2 = f'{_rbi2}R HR'
-                elif _rbi2 == 1:
-                    _pd2 = f'RBI {_pd2}'
-                else:
-                    _pd2 = f'{_rbi2}RBI {_pd2}'
-            _pdw = int(f20.getlength(_pd2))
-            draw.text((799 - _pdw - 10, INFO_Y), _pd2, font=f20, fill=0)
-            draw.text((800 - _pdw - 10, INFO_Y), _pd2, font=f20, fill=0)
+        if _batter and _pb_y2 + 28 <= 478:
+            draw.text((16, _pb_y2), f'{_bat_lbl}: {_batter}  {_ba_str}'.strip(), font=f28, fill=0)
 
     return canvas
 
@@ -1248,6 +1227,13 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
 
     _ds = game_data.get('detailed_state', '')
     _is_live = _ds in ('In Progress', 'Player challenge', 'Manager challenge')
+
+    # Live game: custom full-screen layout (no sidebars, R/H/E + bases)
+    if _is_live:
+        _live_canvas = draw_live_fullscreen_game(game_data, team_data, config)
+        if config.get('dark_mode', False):
+            _live_canvas = ImageOps.invert(_live_canvas.convert('L')).convert('1')
+        return _live_canvas
 
     use_logos   = config.get('use_team_logos', False)
     logo_offset = config.get('small_logo_x_offset', 2)

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -526,15 +526,26 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
     _two_games = (not same_series) and away_game and home_game
     _use_full_time = not _two_games
 
+    strip_right = BAR_X + BAR_W - 1 * s   # rightmost pixel the strip may use
+
+    def _fit_time(t_full, t_abbr, cx, right_limit):
+        """Return the best time string that fits to the right of cx, or '' if none fits."""
+        for t in (t_full, t_abbr):
+            if t and cx + TIME_PAD + int(font14.getlength(t)) <= right_limit:
+                return t
+        return ''
+
     def _draw_single(g, full=True):
-        """Left-to-right: away logo  @  home logo  TIME (immediately after)."""
+        """Left-to-right: away logo  @  home logo  TIME (immediately after, if it fits)."""
         a_abbr = abbr_map.get(str(g['away_team_id']), '')
         h_abbr = abbr_map.get(str(g['home_team_id']), '')
-        t_str  = _game_time(g, full=full)
         cx = BAR_X + 1 * s + left_offset
         cx = _place_logo(a_abbr, g['away_team_id'], cx)
         cx = _draw_vs(cx)
         cx = _place_logo(h_abbr, g['home_team_id'], cx)
+        t_full  = _game_time(g, full=True)
+        t_abbr  = _game_time(g, full=False)
+        t_str   = _fit_time(t_full, t_abbr, cx, strip_right)
         if t_str:
             _tx = cx + TIME_PAD
             draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
@@ -545,8 +556,8 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         return
 
     # New series — only draw the entry for each team that actually has a game.
-    # Single-team entries use full "H:MMp" time immediately after the matchup.
-    # Two different games share the strip → abbreviated time, away LEFT / home RIGHT.
+    # Single-team entries use full "H:MMp" time if it fits, abbreviated otherwise.
+    # Two different games share the strip → abbreviated preferred; each half checked independently.
 
     if away_game and not home_game:
         _draw_single(away_game, full=True)
@@ -556,25 +567,29 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         _draw_single(home_game, full=True)
         return
 
-    # Both teams have different games — abbreviated time, time immediately after each matchup.
-    # Away team's game starts at the left edge; home team's game starts at the strip midpoint.
-    def _draw_half(g, start_cx):
+    # Both teams have different games.
+    # Away entry starts at left edge, may use up to the strip midpoint.
+    # Home entry starts at the strip midpoint, may use up to strip_right.
+    mid = BAR_X + BAR_W // 2
+
+    def _draw_half(g, start_cx, right_limit):
         a_abbr = abbr_map.get(str(g['away_team_id']), '')
         h_abbr = abbr_map.get(str(g['home_team_id']), '')
-        t_str  = _game_time(g, full=False)
         cx = start_cx
         cx = _place_logo(a_abbr, g['away_team_id'], cx)
         cx = _draw_vs(cx)
         cx = _place_logo(h_abbr, g['home_team_id'], cx)
+        t_abbr = _game_time(g, full=False)
+        t_str  = _fit_time('', t_abbr, cx, right_limit)   # abbreviated only for split strip
         if t_str:
             _tx = cx + TIME_PAD
             draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
             draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
 
     if away_game:
-        _draw_half(away_game, BAR_X + left_offset)
+        _draw_half(away_game, BAR_X + left_offset, mid - 2 * s)
     if home_game:
-        _draw_half(home_game, BAR_X + BAR_W // 2)
+        _draw_half(home_game, mid, strip_right)
 
 
 def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1):

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -526,134 +526,55 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
     _two_games = (not same_series) and away_game and home_game
     _use_full_time = not _two_games
 
-    if same_series:
-        # Series continues — teams left-aligned, start time right-aligned, full format
-        g = away_game
+    def _draw_single(g, full=True):
+        """Left-to-right: away logo  @  home logo  TIME (immediately after)."""
         a_abbr = abbr_map.get(str(g['away_team_id']), '')
         h_abbr = abbr_map.get(str(g['home_team_id']), '')
-        t_str = _game_time(g, full=True)
-        cur_x = BAR_X + 1 * s + left_offset
-        cur_x = _place_logo(a_abbr, g['away_team_id'], cur_x)
-        cur_x = _draw_vs(cur_x)
-        _place_logo(h_abbr, g['home_team_id'], cur_x)
+        t_str  = _game_time(g, full=full)
+        cx = BAR_X + 1 * s + left_offset
+        cx = _place_logo(a_abbr, g['away_team_id'], cx)
+        cx = _draw_vs(cx)
+        cx = _place_logo(h_abbr, g['home_team_id'], cx)
         if t_str:
-            t_w = int(font14.getlength(t_str))
-            _tx = BAR_X + BAR_W - t_w - 1 * s
+            _tx = cx + TIME_PAD
             draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
             draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
+
+    if same_series:
+        _draw_single(away_game, full=True)
         return
 
     # New series — only draw the entry for each team that actually has a game.
-    # If only one team has a game, it gets the full strip width → use full time.
-    # If both teams have different games, each gets half the strip → use abbreviated time.
+    # Single-team entries use full "H:MMp" time immediately after the matchup.
+    # Two different games share the strip → abbreviated time, away LEFT / home RIGHT.
 
     if away_game and not home_game:
-        # Only the away team plays tomorrow — left-aligned, full time right-aligned
-        a_abbr = abbr_map.get(str(away_game['away_team_id']), '')
-        h_abbr = abbr_map.get(str(away_game['home_team_id']), '')
-        t_str = _game_time(away_game, full=True)
-        cur_x = BAR_X + left_offset
-        cur_x = _place_logo(a_abbr, away_game['away_team_id'], cur_x)
-        cur_x = _draw_vs(cur_x)
-        _place_logo(h_abbr, away_game['home_team_id'], cur_x)
-        if t_str:
-            t_w = int(font14.getlength(t_str))
-            _tx = BAR_X + BAR_W - t_w - 1 * s
-            draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
-            draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
+        _draw_single(away_game, full=True)
         return
 
     if home_game and not away_game:
-        # Only the home team plays tomorrow — right-aligned, full time right-anchored
-        a_abbr = abbr_map.get(str(home_game['away_team_id']), '')
-        h_abbr = abbr_map.get(str(home_game['home_team_id']), '')
-        t_str = _game_time(home_game, full=True)
-
-        _h_lg = (_logo_small(str(h_abbr), str(home_game['home_team_id']), size=LOGO_SZ)
-                 if use_logos and home_game.get('home_team_id') else None)
-        _a_lg = (_logo_small(str(a_abbr), str(home_game['away_team_id']), size=LOGO_SZ)
-                 if use_logos and home_game.get('away_team_id') else None)
-        h_w = _h_lg.size[0] if _h_lg else int(font14.getlength((h_abbr or '')[:3]))
-        a_w = _a_lg.size[0] if _a_lg else int(font14.getlength((a_abbr or '')[:3]))
-        t_w = int(font14.getlength(t_str)) if t_str else 0
-
-        right = start_x + horizonta_len
-        if t_str:
-            _tx = right - t_w
-            draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
-            draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
-            right = _tx - TIME_PAD
-        if _h_lg:
-            right -= _h_lg.size[0]
-            _paste_logo(Himage, _h_lg, (right, BAR_Y + (BAR_H - _h_lg.size[1]) // 2))
-            draw = ImageDraw.Draw(Himage)
-        else:
-            right -= h_w
-            draw.text((right, _text_y), (h_abbr or '')[:3], font=font14, fill=0)
-        right -= at_w + VS_PAD
-        draw.text((right, _vs_y), at_str, font=font14, fill=0)
-        right -= VS_PAD
-        if _a_lg:
-            right -= _a_lg.size[0]
-            _paste_logo(Himage, _a_lg, (right, BAR_Y + (BAR_H - _a_lg.size[1]) // 2))
-            draw = ImageDraw.Draw(Himage)
-        else:
-            right -= a_w
-            draw.text((right, _text_y), (a_abbr or '')[:3], font=font14, fill=0)
+        _draw_single(home_game, full=True)
         return
 
-    # Both teams have different games — abbreviated time, away LEFT / home RIGHT
+    # Both teams have different games — abbreviated time, time immediately after each matchup.
+    # Away team's game starts at the left edge; home team's game starts at the strip midpoint.
+    def _draw_half(g, start_cx):
+        a_abbr = abbr_map.get(str(g['away_team_id']), '')
+        h_abbr = abbr_map.get(str(g['home_team_id']), '')
+        t_str  = _game_time(g, full=False)
+        cx = start_cx
+        cx = _place_logo(a_abbr, g['away_team_id'], cx)
+        cx = _draw_vs(cx)
+        cx = _place_logo(h_abbr, g['home_team_id'], cx)
+        if t_str:
+            _tx = cx + TIME_PAD
+            draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
+            draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
+
     if away_game:
-        a_abbr = abbr_map.get(str(away_game['away_team_id']), '')
-        h_abbr = abbr_map.get(str(away_game['home_team_id']), '')
-        t_str = _game_time(away_game, full=False)
-        cur_x = BAR_X - 1 * s + left_offset
-        cur_x = _place_logo(a_abbr, away_game['away_team_id'], cur_x)
-        cur_x = _draw_vs(cur_x)
-        cur_x = _place_logo(h_abbr, away_game['home_team_id'], cur_x)
-        if t_str:
-            _tx = cur_x + TIME_PAD
-            draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
-            draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
-
+        _draw_half(away_game, BAR_X + left_offset)
     if home_game:
-        a_abbr = abbr_map.get(str(home_game['away_team_id']), '')
-        h_abbr = abbr_map.get(str(home_game['home_team_id']), '')
-        t_str = _game_time(home_game, full=False)
-
-        _h_lg = (_logo_small(str(h_abbr), str(home_game['home_team_id']), size=LOGO_SZ)
-                 if use_logos and home_game.get('home_team_id') else None)
-        _a_lg = (_logo_small(str(a_abbr), str(home_game['away_team_id']), size=LOGO_SZ)
-                 if use_logos and home_game.get('away_team_id') else None)
-        h_w = _h_lg.size[0] if _h_lg else int(font14.getlength((h_abbr or '')[:3]))
-        a_w = _a_lg.size[0] if _a_lg else int(font14.getlength((a_abbr or '')[:3]))
-        t_w = int(font14.getlength(t_str)) if t_str else 0
-
-        right = start_x + horizonta_len
-        if t_str:
-            _tx = right - t_w
-            draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
-            draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
-            right = _tx - TIME_PAD
-        if _h_lg:
-            actual_y = BAR_Y + (BAR_H - _h_lg.size[1]) // 2
-            right -= _h_lg.size[0]
-            _paste_logo(Himage, _h_lg, (right, actual_y))
-            draw = ImageDraw.Draw(Himage)
-        else:
-            right -= h_w
-            draw.text((right, _text_y), (h_abbr or '')[:3], font=font14, fill=0)
-        right -= at_w + VS_PAD
-        draw.text((right, _vs_y), at_str, font=font14, fill=0)
-        right -= VS_PAD
-        if _a_lg:
-            actual_y = BAR_Y + (BAR_H - _a_lg.size[1]) // 2
-            right -= _a_lg.size[0]
-            _paste_logo(Himage, _a_lg, (right, actual_y))
-            draw = ImageDraw.Draw(Himage)
-        else:
-            right -= a_w
-            draw.text((right, _text_y), (a_abbr or '')[:3], font=font14, fill=0)
+        _draw_half(home_game, BAR_X + BAR_W // 2)
 
 
 def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1):

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -454,14 +454,23 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
     _cfg = load_yaml_file('config.yaml')
     _tz_str = _cfg.get('timezone', 'America/Chicago')
 
-    def _game_time(game):
+    def _game_time(game, full=False):
+        """Return a localised start-time string for game.
+
+        full=False  →  '7p'     (hour + am/pm letter, no minutes)
+        full=True   →  '7:05p'  (hour:minute + am/pm letter)
+        """
         utc_str = game.get('game_start_utc', '')
         if not utc_str:
             return ''
         try:
             _utc = pytz.utc.localize(_datetime.strptime(utc_str[:19], '%Y-%m-%dT%H:%M:%S'))
             _local = _utc.astimezone(pytz.timezone(_tz_str))
-            return _local.strftime('%-I') + _local.strftime('%p').lower()[0]
+            _ampm = _local.strftime('%p').lower()[0]
+            if full:
+                return _local.strftime('%-I:%M') + _ampm
+            else:
+                return _local.strftime('%-I') + _ampm
         except Exception:
             return ''
 
@@ -472,18 +481,25 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         return None
 
     VS_PAD = 1 * s   # pixels on each side of the vs. text
-    TIME_PAD = 2 * s # gap before the time string
+    TIME_PAD = 2 * s # gap between matchup and time string
+
+    def _logo_w(abbr, team_id):
+        """Return the pixel width of the logo or abbreviation text for sizing."""
+        if use_logos and team_id:
+            lg = _logo_small(str(abbr), str(team_id), size=LOGO_SZ)
+            if lg:
+                return lg.size[0]
+        return int(font14.getlength((str(abbr) or '')[:3]))
 
     def _place_logo(abbr, team_id, x):
         nonlocal draw
         if use_logos and team_id:
             lg = _logo_small(str(abbr), str(team_id), size=LOGO_SZ)
             if lg:
-                # Center vertically by actual rendered height, not LOGO_SZ
                 actual_y = BAR_Y + (BAR_H - lg.size[1]) // 2
                 _paste_logo(Himage, lg, (x, actual_y))
                 draw = ImageDraw.Draw(Himage)
-                return x + lg.size[0]  # advance by actual width
+                return x + lg.size[0]
         t = (str(abbr) or '')[:3]
         draw.text((x, _text_y), t, font=font14, fill=0)
         return x + int(font14.getlength(t))
@@ -491,7 +507,6 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
     def _draw_vs(x):
         draw.text((x + VS_PAD, _vs_y), at_str, font=font14, fill=0)
         return x + VS_PAD + at_w + VS_PAD
-
 
     away_game = _find_game(today_away_id)
     home_game = _find_game(today_home_id)
@@ -506,12 +521,17 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         away_game.get('home_team_id') == today_home_id
     )
 
+    # Use full "H:MMp" time when only one matchup fills the whole strip (room to breathe).
+    # When two different games must share the strip, fall back to abbreviated "Hp".
+    _two_games = (not same_series) and away_game and home_game
+    _use_full_time = not _two_games
+
     if same_series:
-        # Series continues — single entry left-aligned, time right-aligned
+        # Series continues — teams left-aligned, start time right-aligned, full format
         g = away_game
         a_abbr = abbr_map.get(str(g['away_team_id']), '')
         h_abbr = abbr_map.get(str(g['home_team_id']), '')
-        t_str = _game_time(g)
+        t_str = _game_time(g, full=True)
         cur_x = BAR_X + 1 * s + left_offset
         cur_x = _place_logo(a_abbr, g['away_team_id'], cur_x)
         cur_x = _draw_vs(cur_x)
@@ -523,12 +543,71 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
             draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
         return
 
-    # New series — away team's game LEFT, home team's game RIGHT
+    # New series — only draw the entry for each team that actually has a game.
+    # If only one team has a game, it gets the full strip width → use full time.
+    # If both teams have different games, each gets half the strip → use abbreviated time.
+
+    if away_game and not home_game:
+        # Only the away team plays tomorrow — left-aligned, full time right-aligned
+        a_abbr = abbr_map.get(str(away_game['away_team_id']), '')
+        h_abbr = abbr_map.get(str(away_game['home_team_id']), '')
+        t_str = _game_time(away_game, full=True)
+        cur_x = BAR_X + left_offset
+        cur_x = _place_logo(a_abbr, away_game['away_team_id'], cur_x)
+        cur_x = _draw_vs(cur_x)
+        _place_logo(h_abbr, away_game['home_team_id'], cur_x)
+        if t_str:
+            t_w = int(font14.getlength(t_str))
+            _tx = BAR_X + BAR_W - t_w - 1 * s
+            draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
+            draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
+        return
+
+    if home_game and not away_game:
+        # Only the home team plays tomorrow — right-aligned, full time right-anchored
+        a_abbr = abbr_map.get(str(home_game['away_team_id']), '')
+        h_abbr = abbr_map.get(str(home_game['home_team_id']), '')
+        t_str = _game_time(home_game, full=True)
+
+        _h_lg = (_logo_small(str(h_abbr), str(home_game['home_team_id']), size=LOGO_SZ)
+                 if use_logos and home_game.get('home_team_id') else None)
+        _a_lg = (_logo_small(str(a_abbr), str(home_game['away_team_id']), size=LOGO_SZ)
+                 if use_logos and home_game.get('away_team_id') else None)
+        h_w = _h_lg.size[0] if _h_lg else int(font14.getlength((h_abbr or '')[:3]))
+        a_w = _a_lg.size[0] if _a_lg else int(font14.getlength((a_abbr or '')[:3]))
+        t_w = int(font14.getlength(t_str)) if t_str else 0
+
+        right = start_x + horizonta_len
+        if t_str:
+            _tx = right - t_w
+            draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
+            draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
+            right = _tx - TIME_PAD
+        if _h_lg:
+            right -= _h_lg.size[0]
+            _paste_logo(Himage, _h_lg, (right, BAR_Y + (BAR_H - _h_lg.size[1]) // 2))
+            draw = ImageDraw.Draw(Himage)
+        else:
+            right -= h_w
+            draw.text((right, _text_y), (h_abbr or '')[:3], font=font14, fill=0)
+        right -= at_w + VS_PAD
+        draw.text((right, _vs_y), at_str, font=font14, fill=0)
+        right -= VS_PAD
+        if _a_lg:
+            right -= _a_lg.size[0]
+            _paste_logo(Himage, _a_lg, (right, BAR_Y + (BAR_H - _a_lg.size[1]) // 2))
+            draw = ImageDraw.Draw(Himage)
+        else:
+            right -= a_w
+            draw.text((right, _text_y), (a_abbr or '')[:3], font=font14, fill=0)
+        return
+
+    # Both teams have different games — abbreviated time, away LEFT / home RIGHT
     if away_game:
         a_abbr = abbr_map.get(str(away_game['away_team_id']), '')
         h_abbr = abbr_map.get(str(away_game['home_team_id']), '')
-        t_str = _game_time(away_game)
-        cur_x = BAR_X - 1 * s + left_offset  # start after any doubleheader label
+        t_str = _game_time(away_game, full=False)
+        cur_x = BAR_X - 1 * s + left_offset
         cur_x = _place_logo(a_abbr, away_game['away_team_id'], cur_x)
         cur_x = _draw_vs(cur_x)
         cur_x = _place_logo(h_abbr, away_game['home_team_id'], cur_x)
@@ -540,9 +619,8 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
     if home_game:
         a_abbr = abbr_map.get(str(home_game['away_team_id']), '')
         h_abbr = abbr_map.get(str(home_game['home_team_id']), '')
-        t_str = _game_time(home_game)
+        t_str = _game_time(home_game, full=False)
 
-        # Pre-load logos to get their actual pixel widths.
         _h_lg = (_logo_small(str(h_abbr), str(home_game['home_team_id']), size=LOGO_SZ)
                  if use_logos and home_game.get('home_team_id') else None)
         _a_lg = (_logo_small(str(a_abbr), str(home_game['away_team_id']), size=LOGO_SZ)
@@ -551,42 +629,31 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         a_w = _a_lg.size[0] if _a_lg else int(font14.getlength((a_abbr or '')[:3]))
         t_w = int(font14.getlength(t_str)) if t_str else 0
 
-        # Draw right-to-left so the entry is truly anchored to the cell's right edge.
-        right = start_x + horizonta_len  # rightmost cell pixel
-
-        # Time (rightmost element)
+        right = start_x + horizonta_len
         if t_str:
             _tx = right - t_w
             draw.text((_tx,         _time_y), t_str, font=font14, fill=0)
             draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
             right = _tx - TIME_PAD
-
-        # Home logo (already loaded above)
         if _h_lg:
             actual_y = BAR_Y + (BAR_H - _h_lg.size[1]) // 2
             right -= _h_lg.size[0]
             _paste_logo(Himage, _h_lg, (right, actual_y))
             draw = ImageDraw.Draw(Himage)
         else:
-            t = (h_abbr or '')[:3]
             right -= h_w
-            draw.text((right, _text_y), t, font=font14, fill=0)
-
-        # vs. separator
+            draw.text((right, _text_y), (h_abbr or '')[:3], font=font14, fill=0)
         right -= at_w + VS_PAD
         draw.text((right, _vs_y), at_str, font=font14, fill=0)
         right -= VS_PAD
-
-        # Away logo (already loaded above)
         if _a_lg:
             actual_y = BAR_Y + (BAR_H - _a_lg.size[1]) // 2
             right -= _a_lg.size[0]
             _paste_logo(Himage, _a_lg, (right, actual_y))
             draw = ImageDraw.Draw(Himage)
         else:
-            t = (a_abbr or '')[:3]
             right -= a_w
-            draw.text((right, _text_y), t, font=font14, fill=0)
+            draw.text((right, _text_y), (a_abbr or '')[:3], font=font14, fill=0)
 
 
 def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1):

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -24,15 +24,15 @@ def normalize_dict(d):
     return d
 
 
-def draw_diamond(Himage, center, size, fill=False):
+def draw_diamond(Himage, center, size, fill=False, outline_width=1):
     draw = ImageDraw.Draw(Himage)
     x, y = center
     diamond = [(x, y - size), (x + size, y), (x, y + size), (x - size, y)]
 
     if fill:
-        draw.polygon(diamond, fill='black', outline='black')
+        draw.polygon(diamond, fill='black', outline='black', width=outline_width)
     else:
-        draw.polygon(diamond, outline='black')
+        draw.polygon(diamond, outline='black', width=outline_width)
     return Himage
 
 


### PR DESCRIPTION
## Summary

### Live fullscreen (v4 layout)
- Restore balls/strikes/outs circles (B/S/O) — were removed in previous refactor
- Restore pitcher and batter lines (f28) below the situation area
- Restore last event display (f36, prominent) for active pitch AND between-innings
- Manager/Player challenge states now shown as last event ('M CHAL' / 'ABS CHAL')
- Large inning label (f80), matchup header (f56), bases diamond right-side spanning both score rows, outs circles below bases

### Morning-mode tomorrow_games fix
- `fetch_tomorrow_games` was missing `for_date` parameter — `image_box._load_tomorrow_games` was calling it with `for_date=_target` which silently raised `TypeError` every morning, leaving preview strips blank
- Added `for_date` param to `fetch_tomorrow_games`; `main.py` step 6b now passes `for_date=today` in morning mode so both callers agree and the fight over `tomorrow_games.json` is eliminated

### Next-game preview strip polish
- Full `H:MMp` start time when a single matchup owns the whole strip (same series / one team off day)
- Abbreviated `Hp` for split two-game strips
- Time placed immediately after the last logo — not right-aligned to the strip edge
- Overlap guard: `_fit_time()` tries full → abbreviated → omits if neither fits within the available half-width, preventing text collision

## Test plan
- [x] Rendered v4 active-pitch, between-innings, and challenge frames locally
- [x] Preview strip rendered with same-series, split two-game, and single-team cases
- [x] `fetch_tomorrow_games(for_date=...)` verified with mock requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)