### PR TITLE
Live fullscreen v5: complete UI overhaul

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,7 +58,7 @@ night_end: 7     # 7am
 # results and today's schedule every 5 minutes. Before night_end always shows yesterday;
 # at/after morning_end always shows today.
 morning_alternate_games: true
-morning_end: 9   # hour (24h) when "yesterday" mode ends and today's games take over
+morning_end: 11  # hour (24h) when "yesterday" mode ends and today's games take over
 
 
 # Team emoji overrides: display emoji instead of logo for these teams

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -880,15 +880,15 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     draw   = ImageDraw.Draw(canvas)
 
     # ---- Fonts ---------------------------------------------------------------
-    f11  = _get_font(11)    # runner jersey numbers inside bases
-    f14  = _get_font(14)    # pitch info / column labels
-    f24  = _get_font(24)    # between-innings batter/pitcher names
-    f28  = _get_font(28)    # pitcher / batter line (bottom, live)
-    f36  = _get_font(36)    # last event  (prominent)
-    f42  = _get_font(42)    # BSO labels + team abbreviations
-    f56  = _get_font(56)    # matchup header (4x f14)
+    f14  = _get_font(14)    # ABS / challenge labels
+    f22  = _get_font(22)    # runner jersey numbers inside bases (doubled)
+    f24  = _get_font(24)    # pitch info / between-innings names
+    f28  = _get_font(28)    # misc
+    f36  = _get_font(36)    # misc
+    f42  = _get_font(42)    # BSO labels + pitcher/batter + team abbreviations
+    f56  = _get_font(56)    # matchup header fallback
     f72  = _get_font(72)    # R / H / E values
-    f80  = _get_font(80)    # inning text (4x f20)
+    f80  = _get_font(80)    # inning text + last event in header
 
     # ---- Team identifiers ----------------------------------------------------
     abbr_map  = team_data.get('team_abbreviation', {})
@@ -910,15 +910,17 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     _pitching_change = (game_data.get('sub_event') or '').startswith('PC:')
 
     # ---- Layout constants ----------------------------------------------------
-    HEADER_H   = 92           # big header (f80 inning + breathing room)
-    LABEL_H    = 20           # R/H/E column label row
+    HEADER_H   = 69           # 25% smaller than original 92 → freed pixels go to bottom bar
+    LABEL_H    = 20           # space between header and first team row
     TEAM_ROW_H = 80           # away/home score rows
-    AWAY_Y     = HEADER_H + LABEL_H          # 112
-    HOME_Y     = AWAY_Y  + TEAM_ROW_H        # 192
-    OUTS_Y_TOP = HOME_Y  + TEAM_ROW_H        # 272  (outs circles here)
-    OUTS_H     = 36
-    DIV_Y      = OUTS_Y_TOP + OUTS_H         # 308
-    SIT_Y      = DIV_Y + 1                   # 309
+    AWAY_Y     = HEADER_H + LABEL_H          # 89
+    HOME_Y     = AWAY_Y  + TEAM_ROW_H        # 169
+    OUTS_Y_TOP = HOME_Y  + TEAM_ROW_H - 21  # 228 → 8px below bases bottom (224)
+    OUTS_H     = 48                          # circles bottom at 272, +4px gap = div at 276
+    DIV_Y      = OUTS_Y_TOP + OUTS_H         # 276
+    SIT_Y      = DIV_Y + 1                   # 277
+    WIN_PCT_H  = 54                          # 3× win % bar
+    WIN_PCT_Y  = 480 - WIN_PCT_H             # 426
 
     # Team row layout
     LOGO_SZ  = 72
@@ -930,19 +932,25 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     H_CX = 360
     E_CX = 480
 
-    # Bases: right side, centre at the boundary between the two score rows
+    # Bases: right side — doubled size, repositioned to fit
     DIAMOND_CX = 645
-    DIAMOND_CY = HOME_Y                      # 192
-    BASE_DIST  = 52
-    BASE_SZ    = 24
-    BASE_OW    = 3
+    DIAMOND_CY = 178                         # shifted up more
+    BASE_DIST  = 58                          # closer together
+    BASE_SZ    = 46                          # ~2x the original 24
+    BASE_OW    = 4
 
     # BSO circles (bottom half)
-    B_R   = 12
-    O_R   = 16
+    B_R   = 16                               # 30% bigger than original 12
+    O_R   = 20                               # bigger outs circles
     C_GAP = 5
 
-    # ---- Last-event helper ---------------------------------------------------
+    # ---- Last-event helper (built early for header use) ----------------------
+    _FLD_POS = [
+        ('center fielder', '8'), ('right fielder', '9'), ('left fielder', '7'),
+        ('first baseman', '3'), ('second baseman', '4'), ('third baseman', '5'),
+        ('shortstop', '6'), ('catcher', '2'), ('pitcher', '1'),
+    ]
+
     def _build_last_event():
         _sub_ev = (game_data.get('sub_event') or '').strip()
         _lp     = game_data.get('last_play') or ''
@@ -950,6 +958,14 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
         if not _raw:
             return ''
         _pd  = _abbr_play(_raw)
+        # Resolve flyout/lineout to F7/L6 etc. using the play description
+        if _pd in ('FO', 'LO', 'PO'):
+            _prefix = _pd[0]
+            _desc   = (game_data.get('last_play_description') or '').lower()
+            for _kw, _code in _FLD_POS:
+                if _kw in _desc:
+                    _pd = f'{_prefix}{_code}'
+                    break
         _rbi = int(game_data.get('last_play_rbi') or 0)
         if _rbi > 0 and not _sub_ev:
             if _pd == 'HR':
@@ -961,39 +977,53 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
                 _pd = f'{_rbi}RBI {_pd}'
         return _pd
 
-    # ---- HEADER (full-width thick line below) --------------------------------
-    # Inning: f80, top-left
-    draw.text((8, 4),  inning_str, font=f80, fill=0)
-    draw.text((9, 4),  inning_str, font=f80, fill=0)   # pseudo-bold
+    _last_ev = _build_last_event()
 
-    # Matchup + date: f56, right-aligned, vertically centred in header
-    _gd_str   = (game_data.get('game_date') or '')[:10]
-    _date_lbl = ''
-    if _gd_str:
-        try:
-            _gd_dt    = datetime.strptime(_gd_str, '%Y-%m-%d')
-            _date_lbl = _gd_dt.strftime('%b %-d')
-        except Exception:
-            _date_lbl = _gd_str
-    _hdr_right = f'{away_abbr} @ {home_abbr}' + (f'  {_date_lbl}' if _date_lbl else '')
-    _inn_w     = int(f80.getlength(inning_str)) + 8 + 16   # min gap after inning
-    _hrw       = int(f56.getlength(_hdr_right))
-    _hdr_x     = 800 - _hrw - 8
-    if _hdr_x < _inn_w:
-        # Fall back to teams-only if date makes it too wide
-        _hdr_right = f'{away_abbr} @ {home_abbr}'
-        _hrw       = int(f56.getlength(_hdr_right))
-        _hdr_x     = 800 - _hrw - 8
-    if _hdr_x > _inn_w:
-        _hry = max(4, (HEADER_H - 56) // 2)
-        draw.text((_hdr_x, _hry), _hdr_right, font=f56, fill=0)
+    # ---- HEADER (69px — full-width thick line below) ------------------------
+    # Inning: f56 fits in 69px header. Triangle 80% of numeral height.
+    _inn_x = 8
+    _inn_y = 4
+    _inn_font = f56
+    if _inn_lbl in ('▲', '▼'):
+        _nbbox   = _inn_font.getbbox(_inn_ord)
+        _n_top   = _inn_y + _nbbox[1]
+        _n_bot   = _inn_y + _nbbox[3]
+        _n_h     = _n_bot - _n_top
+        _tri_h   = int(_n_h * 0.80)
+        _tri_mid = (_n_top + _n_bot) // 2
+        _tri_top = _tri_mid - _tri_h // 2
+        _tri_bot = _tri_top + _tri_h
+        _t_cx    = _inn_x + _tri_h // 2
+        _t_rgt   = _inn_x + _tri_h
+        if _inn_lbl == '▲':
+            draw.polygon([(_t_cx, _tri_top), (_inn_x, _tri_bot), (_t_rgt, _tri_bot)], fill=0)
+        else:
+            draw.polygon([(_inn_x, _tri_top), (_t_rgt, _tri_top), (_t_cx, _tri_bot)], fill=0)
+        _num_x = _t_rgt + 8
+        draw.text((_num_x,     _inn_y), _inn_ord, font=_inn_font, fill=0)
+        draw.text((_num_x + 1, _inn_y), _inn_ord, font=_inn_font, fill=0)
+        _inn_right_edge = _num_x + int(_inn_font.getlength(_inn_ord))
+    else:
+        draw.text((_inn_x,     _inn_y), inning_str, font=_inn_font, fill=0)
+        draw.text((_inn_x + 1, _inn_y), inning_str, font=_inn_font, fill=0)
+        _inn_right_edge = _inn_x + int(_inn_font.getlength(inning_str))
 
-    draw.line((0, HEADER_H - 1, 799, HEADER_H - 1), fill=0, width=2)
+    # Right side of header: last event (f56) right-aligned; fall back to matchup (f36)
+    _inn_min_right = _inn_right_edge + 16
+    if _last_ev:
+        _hdr_right_txt  = _last_ev
+        _hdr_right_font = f56
+    else:
+        _hdr_right_txt  = f'{away_abbr} @ {home_abbr}'
+        _hdr_right_font = f36
+    _hrw   = int(_hdr_right_font.getlength(_hdr_right_txt))
+    _hdr_x = 800 - _hrw - 8
+    if _hdr_x > _inn_min_right:
+        _hry = max(4, (HEADER_H - _hdr_right_font.size) // 2)
+        draw.text((_hdr_x,     _hry), _hdr_right_txt, font=_hdr_right_font, fill=0)
+        draw.text((_hdr_x + 1, _hry), _hdr_right_txt, font=_hdr_right_font, fill=0)
 
-    # ---- R / H / E COLUMN LABELS --------------------------------------------
-    for _lbl2, _cx2 in (('R', R_CX), ('H', H_CX), ('E', E_CX)):
-        _lw2 = int(f14.getlength(_lbl2))
-        draw.text((_cx2 - _lw2 // 2, HEADER_H + 3), _lbl2, font=f14, fill=0)
+    draw.line((0, HEADER_H - 1, 799, HEADER_H - 1), fill=0, width=5)
 
     # ---- SCORE DATA ---------------------------------------------------------
     away_runs = str(game_data.get('away_runs') or 0)
@@ -1006,12 +1036,9 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     _away_ahead = (game_data.get('away_runs') or 0) > (game_data.get('home_runs') or 0)
     _home_ahead = (game_data.get('home_runs') or 0) > (game_data.get('away_runs') or 0)
 
-    def _draw_team_row(abbr, tid, row_y, runs, hits, errs, bold_score=False, batting=False):
+    def _draw_team_row(abbr, tid, row_y, runs, hits, errs, bold_score=False,
+                       batting=False, abs_remaining=None, replay_remaining=None):
         nonlocal draw, canvas
-        if batting:
-            _bi_r  = 7
-            _bi_cy = row_y + TEAM_ROW_H // 2
-            draw.ellipse([-_bi_r, _bi_cy - _bi_r, _bi_r, _bi_cy + _bi_r], fill=0)
         if use_logos:
             _lg = _logo_small(abbr, tid, size=LOGO_SZ)
             if _lg:
@@ -1023,6 +1050,37 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
         _abbr_y = row_y + (TEAM_ROW_H - 42) // 2
         draw.text((ABBR_X,     _abbr_y), abbr, font=f42, fill=0)
         draw.text((ABBR_X + 1, _abbr_y), abbr, font=f42, fill=0)
+
+        # ABS challenges — rectangles above abbreviation, starting at ABBR_X
+        # filled = challenge available, empty outline = challenge used
+        if abs_remaining is not None:
+            _abs_max = game_data.get('abs_challenge_max') or 2
+            _rw, _rh = 36, 10
+            _r_gap   = 4
+            _r_top   = _abbr_y - _rh + 5   # moved down 4px more
+            _r_left  = ABBR_X
+            if _r_top >= row_y:
+                for i in range(_abs_max):
+                    _rx0, _ry0 = _r_left, _r_top
+                    _rx1, _ry1 = _rx0 + _rw, _ry0 + _rh
+                    if i < abs_remaining:   # filled = available
+                        draw.rectangle([_rx0, _ry0, _rx1, _ry1], fill=0)
+                    else:                   # outline only = used
+                        draw.rectangle([_rx0, _ry0, _rx1, _ry1], outline=0, width=2)
+                    _r_left += _rw + _r_gap
+
+        # Manager replay challenge — rectangle below abbreviation, starting at ABBR_X
+        # filled = challenge available, empty outline = used
+        if replay_remaining is not None:
+            _rw, _rh = 36, 10
+            _r_top   = _abbr_y + 42 + 3
+            _r_left  = ABBR_X
+            if _r_top + _rh <= row_y + TEAM_ROW_H:
+                if replay_remaining > 0:    # filled = has challenge
+                    draw.rectangle([_r_left, _r_top, _r_left + _rw, _r_top + _rh], fill=0)
+                else:                       # outline = used
+                    draw.rectangle([_r_left, _r_top, _r_left + _rw, _r_top + _rh], outline=0, width=2)
+
         _ry = row_y + (TEAM_ROW_H - 72) // 2
         for val, cx, bold in ((runs, R_CX, bold_score), (hits, H_CX, False), (errs, E_CX, False)):
             _vw = int(f72.getlength(val))
@@ -1031,10 +1089,25 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             if bold:
                 draw.text((_vx + 1, _ry), val, font=f72, fill=0)
 
+    _away_abs = game_data.get('away_challenges_remaining')
+    _home_abs = game_data.get('home_challenges_remaining')
+    _away_rep = game_data.get('away_replay_remaining')
+    _home_rep = game_data.get('home_replay_remaining')
+
     _draw_team_row(away_abbr, away_id, AWAY_Y, away_runs, away_hits, away_errs,
-                   bold_score=_away_ahead, batting=(_inn_state == 'Top'))
+                   bold_score=_away_ahead, batting=(_inn_state == 'Top'),
+                   abs_remaining=_away_abs, replay_remaining=_away_rep)
     _draw_team_row(home_abbr, home_id,  HOME_Y, home_runs, home_hits, home_errs,
-                   bold_score=_home_ahead, batting=(_inn_state == 'Bottom'))
+                   bold_score=_home_ahead, batting=(_inn_state == 'Bottom'),
+                   abs_remaining=_home_abs, replay_remaining=_home_rep)
+
+    # ---- SAVE SITUATION badge (upper-right, just below header line) ---------
+    if game_data.get('save_situation'):
+        _sv_w = int(f28.getlength('SV'))
+        _sv_x = 800 - _sv_w - 8
+        _sv_y = HEADER_H + 3
+        draw.text((_sv_x,     _sv_y), 'SV', font=f28, fill=0)
+        draw.text((_sv_x + 1, _sv_y), 'SV', font=f28, fill=0)
 
     # ---- BASES (right side, spanning both score rows) -----------------------
     _hi_third  = isinstance(game_data.get('runner_on_third'),  str)
@@ -1044,15 +1117,14 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     _b3 = (DIAMOND_CX - BASE_DIST, DIAMOND_CY)
     _b2 = (DIAMOND_CX,             DIAMOND_CY - BASE_DIST)
     _b1 = (DIAMOND_CX + BASE_DIST, DIAMOND_CY)
-    _bH = (DIAMOND_CX,             DIAMOND_CY + BASE_DIST)   # home plate
+    # home plate removed
 
     canvas = draw_diamond(canvas, _b3, BASE_SZ, _hi_third,  outline_width=BASE_OW)
     canvas = draw_diamond(canvas, _b2, BASE_SZ, _hi_second, outline_width=BASE_OW)
     canvas = draw_diamond(canvas, _b1, BASE_SZ, _hi_first,  outline_width=BASE_OW)
-    canvas = draw_diamond(canvas, _bH, BASE_SZ - 8, False,  outline_width=BASE_OW)  # home plate
     draw   = ImageDraw.Draw(canvas)
 
-    # Runner jersey numbers in white inside filled bases
+    # Runner jersey numbers in white inside filled bases (f22 = doubled from f11)
     for _bfill, _bc, _bkey in (
         (_hi_third,  _b3, 'runner_third_number'),
         (_hi_second, _b2, 'runner_second_number'),
@@ -1062,73 +1134,72 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             _raw  = game_data.get(_bkey)
             _bnum = str(_raw) if _raw is not None else ''
             if _bnum:
-                _bnw = int(f11.getlength(_bnum))
-                draw.text((_bc[0] - _bnw // 2, _bc[1] - 7), _bnum, font=f11, fill=255)
+                _bnw = int(f22.getlength(_bnum))
+                draw.text((_bc[0] - _bnw // 2, _bc[1] - 11), _bnum, font=f22, fill=255)
 
-    # ---- OUTS circles (right side, under bases) -----------------------------
+    # ---- OUTS circles (right side, moved up, bigger) ------------------------
     _outs = game_data.get('num_of_outs') or 0
-    _or   = 14
     _ogap = 8
-    _otw  = 3 * (2 * _or) + 2 * _ogap    # total width = 100px
-    _oxs  = DIAMOND_CX - _otw // 2       # x-start = 595
-    _ocy  = OUTS_Y_TOP + _or + 4          # circle centres y
+    _otw  = 3 * (2 * O_R) + 2 * _ogap
+    _oxs  = DIAMOND_CX - _otw // 2
+    _ocy  = OUTS_Y_TOP + O_R + 4
     for i in range(3):
-        _ocx = _oxs + _or + i * (2 * _or + _ogap)
-        canvas = draw_circle(canvas, (_ocx, _ocy), _or, i < _outs, outline_width=2)
+        _ocx = _oxs + O_R + i * (2 * O_R + _ogap)
+        canvas = draw_circle(canvas, (_ocx, _ocy), O_R, i < _outs, outline_width=2)
     draw = ImageDraw.Draw(canvas)
 
     # ---- DIVIDER (full width, thick) ----------------------------------------
     draw.line((0, DIV_Y, 799, DIV_Y), fill=0, width=2)
 
     # ---- BOTTOM SITUATION AREA ----------------------------------------------
-    _last_ev = _build_last_event()
-
     if _between_innings or _pitching_change:
-        # ---- Between innings: last event  +  due-up batters  +  pitcher ----
-        _by = SIT_Y + 8   # 317
+        # ---- Between innings: due-up batters (big, left) + pitcher (right-aligned) ----
+        _by = SIT_Y + 8
 
-        if _last_ev:
-            draw.text((16, _by),     _last_ev, font=f36, fill=0)
-            draw.text((17, _by),     _last_ev, font=f36, fill=0)
-            _by += 40
-
-        draw.line((16, _by, 420, _by), fill=0, width=1)
-        _by += 10
-
-        _batter_names = [
+        _batter_names = [nm for nm in [
             _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
             _last_name(game_data.get('next_batter_2') or game_data.get('due_up')         or ''),
             _last_name(game_data.get('next_batter_3') or game_data.get('in_hole')        or ''),
-        ]
+        ] if nm]
         _pc_raw = (game_data.get('sub_event') or '')[3:].strip() if _pitching_change else ''
         _pit_nm = _pc_raw or _last_name(
             game_data.get('next_pitcher') or game_data.get('current_pitcher') or ''
         )
 
+        # Batters: stack vertically, bounded by WIN_PCT_Y
+        _bot = WIN_PCT_Y - 4
+        _avail_h = _bot - _by
+        _n = len(_batter_names) or 1
+        _bat_spacing = min(48, _avail_h // _n)
         for _nm in _batter_names:
-            if _nm and _by + 28 <= 476:
-                draw.text((16, _by), _nm, font=f24, fill=0)
-                _by += 28
+            if _by + 42 <= _bot:
+                draw.text((16, _by),     _nm, font=f42, fill=0)
+                draw.text((17, _by),     _nm, font=f42, fill=0)
+                _by += _bat_spacing
 
-        if _pit_nm and _by + 8 <= 476:
-            draw.line((16, _by + 4, 320, _by + 4), fill=0, width=1)
-            _by += 12
-            if _by + 24 <= 476:
-                draw.text((16, _by), _pit_nm, font=f24, fill=0)
+        # Pitcher: right-aligned, vertically centred in the bottom section
+        if _pit_nm:
+            _pit_w = int(f42.getlength(_pit_nm))
+            _pit_x = 800 - _pit_w - 16
+            _pit_y = (SIT_Y + 8 + _bot) // 2 - 21
+            draw.text((_pit_x, _pit_y),     _pit_nm, font=f42, fill=0)
+            draw.text((_pit_x + 1, _pit_y), _pit_nm, font=f42, fill=0)
 
     else:
-        # ---- Active pitch: B/S/O  +  pitch info  +  last event  +  pitcher/batter ----
+        # ---- Active pitch: B/S (no O)  +  pitch info  +  pitcher/batter ----
 
-        _bso_y  = SIT_Y + 6    # 315  — top of BSO label text
-        _bso_cy = _bso_y + 21  # 336  — circle centres (vertically centred in f42 cap-height)
+        _bso_y  = SIT_Y + 6    # top of BSO label text
+        # Circle centres: vertically centred on the cap-height of the 'B' glyph
+        _b_bbox = f42.getbbox('B')
+        _bso_cy = _bso_y + (_b_bbox[1] + _b_bbox[3]) // 2
 
-        # Balls
+        # Balls (3 circles)
         _bx = 16
         draw.text((_bx,     _bso_y), 'B', font=f42, fill=0)
         draw.text((_bx + 1, _bso_y), 'B', font=f42, fill=0)
         _bx += int(f42.getlength('B')) + 8
         _balls = game_data.get('balls') or 0
-        for i in range(4):
+        for i in range(3):
             _cx = _bx + B_R
             canvas = draw_circle(canvas, (_cx, _bso_cy), B_R, i < _balls)
             _bx += 2 * B_R + C_GAP
@@ -1154,25 +1225,7 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
                 draw   = ImageDraw.Draw(canvas)
             _sx += 2 * B_R + C_GAP
 
-        # Outs
-        _ox = _sx + 16
-        draw.text((_ox,     _bso_y), 'O', font=f42, fill=0)
-        draw.text((_ox + 1, _bso_y), 'O', font=f42, fill=0)
-        _ox += int(f42.getlength('O')) + 8
-        _outs2 = game_data.get('num_of_outs') or 0
-        for i in range(3):
-            _cx2 = _ox + O_R
-            canvas = draw_circle(canvas, (_cx2, _bso_cy), O_R, i < _outs2, outline_width=2)
-            _ox += 2 * O_R + C_GAP
-        draw = ImageDraw.Draw(canvas)
-
-        # Save situation badge
-        if game_data.get('save_situation'):
-            _sv_x = 800 - int(f28.getlength('SV')) - 16
-            draw.text((_sv_x,     _bso_y + 6), 'SV', font=f28, fill=0)
-            draw.text((_sv_x + 1, _bso_y + 6), 'SV', font=f28, fill=0)
-
-        # Pitch info: count / speed / type  (f14, below circles)
+        # Pitch info: f36, right-aligned, same row as B/S
         _lps = game_data.get('last_pitch_speed')
         _pt  = game_data.get('last_pitch_type', '')
         _pc  = game_data.get('pitch_count')
@@ -1180,37 +1233,121 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
         if _pc  is not None: _pitch_parts.append(f'{_pc}P')
         if _lps:             _pitch_parts.append(f'{int(_lps)}mph')
         if _pt:              _pitch_parts.append(_pt)
+        # SV shown in top half of display, not here
         if _pitch_parts:
-            draw.text((16, _bso_y + 46), '  '.join(_pitch_parts), font=f14, fill=0)
+            _ptxt = '  '.join(_pitch_parts)
+            _ptw  = int(f36.getlength(_ptxt))
+            _pt_bbox = f36.getbbox(_ptxt)
+            _pty = _bso_cy - (_pt_bbox[1] + _pt_bbox[3]) // 2
+            draw.text((800 - _ptw - 8, _pty), _ptxt, font=f36, fill=0)
 
-        # Last event  (f36, prominent)
-        _ev_y = _bso_y + 62   # 377
-        if _last_ev:
-            draw.text((16, _ev_y),     _last_ev, font=f36, fill=0)
-            draw.text((17, _ev_y),     _last_ev, font=f36, fill=0)
+        # Pitcher (left) + Batter (x=400) on one line
+        _pb_y = _bso_y + 48
+        _pitcher_full = (game_data.get('current_pitcher') or '').strip()
+        if _pitcher_full and _pb_y + 42 <= WIN_PCT_Y:
+            draw.text((16, _pb_y),     f'P: {_pitcher_full}', font=f42, fill=0)
+            draw.text((17, _pb_y),     f'P: {_pitcher_full}', font=f42, fill=0)
 
-        # Pitcher  (f28)
-        _pb_y = _bso_y + 104  # 419
-        _pitcher = _format_player_name(game_data.get('current_pitcher') or '')
-        if _pitcher and _pb_y + 28 <= 478:
-            draw.text((16, _pb_y), f'P: {_pitcher}', font=f28, fill=0)
-
-        # Batter  (f28)
-        _pb_y2  = _pb_y + 32  # 451
-        _bh     = game_data.get('batter_hits')
-        _ba     = game_data.get('batter_at_bats')
-        _ba_str = f'({_bh}-{_ba})' if _bh is not None and _ba is not None else ''
+        # Batter — due_up when at-bat complete, else current_hitter
         _ab_done = game_data.get('current_at_bat_complete', False)
         if _ab_done and not _is_game_effectively_over(game_data):
-            _batter  = _format_player_name(
-                game_data.get('due_up') or game_data.get('next_batter_1') or ''
-            )
-            _bat_lbl = 'Next'
+            _batter_full = (game_data.get('due_up') or game_data.get('next_batter_1') or '').strip()
+            _od_full     = (game_data.get('in_hole') or '').strip()
         else:
-            _batter  = _format_player_name(game_data.get('current_hitter') or '')
-            _bat_lbl = 'AB'
-        if _batter and _pb_y2 + 28 <= 478:
-            draw.text((16, _pb_y2), f'{_bat_lbl}: {_batter}  {_ba_str}'.strip(), font=f28, fill=0)
+            _batter_full = (game_data.get('current_hitter') or '').strip()
+            _od_full     = (game_data.get('due_up') or '').strip()
+        # Safety: on-deck must never be the same person as at-bat
+        if _od_full == _batter_full:
+            _od_full = ''
+        # Label column: right-align "AB:" and "OD:" so colons line up,
+        # then names start at the same x
+        _ab_lbl_w = int(f42.getlength('AB:'))
+        _od_lbl_w = int(f42.getlength('OD:'))
+        _lbl_col  = max(_ab_lbl_w, _od_lbl_w)
+        _name_x   = 400 + _lbl_col + 8
+
+        if _batter_full and _pb_y + 42 <= WIN_PCT_Y:
+            _ax = 400 + (_lbl_col - _ab_lbl_w)
+            draw.text((_ax,      _pb_y), 'AB:', font=f42, fill=0)
+            draw.text((_ax+1,    _pb_y), 'AB:', font=f42, fill=0)
+            draw.text((_name_x,  _pb_y), _batter_full, font=f42, fill=0)
+            draw.text((_name_x+1,_pb_y), _batter_full, font=f42, fill=0)
+
+        # On-deck hitter below AB batter — same font, labels right-aligned
+        _od_y = _pb_y + 46
+        if _od_full and _od_y + 42 <= WIN_PCT_Y - 2:
+            _ox = 400 + (_lbl_col - _od_lbl_w)
+            draw.text((_ox,      _od_y), 'OD:', font=f42, fill=0)
+            draw.text((_ox+1,    _od_y), 'OD:', font=f42, fill=0)
+            draw.text((_name_x,  _od_y), _od_full, font=f42, fill=0)
+            draw.text((_name_x+1,_od_y), _od_full, font=f42, fill=0)
+
+    # ---- SEPARATOR LINE above win % bar -------------------------------------
+    draw.line((0, WIN_PCT_Y - 1, 799, WIN_PCT_Y - 1), fill=0, width=2)
+
+    # ---- WIN PERCENTAGE BAR (3× height — full-width with LOSS/WIN watermarks + logos) --
+    _away_wp = game_data.get('away_win_probability')
+    _home_wp = game_data.get('home_win_probability')
+    if _away_wp is not None and _home_wp is not None:
+        try:
+            _awp = float(_away_wp)
+            _hwp = float(_home_wp)
+            if _awp + _hwp > 1.5:          # already percentage (0-100)
+                _awp /= 100.0
+                _hwp /= 100.0
+
+            BAR_W = 800
+            BAR_H = WIN_PCT_H              # 54px
+            LOGO_SZ = BAR_H - 4            # 50px logos
+
+            # Ghost strip: "LOSS" left, "WIN" right, semi-transparent
+            _ghost = Image.new('L', (BAR_W, BAR_H), 255)
+            _gd    = ImageDraw.Draw(_ghost)
+            _wf    = f36
+            _gd.text((6, (BAR_H - 36) // 2),                        'LOSS', font=_wf, fill=0)
+            _win_w = int(_wf.getlength('WIN'))
+            _gd.text((BAR_W - _win_w - 6, (BAR_H - 36) // 2),       'WIN',  font=_wf, fill=0)
+            _ghost = _ghost.point(lambda p: 255 if p > 180 else min(255, int(p * 0.35 + 155)))
+            _gd.line((0, BAR_H // 2, BAR_W, BAR_H // 2), fill=0)
+            canvas.paste(_ghost.convert('1'), (0, WIN_PCT_Y))
+            draw = ImageDraw.Draw(canvas)
+
+            # Logo positions along the bar
+            _away_px   = int(BAR_W * _awp)
+            _home_px   = int(BAR_W * _hwp)
+            _away_lx   = max(0, min(BAR_W - LOGO_SZ, _away_px - LOGO_SZ // 2))
+            _home_lx   = max(0, min(BAR_W - LOGO_SZ, _home_px - LOGO_SZ // 2))
+            MIN_SEP    = LOGO_SZ + 2
+            if _away_lx > _home_lx:
+                if _away_lx - _home_lx < MIN_SEP:
+                    _mid = (_away_lx + _home_lx) // 2
+                    _away_lx = min(BAR_W - LOGO_SZ, _mid + MIN_SEP // 2)
+                    _home_lx = max(0, _mid - MIN_SEP // 2)
+            else:
+                if _home_lx - _away_lx < MIN_SEP:
+                    _mid = (_away_lx + _home_lx) // 2
+                    _home_lx = min(BAR_W - LOGO_SZ, _mid + MIN_SEP // 2)
+                    _away_lx = max(0, _mid - MIN_SEP // 2)
+
+            if use_logos:
+                _awl = _logo_small(away_abbr, away_id, size=LOGO_SZ)
+                _hwl = _logo_small(home_abbr, home_id, size=LOGO_SZ)
+                if _awl:
+                    _paste_logo(canvas, _awl, (_away_lx, WIN_PCT_Y + (BAR_H - _awl.size[1]) // 2))
+                if _hwl:
+                    _paste_logo(canvas, _hwl, (_home_lx, WIN_PCT_Y + (BAR_H - _hwl.size[1]) // 2))
+                draw = ImageDraw.Draw(canvas)
+            else:
+                # No logos: draw vertical markers + percentage text
+                draw.line((_away_px, WIN_PCT_Y, _away_px, WIN_PCT_Y + BAR_H), fill=0, width=2)
+                draw.line((_home_px, WIN_PCT_Y, _home_px, WIN_PCT_Y + BAR_H), fill=0, width=2)
+                _astr = f'{_awp:.0%}'
+                _hstr = f'{_hwp:.0%}'
+                draw.text((_away_px + 4, WIN_PCT_Y + (BAR_H - 14) // 2), _astr, font=f14, fill=0)
+                _hsw = int(f14.getlength(_hstr))
+                draw.text((_home_px - _hsw - 4, WIN_PCT_Y + (BAR_H - 14) // 2), _hstr, font=f14, fill=0)
+        except (ValueError, TypeError):
+            pass
 
     return canvas
 


### PR DESCRIPTION
## Summary
- **Header**: 25% shorter (92→69px), triangle drawn as polygon sized to numeral height (80% scale), last event right-aligned at f56, 5px thick separator line
- **Bases**: ~2× bigger (BASE_SZ 24→46), no home plate, closer together, runner jersey numbers doubled (f11→f22)
- **Outs**: bigger circles (r=20), repositioned above divider with 4px gap to line; 3 outs circles only on right side — O removed from bottom B/S/O row
- **B/S circles**: 30% bigger (r=16), 3 balls only (not 4), vertically centred on cap-height of 'B' glyph
- **Pitch info**: f36, right-aligned at B/S row level, vertically centred on circle midline
- **Pitcher / AB / OD**: all f42; label column right-aligned so colons line up; OD≠AB safety guard; OD uses `in_hole` when AB shows `due_up`
- **Win % bar**: 3× height (54px), LOSS/WIN ghost watermarks, logos slide to probability position; separator line always drawn above bar
- **Challenge indicators**: rectangles (36×10px) — filled = available, outline = used; ABS above abbreviation, manager below
- **SV badge**: f28, below header line upper-right
- **Flyout/lineout/popout**: resolved to F7/L6/P5 using `last_play_description` fielder keywords
- **Between-innings**: batters at f42 bounded above win % bar; pitcher right-aligned and centred vertically

## Test plan
- [ ] Render with active pitch data (runners on base, save situation, challenges)
- [ ] Render between-innings with 3 batters — confirm none cut off by win % bar
- [ ] Render with win probability data (logos and no-logos paths)
- [ ] Confirm flyout in header shows F7 not FO when description available
- [ ] Confirm OD never shows same name as AB

🤖 Generated with [Claude Code](https://claude.com/claude-code)