### PR TITLE
Morning flip: 9am weekday cutoff, 11am weekend; remove fullscreen division headers

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,7 +58,8 @@ night_end: 7     # 7am
 # results and today's schedule every 5 minutes. Before night_end always shows yesterday;
 # at/after morning_end always shows today.
 morning_alternate_games: true
-morning_end: 11  # hour (24h) when "yesterday" mode ends and today's games take over
+morning_end: 9          # weekday cutoff (Mon–Fri)
+morning_end_weekend: 11 # weekend cutoff (Sat–Sun)
 
 
 # Team emoji overrides: display emoji instead of logo for these teams

--- a/main.py
+++ b/main.py
@@ -472,7 +472,9 @@ Examples:
     else:
         tz = config.get('timezone', 'America/Chicago')
         _now = datetime.now(pytz.timezone(tz))
-        _morning_end  = config.get('morning_end', 9)
+        _is_weekend = _now.weekday() >= 5  # 5=Sat, 6=Sun
+        _morning_end = (config.get('morning_end_weekend', 11) if _is_weekend
+                        else config.get('morning_end', 9))
         _morning_start = config.get('night_end', 7)
         if _now.hour >= _morning_end:
             date_str = _now.date().strftime('%Y-%m-%d')

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -406,8 +406,10 @@ def _load_tomorrow_games():
     try:
         _cfg = load_yaml_file('config.yaml')
         _tz_str = _cfg.get('timezone', 'America/Chicago')
-        _morning_end = _cfg.get('morning_end', 9)
         _now_local = _dt.now(pytz.timezone(_tz_str))
+        _is_wkend = _now_local.weekday() >= 5
+        _morning_end = (_cfg.get('morning_end_weekend', 11) if _is_wkend
+                        else _cfg.get('morning_end', 9))
         _is_morning = _now_local.hour < _morning_end
     except Exception:
         _is_morning = False

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -391,11 +391,10 @@ def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='l
         logo_sz = _FS_LOGO_SZ
 
     n_teams     = 5
-    team_area_h = height - _FS_LABEL_H
-    slot_h      = team_area_h // n_teams   # 87 px
+    team_area_h = height
+    slot_h      = team_area_h // n_teams
 
     draw       = ImageDraw.Draw(canvas)
-    font_label = _get_font(9)
 
     # --- Movement indicator detection (same logic as draw_standings_sidebar) ---
     _now_ts   = _time.time()
@@ -490,11 +489,6 @@ def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='l
     for col_idx, div_name in enumerate(divisions[:3]):
         col_x = x_anchor + col_idx * col_w
 
-        # Division label: first letter of direction word (East→E, Central→C, West→W)
-        label = div_name.split()[-1][0]
-        lw = int(font_label.getlength(label))
-        draw.text((col_x + (col_w - lw) // 2, y_start + 2), label, font=font_label, fill=0)
-
         teams = standings_data.get('standings', {}).get(div_name, [])
         teams = sorted(teams, key=lambda t: int(t.get('divisionRank', 99)))
 
@@ -502,7 +496,7 @@ def draw_standings_sidebar_fullscreen(canvas, standings_data, team_data, side='l
             team_id = str(team.get('team_id', ''))
             abbr    = abbr_map.get(team_id, f'T{team_id}')
 
-            slot_y = y_start + _FS_LABEL_H + slot_idx * slot_h
+            slot_y = y_start + slot_idx * slot_h
             logo_x = col_x + (col_w - logo_sz) // 2
             logo_y = slot_y + (slot_h - logo_sz) // 2
 


### PR DESCRIPTION
## Summary
- Morning alternating flip now ends at 9am on weekdays (Mon–Fri) and 11am on weekends (Sat–Sun), configurable via `morning_end` and `morning_end_weekend` in config.yaml
- Fixed `image_box.py` to use the same weekend-aware logic so the next-game preview strip loads today's games (not tomorrow's) during the extended weekend morning window — applies to both big and small display cells
- Removed E/C/W division headers from the fullscreen standings sidebar, reclaiming that space for the team logo slots

## Test plan
- [ ] On a weekday before 9am: flip shows yesterday; 9am+ shows today
- [ ] On a weekend before 11am: flip shows yesterday/today alternating; 11am+ shows today
- [ ] Preview strip shows today's upcoming games during morning window (not tomorrow's)
- [ ] Fullscreen standings sidebar no longer shows E/C/W labels above each column

🤖 Generated with [Claude Code](https://claude.com/claude-code)