### PR TITLE
Fix AB label flip-flop when at-bat transitions to next batter

### DIFF
--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -347,8 +347,14 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
                 last_type = _PITCH_TYPE_ABBR.get(raw_code, raw_code)
                 last_speed = pd.get('startSpeed')
 
+        _current_play = plays.get('currentPlay', {})
         current_at_bat_complete = bool(
-            plays.get('currentPlay', {}).get('result', {}).get('event')
+            _current_play.get('result', {}).get('event')
+        )
+        # Batter name from currentPlay.matchup — updates atomically with current_at_bat_complete,
+        # so it never lags behind the linescore like linescore.offense.batter can.
+        current_play_batter = (
+            _current_play.get('matchup', {}).get('batter', {}).get('fullName') or None
         )
 
         # ABS max grows by 1 per extra inning (10th = 3 total, 11th = 4, ...)
@@ -402,6 +408,7 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             'strike_calls': strike_calls,
             'at_bat_pitch_count': at_bat_pitch_count,
             'current_at_bat_complete': current_at_bat_complete,
+            'current_play_batter': current_play_batter,
             'sub_event': sub_event,
             'abs_challenge_max': abs_max,
             'away_challenges_remaining': away_remaining,

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -943,7 +943,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                     _next_str, _next_font = fit_text(f'AB: {_next_hitter}', max(1, max_text_width - _ba_w))
                     draw.text((start_x + 2 * s, start_y + 25 * s + 89 * s), _next_str, font=_next_font, fill=0)
             else:
-                _hitter_name = _format_player_name(game_data.get('current_hitter') or '')
+                # Prefer current_play_batter (from currentPlay.matchup) over current_hitter
+                # (from linescore.offense.batter) — both fields update when the at-bat changes,
+                # but linescore can lag by one poll cycle, causing the AB label to briefly flip
+                # back to the previous batter.
+                _hitter_name = _format_player_name(
+                    game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
+                )
                 hitter_str, hitter_font = fit_text(
                     f'AB: {_hitter_name}',
                     max(1, max_text_width - _ba_w),

--- a/src/image_featured.py
+++ b/src/image_featured.py
@@ -475,7 +475,11 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             _batter_full = (game_data.get('due_up') or game_data.get('next_batter_1') or '').strip()
             _od_full     = (game_data.get('in_hole') or '').strip()
         else:
-            _batter_full = (game_data.get('current_hitter') or '').strip()
+            # Prefer current_play_batter (currentPlay.matchup) over current_hitter
+            # (linescore) — they update atomically, eliminating the lag-driven flip-flop.
+            _batter_full = (
+                game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
+            ).strip()
             _od_full     = (game_data.get('due_up') or '').strip()
         # Safety: on-deck must never be the same person as at-bat
         if _od_full == _batter_full:


### PR DESCRIPTION
## Summary
- Extracts `current_play_batter` from `currentPlay.matchup.batter.fullName` in `game_detail_fetch.py` and exposes it in the returned dict
- In `image_box.py` and `image_featured.py`, prefer `current_play_batter` over `current_hitter` (linescore) when rendering the AB label for a live at-bat

## Root cause
`current_at_bat_complete` and the next batter's name both derive from `currentPlay`, but the displayed batter name was falling back to `linescore.offense.batter`. The linescore can lag one poll cycle behind `currentPlay`, creating a window where:
1. `currentPlay` already shows the new batter (clearing `current_at_bat_complete`)
2. `linescore.offense.batter` still shows the old (completed) batter

This caused the AB label to briefly flip back to the previous batter before the linescore caught up.

## Fix
Use `currentPlay.matchup.batter` as the batter name source — it updates atomically with the result event that drives `current_at_bat_complete`, so both fields are always in sync.

## Test plan
- [ ] Watch a live in-progress game through several at-bat transitions; verify "AB: Name" does not briefly revert to the previous batter's name between at-bats

🤖 Generated with [Claude Code](https://claude.com/claude-code)