### PR TITLE
Center linescore run scores in each 40px column via getbbox

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -166,31 +166,26 @@ def _get_or_set_final_time(game_pk):
 def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos, scale=1):
     """Per-inning linescore grid for between-inning scoreboard tiles.
 
-    All 10 cells (1 logo + 9 inning) are equal width (12px each = 120px).
-    The 120px grid is centred inside the 135px box (~7px margins each side).
+    Standard games: 10 cells (1 logo + 9 inning) × 12px = 120px centred in 135px box.
+    Extra-inning games: expand to 11 cells (+ 10th column) when current_inning >= 10,
+    then slide the window for innings beyond 10 so the current inning stays rightmost.
     Row dividers span the full box width for a clean framed look.
-
-    Extra-innings: window shifts so the current inning is the rightmost column.
     """
     s = scale
     BOX_W      = 135 * s   # full tile width
-    COL_W      = 12 * s    # all cells equal — interior 11px (odd) → exact center at +6
+    COL_W      = 12 * s    # all cells equal width
     LOGO_COL_W = COL_W     # logo column same width as inning columns
     ROW_H_HDR  = 14 * s
     ROW_H_TEAM = 16 * s
-    N_COLS     = 9
-
-    # Centre the 120px (10 × 12) grid inside the 135px box
-    _total_w  = LOGO_COL_W + N_COLS * COL_W   # = 120 * s
-    grid_x0   = start_x + (BOX_W - _total_w) // 2  # ≈ start_x + 7*s
-
-    y0 = start_y + 83 * s            # grid top
-    y1 = y0 + ROW_H_HDR              # away row top  (start_y + 97)
-    y2 = y1 + ROW_H_TEAM             # home row top  (start_y + 113)
-    y3 = y2 + ROW_H_TEAM             # grid bottom   (start_y + 129)
 
     current_inning = game_data.get('current_inning') or 1
+    # Expand to 10 inning columns once extra innings begin; slide window beyond that
+    N_COLS    = 10 if current_inning >= 10 else 9
     first_inn = max(1, current_inning - N_COLS + 1) if current_inning > N_COLS else 1
+
+    # Centre the grid (logo col + N_COLS inning cols) inside the 135px box
+    _total_w  = LOGO_COL_W + N_COLS * COL_W
+    grid_x0   = start_x + (BOX_W - _total_w) // 2
 
     away_inn = game_data.get('away_inning_runs') or []
     home_inn = game_data.get('home_inning_runs') or []
@@ -290,7 +285,7 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
     _draw_row(away_inn, y1)
     _draw_row(home_inn, y2)
 
-    # X in the home team's last column when the bottom half wasn't played.
+    # Short dash in the home team's last column when the bottom half wasn't played.
     _is_final = game_data.get('detailed_state') in ('Final', 'Game Over', 'Final: Tied')
     if _is_final and away_inn:
         last_idx = len(away_inn) - 1
@@ -301,8 +296,9 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
             if 0 <= col_k < N_COLS:
                 cell_x = grid_x0 + LOGO_COL_W + col_k * COL_W
                 cx = cell_x + COL_W // 2
-                cy = y2 + ROW_H_TEAM // 2
-                _draw_centered(font11, 'X', cx, cy)
+                cy = y2 + ROW_H_TEAM // 2 + 1
+                dash_half = 3 * s
+                draw.line((cx - dash_half, cy, cx + dash_half, cy), fill=0)
 
     return draw, Himage
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -237,7 +237,8 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
             # Center of ink relative to the draw anchor (ox, oy)
             ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox
             ink_cy = (min(ink_ys) + max(ink_ys)) / 2 - oy
-            draw.text((round(cx - ink_cx) + 1, round(cy - ink_cy) + 1), txt, font=fnt, fill=0)
+            x_nudge = 0 if txt == '1' else 1   # '1' sits 1px left of the general +1 nudge
+            draw.text((round(cx - ink_cx) + x_nudge, round(cy - ink_cy) + 1), txt, font=fnt, fill=0)
         except Exception:
             draw.text((cx, cy), txt, font=fnt, fill=0, anchor='mm')
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -237,7 +237,7 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
             # Center of ink relative to the draw anchor (ox, oy)
             ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox
             ink_cy = (min(ink_ys) + max(ink_ys)) / 2 - oy
-            draw.text((round(cx - ink_cx), round(cy - ink_cy)), txt, font=fnt, fill=0)
+            draw.text((round(cx - ink_cx) + 1, round(cy - ink_cy) + 1), txt, font=fnt, fill=0)
         except Exception:
             draw.text((cx, cy), txt, font=fnt, fill=0, anchor='mm')
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -187,6 +187,11 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
     _total_w  = LOGO_COL_W + N_COLS * COL_W
     grid_x0   = start_x + (BOX_W - _total_w) // 2
 
+    y0 = start_y + 83 * s            # grid top
+    y1 = y0 + ROW_H_HDR              # away row top
+    y2 = y1 + ROW_H_TEAM             # home row top
+    y3 = y2 + ROW_H_TEAM             # grid bottom
+
     away_inn = game_data.get('away_inning_runs') or []
     home_inn = game_data.get('home_inning_runs') or []
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -237,7 +237,7 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
             # Center of ink relative to the draw anchor (ox, oy)
             ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox
             ink_cy = (min(ink_ys) + max(ink_ys)) / 2 - oy
-            x_nudge = 0 if txt == '1' else 1   # '1' sits 1px left of the general +1 nudge
+            x_nudge = -1 if txt == '1' else 1  # '1' sits 2px left of the general +1 nudge
             draw.text((round(cx - ink_cx) + x_nudge, round(cy - ink_cy) + 1), txt, font=fnt, fill=0)
         except Exception:
             draw.text((cx, cy), txt, font=fnt, fill=0, anchor='mm')

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -213,29 +213,29 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
     def _draw_centered(fnt, val, cx, cy):
         """Draw val pixel-centered at (cx, cy) by scanning actual rendered ink bounds.
 
-        getbbox() returns the advance-width cell for bitmap/pixel fonts (all digits
-        report the same box), so centering by ink width alone leaves narrow glyphs
-        like '1' visually left of center.  Rendering to a scratch buffer and measuring
-        the real leftmost/rightmost ink pixel gives sub-pixel accuracy (max ±0.5 px).
+        getbbox() returns the advance-width cell for this bitmap/pixel font (all digits
+        share the same box), so centering by bounding-box width leaves narrow glyphs
+        like '1' visually off-center.  Rendering to a scratch buffer at a known anchor
+        (ox, oy) and measuring the real ink extents gives ≤0.5 px accuracy in both axes.
         """
         txt = str(val)
         if not txt:
             return
         try:
             bb = fnt.getbbox(txt)
-            # Render into a scratch 1-channel buffer with a 2-px guard border
-            ox, oy = 2, 2
-            buf_w = max(bb[2] - bb[0] + ox * 2, 6)
-            buf_h = max(bb[3] - bb[1] + oy * 2, 6)
+            ox, oy = 2, 2          # guard border; draw at (ox, oy) so subtracting them
+            buf_w = max(bb[2] + ox + 2, 6)   # gives center relative to draw position
+            buf_h = max(bb[3] + oy + 2, 6)
             buf = Image.new('L', (buf_w, buf_h), 255)
-            ImageDraw.Draw(buf).text((ox - bb[0], oy - bb[1]), txt, font=fnt, fill=0)
+            ImageDraw.Draw(buf).text((ox, oy), txt, font=fnt, fill=0)
             bpx = buf.load()
             ink_xs = [c for r in range(buf_h) for c in range(buf_w) if bpx[c, r] < 128]
             ink_ys = [r for r in range(buf_h) for c in range(buf_w) if bpx[c, r] < 128]
             if not ink_xs:
                 draw.text((cx, cy), txt, font=fnt, fill=0, anchor='mm')
                 return
-            ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox  # relative to draw origin
+            # Center of ink relative to the draw anchor (ox, oy)
+            ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox
             ink_cy = (min(ink_ys) + max(ink_ys)) / 2 - oy
             draw.text((round(cx - ink_cx), round(cy - ink_cy)), txt, font=fnt, fill=0)
         except Exception:

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -211,13 +211,35 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
         draw.line((vx, y0, vx, y3), fill=0)
 
     def _draw_centered(fnt, val, cx, cy):
-        """Draw val centered at (cx, cy) using actual ink bounds (not advance width)."""
+        """Draw val pixel-centered at (cx, cy) by scanning actual rendered ink bounds.
+
+        getbbox() returns the advance-width cell for bitmap/pixel fonts (all digits
+        report the same box), so centering by ink width alone leaves narrow glyphs
+        like '1' visually left of center.  Rendering to a scratch buffer and measuring
+        the real leftmost/rightmost ink pixel gives sub-pixel accuracy (max ±0.5 px).
+        """
+        txt = str(val)
+        if not txt:
+            return
         try:
-            bb = fnt.getbbox(val)
-            tw, th = bb[2] - bb[0], bb[3] - bb[1]
-            draw.text((cx - tw // 2 - bb[0], cy - th // 2 - bb[1]), val, font=fnt, fill=0)
+            bb = fnt.getbbox(txt)
+            # Render into a scratch 1-channel buffer with a 2-px guard border
+            ox, oy = 2, 2
+            buf_w = max(bb[2] - bb[0] + ox * 2, 6)
+            buf_h = max(bb[3] - bb[1] + oy * 2, 6)
+            buf = Image.new('L', (buf_w, buf_h), 255)
+            ImageDraw.Draw(buf).text((ox - bb[0], oy - bb[1]), txt, font=fnt, fill=0)
+            bpx = buf.load()
+            ink_xs = [c for r in range(buf_h) for c in range(buf_w) if bpx[c, r] < 128]
+            ink_ys = [r for r in range(buf_h) for c in range(buf_w) if bpx[c, r] < 128]
+            if not ink_xs:
+                draw.text((cx, cy), txt, font=fnt, fill=0, anchor='mm')
+                return
+            ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox  # relative to draw origin
+            ink_cy = (min(ink_ys) + max(ink_ys)) / 2 - oy
+            draw.text((round(cx - ink_cx), round(cy - ink_cy)), txt, font=fnt, fill=0)
         except Exception:
-            draw.text((cx, cy), val, font=fnt, fill=0, anchor='mm')
+            draw.text((cx, cy), txt, font=fnt, fill=0, anchor='mm')
 
     # --- inning header labels ---
     for k in range(N_COLS):

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -349,27 +349,30 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
     draw.line((col_start, 60 + row_start, 580 + col_start, 60 + row_start), fill = 0)
     draw.line((col_start, 90 + row_start, 580 + col_start, 90 + row_start), fill = 0)
 
+    def _cell_center(fnt, val, cell_idx, y):
+        """Draw val horizontally centred in the 40-px column at index cell_idx."""
+        cell_left = 100 + 40 * cell_idx + col_start
+        cell_w = 40
+        txt = str(val)
+        try:
+            bb = fnt.getbbox(txt)
+            tw = bb[2] - bb[0]
+            tx = cell_left + (cell_w - tw) // 2 - bb[0]
+        except Exception:
+            tw = int(fnt.getlength(txt))
+            tx = cell_left + (cell_w - tw) // 2
+        draw.text((tx, y), txt, font=fnt, fill=0)
+
     for i in range(13):
-        # inning
-        sub_header, sub_away, sub_home = 0,0,0
         if i < 12:
-
-            if 1 < len(str(inning_header[i])):
-                sub_header = -7
-            if 1 < len(str(away[i])):
-                sub_away = -7
-            if 1 < len(str(home[i])):
-                sub_home = -7
-
-            if away[i] == None:
+            if away[i] is None:
                 away[i] = ''
-
-            if home[i] == None:
+            if home[i] is None:
                 home[i] = ''
 
-            draw.text((115 + sub_header + (40*i) + col_start, 0 + row_start), str(inning_header[i]), font = font24, fill = 0)
-            draw.text((115 + sub_away + (40*i) + col_start, 30 + row_start), str(away[i]), font = font24, fill = 0)
-            draw.text((115 + sub_home + (40*i) + col_start, 60 + row_start), str(home[i]), font = font24, fill = 0)
+            _cell_center(font24, inning_header[i], i, 0 + row_start)
+            _cell_center(font24, away[i], i, 30 + row_start)
+            _cell_center(font24, home[i], i, 60 + row_start)
 
         # vertical line
         if i >= 1 and i <= 8 and DISPLAY_PROBS:

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -350,18 +350,34 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
     draw.line((col_start, 90 + row_start, 580 + col_start, 90 + row_start), fill = 0)
 
     def _cell_center(fnt, val, cell_idx, y):
-        """Draw val horizontally centred in the 40-px column at index cell_idx."""
+        """Draw val horizontally centred in the 40-px column at index cell_idx.
+
+        Uses tight pixel-scan centering: renders to a scratch buffer to find
+        the actual leftmost/rightmost ink pixel, then positions so the ink
+        center lands at the column midpoint.  Max error ≤ 0.5 px (rounding).
+        """
         cell_left = 100 + 40 * cell_idx + col_start
-        cell_w = 40
+        cell_cx = cell_left + 20   # midpoint of the 40-px column
         txt = str(val)
+        if not txt:
+            return
         try:
             bb = fnt.getbbox(txt)
-            tw = bb[2] - bb[0]
-            tx = cell_left + (cell_w - tw) // 2 - bb[0]
+            ox, oy = 2, 2
+            buf_w = max(bb[2] - bb[0] + ox * 2, 6)
+            buf_h = max(bb[3] - bb[1] + oy * 2, 6)
+            buf = Image.new('L', (buf_w, buf_h), 255)
+            ImageDraw.Draw(buf).text((ox - bb[0], oy - bb[1]), txt, font=fnt, fill=0)
+            bpx = buf.load()
+            ink_xs = [c for r in range(buf_h) for c in range(buf_w) if bpx[c, r] < 128]
+            if not ink_xs:
+                draw.text((cell_left + 10, y), txt, font=fnt, fill=0)
+                return
+            ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox   # relative to draw origin
+            draw.text((round(cell_cx - ink_cx), y), txt, font=fnt, fill=0)
         except Exception:
             tw = int(fnt.getlength(txt))
-            tx = cell_left + (cell_w - tw) // 2
-        draw.text((tx, y), txt, font=fnt, fill=0)
+            draw.text((cell_left + (40 - tw) // 2, y), txt, font=fnt, fill=0)
 
     for i in range(13):
         if i < 12:

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -352,9 +352,9 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
     def _cell_center(fnt, val, cell_idx, y):
         """Draw val horizontally centred in the 40-px column at index cell_idx.
 
-        Uses tight pixel-scan centering: renders to a scratch buffer to find
-        the actual leftmost/rightmost ink pixel, then positions so the ink
-        center lands at the column midpoint.  Max error ≤ 0.5 px (rounding).
+        Renders to a scratch buffer at a known anchor (ox, oy) and measures
+        the actual leftmost/rightmost ink pixel so the ink center lands at
+        the column midpoint.  Max horizontal error ≤ 0.5 px (rounding).
         """
         cell_left = 100 + 40 * cell_idx + col_start
         cell_cx = cell_left + 20   # midpoint of the 40-px column
@@ -364,16 +364,16 @@ def generate_image(Himage, col_start, row_start, away_team, home_team, away,
         try:
             bb = fnt.getbbox(txt)
             ox, oy = 2, 2
-            buf_w = max(bb[2] - bb[0] + ox * 2, 6)
-            buf_h = max(bb[3] - bb[1] + oy * 2, 6)
+            buf_w = max(bb[2] + ox + 2, 6)
+            buf_h = max(bb[3] + oy + 2, 6)
             buf = Image.new('L', (buf_w, buf_h), 255)
-            ImageDraw.Draw(buf).text((ox - bb[0], oy - bb[1]), txt, font=fnt, fill=0)
+            ImageDraw.Draw(buf).text((ox, oy), txt, font=fnt, fill=0)
             bpx = buf.load()
             ink_xs = [c for r in range(buf_h) for c in range(buf_w) if bpx[c, r] < 128]
             if not ink_xs:
                 draw.text((cell_left + 10, y), txt, font=fnt, fill=0)
                 return
-            ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox   # relative to draw origin
+            ink_cx = (min(ink_xs) + max(ink_xs)) / 2 - ox   # relative to draw anchor
             draw.text((round(cell_cx - ink_cx), y), txt, font=fnt, fill=0)
         except Exception:
             tw = int(fnt.getlength(txt))


### PR DESCRIPTION
## What

Replace the `sub_header` / `sub_away` / `sub_home` -7 px hack in `generate_image()` with a `_cell_center()` helper that uses `font.getbbox()` to compute the exact ink width and center each value within its 40 px column.

## Why

The old code subtracted a hard-coded 7 px for any two-character value. That works for digits but is wrong for wide characters (e.g. double-digit innings in extra inning games like `10`, `11`) and it leaves single-digit values slightly left-of-centre because their ink width (≈13 px) is narrower than the cell (40 px) by more than 7 px.

## How

```
cell_left = 100 + 40 * cell_idx + col_start   # left edge of column
tx = cell_left + (cell_w - ink_w) // 2 - bb[0]   # true ink-centred x
```

This is identical to the approach already used in `_draw_linescore_grid._draw_centered()` (scoreboard grid mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)