### PR TITLE
Linescore X as diagonal lines; tie tomorrow-game window to final_linescore_minutes

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -1761,16 +1761,26 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     # Next game preview — shown in the win-prob strip for Final games after final_linescore_minutes expires
     if _game_is_final and not _historical_mode:
         _window_expired = False
+        _end_time_resolved = False
         if _end_utc_str:
             try:
                 _end_utc = pytz.utc.localize(_datetime.strptime(_end_utc_str[:19], '%Y-%m-%dT%H:%M:%S'))
                 _window_expired = (_datetime.now(pytz.utc) - _end_utc).total_seconds() >= _FINAL_LINESCORE_SECS
+                _end_time_resolved = True  # authoritative — skip all fallbacks
             except Exception:
                 pass
-        if not _window_expired:
-            # game_date before today UTC → definitely a past-day game (morning window showing yesterday)
+        if not _end_time_resolved:
+            # No precise UTC end time — use game_date (local date) or first-seen timestamp.
+            # game_date is in local time so compare in local tz, not UTC, to avoid false
+            # expiry for evening games that cross midnight UTC.
+            try:
+                _cfg2 = load_yaml_file('config.yaml')
+                _tz_str2 = _cfg2.get('timezone', 'America/Chicago')
+                _today_local = _datetime.now(pytz.timezone(_tz_str2)).strftime('%Y-%m-%d')
+            except Exception:
+                _today_local = _datetime.now(pytz.utc).strftime('%Y-%m-%d')
             _gd_prefix = (game_data.get('game_date') or '')[:10]
-            if _gd_prefix and _gd_prefix < _datetime.now(pytz.utc).strftime('%Y-%m-%d'):
+            if _gd_prefix and _gd_prefix < _today_local:
                 _window_expired = True
             else:
                 _fts = _get_or_set_final_time(game_data.get('game_pk'))

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -290,7 +290,7 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
     _draw_row(away_inn, y1)
     _draw_row(home_inn, y2)
 
-    # Short dash in the home team's last column when the bottom half wasn't played.
+    # X mark in the home team's last column when the bottom half wasn't played.
     _is_final = game_data.get('detailed_state') in ('Final', 'Game Over', 'Final: Tied')
     if _is_final and away_inn:
         last_idx = len(away_inn) - 1
@@ -301,9 +301,11 @@ def _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, u
             if 0 <= col_k < N_COLS:
                 cell_x = grid_x0 + LOGO_COL_W + col_k * COL_W
                 cx = cell_x + COL_W // 2
-                cy = y2 + ROW_H_TEAM // 2 + 1
-                dash_half = 3 * s
-                draw.line((cx - dash_half, cy, cx + dash_half, cy), fill=0)
+                cy = y2 + ROW_H_TEAM // 2
+                hx = 2 * s  # narrow horizontal spread → skinny X
+                hy = 4 * s  # taller vertical spread
+                draw.line((cx - hx, cy - hy, cx + hx, cy + hy), fill=0)
+                draw.line((cx + hx, cy - hy, cx - hx, cy + hy), fill=0)
 
     return draw, Himage
 

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -123,11 +123,13 @@ def generate_linescore(col_start, row_start, team_abbr, Himage, new_image_dict):
                             game_end_time=game_end_time)
     return Himage, new_image_dict
 
-_LINESCORE_SHOW_SECONDS = 60 * 60  # show linescore for 60 min after last play
+def _game_in_window(team_abbr, games_scheduled, window_secs=3600):
+    """Return True if the team's game is live or ended within window_secs ago.
 
-
-def _game_in_window(team_abbr, games_scheduled):
-    """Return True if the team's game is live or ended less than 60 minutes ago."""
+    window_secs defaults to 3600 (1 hour) but callers should pass
+    ``config.get('final_linescore_minutes', 60) * 60`` so the value
+    stays in sync with the YAML setting used everywhere else.
+    """
     game_id = (games_scheduled or {}).get('team_to_game_id', {}).get(team_abbr)
     if not game_id:
         return True
@@ -139,7 +141,7 @@ def _game_in_window(team_abbr, games_scheduled):
         return False
     try:
         end_utc = pytz.utc.localize(datetime.strptime(end_utc_str[:19], "%Y-%m-%dT%H:%M:%S"))
-        return (datetime.now(pytz.utc) - end_utc).total_seconds() < _LINESCORE_SHOW_SECONDS
+        return (datetime.now(pytz.utc) - end_utc).total_seconds() < window_secs
     except Exception:
         return False
 
@@ -154,9 +156,11 @@ def draw_boards():
     col_start = 100
     row_start = 40
 
+    _window_secs = config_data.get('final_linescore_minutes', 60) * 60
+
     team_abbr = None
     for _candidate in [config_data.get('primary'), config_data.get('primary_backup'), config_data.get('primary_backup_2')]:
-        if linescore_data.get(_candidate) and _game_in_window(_candidate, games_scheduled):
+        if linescore_data.get(_candidate) and _game_in_window(_candidate, games_scheduled, _window_secs):
             team_abbr = _candidate
             break
 
@@ -165,7 +169,7 @@ def draw_boards():
 
     team_abbr = None
     for _candidate in [config_data.get('secondary'), config_data.get('secondary_backup'), config_data.get('secondary_backup_2')]:
-        if linescore_data.get(_candidate) and _game_in_window(_candidate, games_scheduled):
+        if linescore_data.get(_candidate) and _game_in_window(_candidate, games_scheduled, _window_secs):
             team_abbr = _candidate
             break
 


### PR DESCRIPTION
## Changes

### X mark (image_box.py)
Replaces the horizontal dash with two diagonal `draw.line` calls forming an X. Half-arms are `hx=2, hy=4` — matching the ink footprint of the `'0'` glyph (5×8 px). Previous font-glyph attempt was visually awkward at font11 in a 12 px cell.

### Tomorrow-game window (image_grid.py)
Removes the hardcoded `_LINESCORE_SHOW_SECONDS = 3600` constant from `_game_in_window()`. `draw_boards()` now passes `final_linescore_minutes * 60` (from `config.yaml`) so the cutoff matches the value already used in `generate_image.py`. Previously tomorrow's-game view could appear while the linescore was still being shown if the config value differed from 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)