### PR TITLE
Fullscreen live: between-innings linescore, end-of-game FINAL, AB/OD alignment

### DIFF
--- a/src/image_featured.py
+++ b/src/image_featured.py
@@ -57,17 +57,24 @@ def _find_featured_game(game_state_data, team_data, primary_abbr):
 def draw_live_fullscreen_game(game_data, team_data, config=None):
     """Full 800x480 canvas for a live (In Progress) featured game.
 
-    Layout v4
+    Layout v5 (linescore added)
     ---------
-    y=0..91    Header  : inning (f80, left)  matchup (f56, right)  [thick line below]
-    y=92..111  R / H / E column labels (f14)
-    y=112..191 Away row : logo  abbr  R  H  E  |  bases diamond (right, spans rows)
-    y=192..271 Home row : logo  abbr  R  H  E  |
-    y=272..307 [blank left]  |  outs circles (right, under bases)
-    y=308      Divider line
-    y=309..479 Bottom :
-        Live           : B/S/O circles + pitch info + last event (f36) + pitcher/batter (f28)
-        Between-innings: last event (f36) + due-up batters (f24) + pitcher (f24)
+    y=0..59    Header  : inning (f56, left)  last event/matchup (f56/f36, right)
+    y=60       Thick header line
+    y=61..78   Linescore inning-number header row
+    y=79..96   Linescore away-team row
+    y=97..114  Linescore home-team row
+    y=115      Thin linescore bottom line
+    y=115..134 R / H / E column labels (f14)
+    y=135..214 Away row : logo  abbr  R  H  E  |  bases diamond (right, spans rows)
+    y=215..294 Home row : logo  abbr  R  H  E  |
+    y=274..322 [blank left]  |  outs circles (right, under bases)
+    y=322      Thick divider line
+    y=323..425 Situation area (103 px):
+        Live           : B/S circles (f36) + pitch info (f28) + pitcher/batter (f28)
+        Between-innings: pitcher (f36, left) + due-up batters (f28, right)
+    y=425      Win % divider
+    y=426..479 Win % bar (54 px)
     """
     import re as _re_lf
 
@@ -88,15 +95,14 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     draw   = ImageDraw.Draw(canvas)
 
     # ---- Fonts ---------------------------------------------------------------
-    f14  = _get_font(14)    # ABS / challenge labels
-    f44  = _get_font(44)    # runner jersey numbers inside bases
-    f24  = _get_font(24)    # pitch info / between-innings names
-    f28  = _get_font(28)    # misc
-    f36  = _get_font(36)    # misc
+    f14  = _get_font(14)    # linescore team rows + ABS labels
+    f24  = _get_font(24)    # between-innings batters + OD
+    f28  = _get_font(28)    # between-innings pitcher + SV badge
+    f36  = _get_font(36)    # pitch info right-aligned
     f42  = _get_font(42)    # BSO labels + pitcher/batter + team abbreviations
-    f56  = _get_font(56)    # matchup header fallback
-    f72  = _get_font(72)    # R / H / E values
-    f80  = _get_font(80)    # inning text + last event in header
+    f44  = _get_font(44)    # runner jersey numbers inside bases
+    f56  = _get_font(56)    # header inning + last-event text
+    f72  = _get_font(72)    # R / H / E values in score rows
 
     # ---- Team identifiers ----------------------------------------------------
     abbr_map  = team_data.get('team_abbreviation', {})
@@ -117,18 +123,18 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     _between_innings = _inn_state in ('Middle', 'End')
     _pitching_change = (game_data.get('sub_event') or '').startswith('PC:')
 
-    # ---- Layout constants ----------------------------------------------------
-    HEADER_H   = 69           # 25% smaller than original 92 → freed pixels go to bottom bar
-    LABEL_H    = 20           # space between header and first team row
-    TEAM_ROW_H = 80           # away/home score rows
+    # ---- Layout constants (original — linescore lives in situation area) -----
+    HEADER_H   = 69
+    LABEL_H    = 20
+    TEAM_ROW_H = 80
     AWAY_Y     = HEADER_H + LABEL_H          # 89
     HOME_Y     = AWAY_Y  + TEAM_ROW_H        # 169
-    OUTS_Y_TOP = HOME_Y  + TEAM_ROW_H - 21  # 228 → 8px below bases bottom (224)
-    OUTS_H     = 48                          # circles bottom at 272, +4px gap = div at 276
+    OUTS_Y_TOP = HOME_Y  + TEAM_ROW_H - 21  # 228
+    OUTS_H     = 48
     DIV_Y      = OUTS_Y_TOP + OUTS_H         # 276
     SIT_Y      = DIV_Y + 1                   # 277
-    WIN_PCT_H  = 54                          # 3× win % bar
-    WIN_PCT_Y  = 480 - WIN_PCT_H             # 426
+    WIN_PCT_H  = 54
+    WIN_PCT_Y  = 480 - WIN_PCT_H             # 426  (situation area = 149 px)
 
     # Team row layout
     LOGO_SZ  = 72
@@ -140,17 +146,21 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     H_CX = 360
     E_CX = 480
 
-    # Bases: right side — doubled size, repositioned to fit
+    # Bases: right side, spanning both score rows
     DIAMOND_CX = 645
-    DIAMOND_CY = 178                         # shifted up more
-    BASE_DIST  = 58                          # closer together
-    BASE_SZ    = 46                          # ~2x the original 24
+    DIAMOND_CY = 178
+    BASE_DIST  = 58
+    BASE_SZ    = 46
     BASE_OW    = 4
 
-    # BSO circles (bottom half)
-    B_R   = 16                               # 30% bigger than original 12
-    O_R   = 20                               # bigger outs circles
+    # BSO circles
+    B_R   = 16
+    O_R   = 20
     C_GAP = 5
+
+    # Between-innings linescore metrics (used in situation area only)
+    _LS_TEAM_W = 60            # team abbr column
+    _LS_ROW_H  = 15            # height of each linescore team row
 
     # ---- Last-event helper (built early for header use) ----------------------
     _FLD_POS = [
@@ -382,10 +392,20 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     # ---- DIVIDER (full width, thick) ----------------------------------------
     draw.line((0, DIV_Y, 799, DIV_Y), fill=0, width=2)
 
-    # ---- BOTTOM SITUATION AREA ----------------------------------------------
+    # ---- BOTTOM SITUATION AREA (149 px: SIT_Y=277 → WIN_PCT_Y=426) ----------
+    # Detect when game is effectively over in a transient between-innings state.
+    _game_effectively_over = (
+        _between_innings and _cur_inn >= 9 and (
+            (_inn_state == 'Middle' and
+             (game_data.get('home_runs') or 0) > (game_data.get('away_runs') or 0)) or
+            (not (game_data.get('next_batter_1') or game_data.get('next_batter_2')) and
+             (game_data.get('home_runs') or 0) != (game_data.get('away_runs') or 0))
+        )
+    )
+
     if _between_innings or _pitching_change:
-        # ---- Between innings: due-up batters (big, left) + pitcher (right-aligned) ----
-        _by = SIT_Y + 8
+        # ---- Between innings: pitcher (top-left) | linescore | batters (bottom-right) ----
+        _bot = WIN_PCT_Y - 2
 
         _batter_names = [nm for nm in [
             _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
@@ -397,31 +417,90 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             game_data.get('next_pitcher') or game_data.get('current_pitcher') or ''
         )
 
-        _bot = WIN_PCT_Y - 4
+        if _game_effectively_over:
+            _fin_txt = 'FINAL'
+            _fin_w   = int(f42.getlength(_fin_txt))
+            _fin_y   = SIT_Y + ((_bot - SIT_Y) - 42) // 2
+            draw.text((400 - _fin_w // 2,     _fin_y), _fin_txt, font=f42, fill=0)
+            draw.text((400 - _fin_w // 2 + 1, _fin_y), _fin_txt, font=f42, fill=0)
+        else:
+            # Pitcher: top-left, f28
+            _pit_y = SIT_Y + 6
+            if _pit_nm and _pit_y + 28 <= _bot:
+                draw.text((16, _pit_y),     _pit_nm, font=f28, fill=0)
+                draw.text((17, _pit_y),     _pit_nm, font=f28, fill=0)
 
-        # Pitcher: left side, vertically centred in the bottom section
-        if _pit_nm:
-            _pit_y = (SIT_Y + 8 + _bot) // 2 - 21
-            draw.text((16, _pit_y),     _pit_nm, font=f42, fill=0)
-            draw.text((17, _pit_y),     _pit_nm, font=f42, fill=0)
+            # Mini linescore (2 team rows, no inning header) between pitcher and batters
+            _ls_away = game_data.get('away_inning_runs') or []
+            _ls_home = game_data.get('home_inning_runs') or []
+            _ls_n     = min(max(9, _cur_inn), 12)
+            _ls_first = max(1, _cur_inn - _ls_n + 1) if _cur_inn > _ls_n else 1
+            _ls_inn_w = (800 - _LS_TEAM_W) // _ls_n   # px per inning column
 
-        # Batters: right-aligned, stacked from top, bounded by WIN_PCT_Y
-        _avail_h = _bot - _by
-        _n = len(_batter_names) or 1
-        _bat_spacing = min(48, _avail_h // _n)
-        for _nm in _batter_names:
-            if _by + 42 <= _bot:
-                _nm_w = int(f42.getlength(_nm))
-                _nm_x = 800 - _nm_w - 16
-                draw.text((_nm_x, _by),     _nm, font=f42, fill=0)
-                draw.text((_nm_x + 1, _by), _nm, font=f42, fill=0)
-                _by += _bat_spacing
+            # Position linescore below pitcher + gap
+            _ls_top = _pit_y + 28 + 6    # y=SIT_Y+40 ≈ 317
+            _ls_a_y = _ls_top             # away row top
+            _ls_h_y = _ls_top + _LS_ROW_H + 1  # home row top (1px for divider)
+            _ls_bot = _ls_h_y + _LS_ROW_H  # bottom of linescore
+
+            # Horizontal dividers
+            draw.line((0, _ls_top, 799, _ls_top), fill=0, width=1)
+            draw.line((0, _ls_a_y + _LS_ROW_H, 799, _ls_a_y + _LS_ROW_H), fill=0, width=1)
+            draw.line((0, _ls_bot, 799, _ls_bot), fill=0, width=1)
+            # Team column divider
+            draw.line((_LS_TEAM_W, _ls_top, _LS_TEAM_W, _ls_bot), fill=0, width=1)
+            # Inning column dividers (light)
+            for _k in range(1, _ls_n):
+                _vx = _LS_TEAM_W + _k * _ls_inn_w
+                draw.line((_vx, _ls_top, _vx, _ls_bot), fill=0, width=1)
+
+            # Team abbr in team column
+            for _ls_abbr, _row_y in ((away_abbr, _ls_a_y), (home_abbr, _ls_h_y)):
+                _tw = int(f14.getlength(_ls_abbr[:3]))
+                draw.text(((_LS_TEAM_W - _tw) // 2, _row_y + (_LS_ROW_H - 14) // 2),
+                          _ls_abbr[:3], font=f14, fill=0)
+
+            # Per-inning run values
+            def _ls_val(inn_runs, row_y, val_offset=0):
+                for _k in range(_ls_n):
+                    _idx = _ls_first - 1 + _k
+                    if _idx < len(inn_runs) and inn_runs[_idx] is not None:
+                        _val = str(inn_runs[_idx])
+                        _vx  = _LS_TEAM_W + _k * _ls_inn_w + (_ls_inn_w - int(f14.getlength(_val))) // 2
+                        draw.text((_vx, row_y + val_offset), _val, font=f14, fill=0)
+
+            _ls_val(_ls_away, _ls_a_y, (_LS_ROW_H - 14) // 2)
+            _ls_val(_ls_home, _ls_h_y, (_LS_ROW_H - 14) // 2)
+
+            # X in home row when home team wins without batting in the last inning
+            _ls_finally = (
+                _inn_state == 'Middle' and _cur_inn >= 9 and
+                (game_data.get('home_runs') or 0) > (game_data.get('away_runs') or 0)
+            )
+            if _ls_finally and _ls_away:
+                _last_idx = len(_ls_away) - 1
+                _home_last = _ls_home[_last_idx] if _last_idx < len(_ls_home) else None
+                if _home_last is None:
+                    _col_k = _last_idx - (_ls_first - 1)
+                    if 0 <= _col_k < _ls_n:
+                        _cx = _LS_TEAM_W + _col_k * _ls_inn_w + _ls_inn_w // 2
+                        _cy = _ls_h_y + _LS_ROW_H // 2
+                        draw.line((_cx - 4, _cy - 5, _cx + 4, _cy + 5), fill=0, width=2)
+                        draw.line((_cx + 4, _cy - 5, _cx - 4, _cy + 5), fill=0, width=2)
+
+            # Batters: right-aligned below linescore, f24, 24px spacing
+            _by = _ls_bot + 3
+            for _nm in _batter_names:
+                if _by + 24 <= _bot:
+                    _nm_w = int(f24.getlength(_nm))
+                    draw.text((800 - _nm_w - 16, _by),     _nm, font=f24, fill=0)
+                    draw.text((800 - _nm_w - 15, _by),     _nm, font=f24, fill=0)
+                    _by += 24
 
     else:
-        # ---- Active pitch: B/S (no O)  +  pitch info  +  pitcher/batter ----
+        # ---- Active pitch: B/S circles (f42) + pitch info (f36) + pitcher/batter (f42) ----
 
-        _bso_y  = SIT_Y + 6    # top of BSO label text
-        # Circle centres: vertically centred on the cap-height of the 'B' glyph
+        _bso_y  = SIT_Y + 6
         _b_bbox = f42.getbbox('B')
         _bso_cy = _bso_y + (_b_bbox[1] + _b_bbox[3]) // 2
 
@@ -463,58 +542,49 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
         if _pc  is not None: _pitch_parts.append(f'{_pc}P')
         if _lps:             _pitch_parts.append(f'{int(_lps)}mph')
         if _pt:              _pitch_parts.append(_pt)
-        # SV shown in top half of display, not here
         if _pitch_parts:
-            _ptxt = '  '.join(_pitch_parts)
-            _ptw  = int(f36.getlength(_ptxt))
+            _ptxt    = '  '.join(_pitch_parts)
+            _ptw     = int(f36.getlength(_ptxt))
             _pt_bbox = f36.getbbox(_ptxt)
-            _pty = _bso_cy - (_pt_bbox[1] + _pt_bbox[3]) // 2
+            _pty     = _bso_cy - (_pt_bbox[1] + _pt_bbox[3]) // 2
             draw.text((800 - _ptw - 8, _pty), _ptxt, font=f36, fill=0)
 
-        # Pitcher (left) + Batter (x=400) on one line
+        # Pitcher (left, x=16) + AB/OD block (right of x=400)
         _pb_y = _bso_y + 48
         _pitcher_full = (game_data.get('current_pitcher') or '').strip()
         if _pitcher_full and _pb_y + 42 <= WIN_PCT_Y:
             draw.text((16, _pb_y),     f'P: {_pitcher_full}', font=f42, fill=0)
             draw.text((17, _pb_y),     f'P: {_pitcher_full}', font=f42, fill=0)
 
-        # Batter — due_up when at-bat complete, else current_hitter
+        # Batter
         _ab_done = game_data.get('current_at_bat_complete', False)
         if _ab_done and not _is_game_effectively_over(game_data):
             _batter_full = (game_data.get('due_up') or game_data.get('next_batter_1') or '').strip()
             _od_full     = (game_data.get('in_hole') or '').strip()
         else:
-            # Prefer current_play_batter (currentPlay.matchup) over current_hitter
-            # (linescore) — they update atomically, eliminating the lag-driven flip-flop.
             _batter_full = (
                 game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
             ).strip()
-            _od_full     = (game_data.get('due_up') or '').strip()
-        # Safety: on-deck must never be the same person as at-bat
+            _od_full = (game_data.get('due_up') or '').strip()
         if _od_full == _batter_full:
             _od_full = ''
-        # Label column: right-align "AB:" and "OD:" so colons line up,
-        # then names start at the same x
-        _ab_lbl_w = int(f42.getlength('AB:'))
-        _od_lbl_w = int(f42.getlength('OD:'))
-        _lbl_col  = max(_ab_lbl_w, _od_lbl_w)
-        _name_x   = 400 + _lbl_col + 8
+
+        # AB: and OD: left-aligned at x=400 so labels stack vertically
+        _lbl_x  = 400
+        _name_x = _lbl_x + int(f42.getlength('AB:')) + 8
 
         if _batter_full and _pb_y + 42 <= WIN_PCT_Y:
-            _ax = 400 + (_lbl_col - _ab_lbl_w)
-            draw.text((_ax,      _pb_y), 'AB:', font=f42, fill=0)
-            draw.text((_ax+1,    _pb_y), 'AB:', font=f42, fill=0)
-            draw.text((_name_x,  _pb_y), _batter_full, font=f42, fill=0)
-            draw.text((_name_x+1,_pb_y), _batter_full, font=f42, fill=0)
+            draw.text((_lbl_x,      _pb_y), 'AB:', font=f42, fill=0)
+            draw.text((_lbl_x + 1,  _pb_y), 'AB:', font=f42, fill=0)
+            draw.text((_name_x,     _pb_y), _batter_full, font=f42, fill=0)
+            draw.text((_name_x + 1, _pb_y), _batter_full, font=f42, fill=0)
 
-        # On-deck hitter below AB batter — same font, labels right-aligned
         _od_y = _pb_y + 46
         if _od_full and _od_y + 42 <= WIN_PCT_Y - 2:
-            _ox = 400 + (_lbl_col - _od_lbl_w)
-            draw.text((_ox,      _od_y), 'OD:', font=f42, fill=0)
-            draw.text((_ox+1,    _od_y), 'OD:', font=f42, fill=0)
-            draw.text((_name_x,  _od_y), _od_full, font=f42, fill=0)
-            draw.text((_name_x+1,_od_y), _od_full, font=f42, fill=0)
+            draw.text((_lbl_x,      _od_y), 'OD:', font=f42, fill=0)
+            draw.text((_lbl_x + 1,  _od_y), 'OD:', font=f42, fill=0)
+            draw.text((_name_x,     _od_y), _od_full, font=f42, fill=0)
+            draw.text((_name_x + 1, _od_y), _od_full, font=f42, fill=0)
 
     # ---- SEPARATOR LINE above win % bar -------------------------------------
     draw.line((0, WIN_PCT_Y - 1, 799, WIN_PCT_Y - 1), fill=0, width=2)


### PR DESCRIPTION
## Summary

- **Between-innings linescore** — pitcher name at top-left, then a compact 2-row linescore showing per-inning runs for both teams (full width), then 3 due-up batters right-aligned at the bottom. The linescore appears between the pitcher and the upcoming batters exactly as requested. X drawn in home team's final column when they win without batting.
- **End-of-game detection** — when the game is in a transient between-innings state but is effectively over (Middle of 9th+ with home team leading, or no batters due up with a winner), shows "FINAL" centred in the situation area instead of pitcher/batters
- **AB/OD vertical alignment** — in active play, both `AB:` and `OD:` labels now left-align at x=400, names start at the same column — colons and names stack cleanly

## Test plan

- [ ] Between innings (End 5th): pitcher top-left, linescore strip in middle, 3 batters right-aligned bottom
- [ ] Middle 9th, home winning: shows FINAL instead of due-up batters
- [ ] Active play: AB: and OD: labels start at same x, names aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)