### PR TITLE
Partial cell refresh for scoreboard: up to 9 cells, full every 10

### DIFF
--- a/src/display_eink.py
+++ b/src/display_eink.py
@@ -8,7 +8,7 @@ import logging
 from PIL import Image
 
 from util import load_json_file, load_yaml_file
-from refresh_tracker import needs_full_refresh, record_full_refresh
+from refresh_tracker import needs_full_refresh, record_full_refresh, record_partial_refresh
 
 # Only import waveshare hardware drivers on non-Darwin platforms
 if platform.system() != 'Darwin':
@@ -101,6 +101,7 @@ def display_partial_regions(full_image, regions, output_filename='resulting_imag
     # Always save the full image
     full_image.save(output_filename)
     print(f"Image saved to {output_filename}")
+    record_partial_refresh()
 
     for r in regions:
         print(f"  Partial region: x={r[0]}, y={r[1]}, w={r[2]}, h={r[3]}")

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -272,8 +272,8 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
             rh = 150
             changed_regions.append((rx, ry, rw, rh))
 
-    # If too many regions changed, signal full refresh with empty list
-    if len(changed_regions) > 5:
+    # If 10+ cells changed, signal full refresh with empty list; fewer → partial per cell
+    if len(changed_regions) >= 10:
         changed_regions = []
 
     return (Himage, changed_regions)

--- a/src/refresh_tracker.py
+++ b/src/refresh_tracker.py
@@ -4,6 +4,7 @@ import time
 
 STATE_FILE = os.path.join(os.path.dirname(__file__), '..', 'data', 'refresh_state.json')
 FULL_REFRESH_INTERVAL = 3600  # 1 hour in seconds
+PARTIAL_REFRESH_BEFORE_FULL = 20  # force full refresh after this many partial refreshes
 
 
 def _load_state():
@@ -15,18 +16,31 @@ def _load_state():
 
 
 def needs_full_refresh():
-    """Return True if 1+ hour since last full refresh (or first run)."""
+    """Return True if 1+ hour since last full refresh, or >= 10 partial refreshes since last full."""
     state = _load_state()
     last = state.get('last_full_refresh')
     if last is None:
         return True
-    return (time.time() - last) >= FULL_REFRESH_INTERVAL
+    if (time.time() - last) >= FULL_REFRESH_INTERVAL:
+        return True
+    partial_count = state.get('partial_refresh_count', 0)
+    return partial_count >= PARTIAL_REFRESH_BEFORE_FULL
 
 
 def record_full_refresh():
-    """Save current timestamp as last full refresh."""
+    """Save current timestamp as last full refresh and reset the partial refresh counter."""
     state = _load_state()
     state['last_full_refresh'] = time.time()
+    state['partial_refresh_count'] = 0
+    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+    with open(STATE_FILE, 'w') as f:
+        json.dump(state, f, indent=4)
+
+
+def record_partial_refresh():
+    """Increment the partial refresh counter."""
+    state = _load_state()
+    state['partial_refresh_count'] = state.get('partial_refresh_count', 0) + 1
     os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
     with open(STATE_FILE, 'w') as f:
         json.dump(state, f, indent=4)


### PR DESCRIPTION
## Summary
- **Wider partial-refresh window**: threshold raised from 5 → 9 changed cells. 1–9 cells → per-cell partial refresh; 10+ → full refresh.
- **Count-based full-refresh**: after 20 cumulative partial refreshes (~20 min at 1-min polling), forces a full redraw to prevent e-ink ghosting. Counter resets on every full refresh.
- **`record_partial_refresh()`**: new function in `refresh_tracker.py`; called by `display_eink.display_partial_regions()` automatically.

## Test plan
- [ ] Verify partial refresh fires for 1–9 changed cells
- [ ] Verify 10+ changed cells triggers full refresh
- [ ] Verify `data/refresh_state.json` accumulates `partial_refresh_count`; resets after full refresh
- [ ] On Pi: count-based full refresh fires at count=20

🤖 Generated with [Claude Code](https://claude.com/claude-code)