### PR TITLE
Wide-cell scoreboard for <15 games

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 # MLB Display Configuration
 # scoreboard: true = 15 game grid, false = 2 detailed linescores + standings
-scoreboard: false
+scoreboard: true
 
 # Display mode: "scoreboard" | "linescore" | "field" | "scorecard" | "pitch"
 # If set, overrides the scoreboard: true/false flag above.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,6 +101,12 @@ scoreboard_win_probability: true
 # Adds one extra API call (live feed) per in-progress game per refresh cycle.
 scoreboard_live_details: true
 
+# Wide cell: show a 2-slot expanded tile for in-progress games with pitch zone, bases, K strip, etc.
+# When false (or omitted), wide cells only appear when there are fewer than 15 games.
+# When true, always show a wide cell for the in-progress game farthest into the game (by inning),
+# even when there are 15+ games on the slate (one game will be dropped from the grid to make room).
+wide_cell_always: false
+
 # Pre-game weather footer on Scheduled/Pre-Game/Warmup tiles (temp, wind, precip%).
 # Uses Open-Meteo (no API key required) with stadium coordinates from data/stadium_weather.json.
 weather:

--- a/main.py
+++ b/main.py
@@ -620,15 +620,8 @@ Examples:
     image, changed_regions = result
 
     # 9. Send to display
-    from refresh_tracker import needs_full_refresh
-    if needs_full_refresh() or not changed_regions:
-        print("Scoreboard: full refresh")
-        refresh_mode = 'full'
-    else:
-        print(f"Scoreboard: partial refresh ({len(changed_regions)} region(s))")
-        refresh_mode = 'partial'
-
-    send_to_display(output_path, changed_regions if refresh_mode == 'partial' else None)
+    refresh_mode = send_to_display(output_path, changed_regions)
+    print(f"Scoreboard: {refresh_mode} refresh ({len(changed_regions)} region(s))")
 
     print(f"\n✓ Display updated successfully!")
     print(f"  Image: {output_path}")

--- a/src/display.py
+++ b/src/display.py
@@ -21,21 +21,25 @@ def send_to_display(image_path, changed_regions=None, force_full=False):
     """
     Load image from path and push to e-ink.
 
+    Full refresh (flash) only when force_full=True or the hourly timer fires.
+    All other updates use partial refresh — defaulting to a full-screen partial
+    when no specific regions are provided.
+
     Args:
         image_path: Path to the image file to display
         changed_regions: List of (x, y, w, h) tuples for partial refresh, or None
-        force_full: Force a full refresh even if partial is possible
+        force_full: Force a full (flashing) refresh
 
     Returns:
         'full' or 'partial'
     """
     image = Image.open(image_path)
-    if force_full or needs_full_refresh() or not changed_regions:
+    if force_full or needs_full_refresh():
         display_image(image, output_filename=image_path)
         return 'full'
-    else:
-        display_partial_regions(image, changed_regions, output_filename=image_path)
-        return 'partial'
+    regions = changed_regions or [(0, 0, image.width, image.height)]
+    display_partial_regions(image, regions, output_filename=image_path)
+    return 'partial'
 
 
 def main():

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -430,6 +430,29 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             live_last_play_rbi = int(_lp.get('result', {}).get('rbi') or 0)
             break
 
+        # Wide-cell extras: current AB pitches (locations + type) and last 3 half-inning play descriptions.
+        ab_pitches = _extract_pitches_detailed(plays)
+        for _p in ab_pitches:
+            _p['pt_abbr'] = _PITCH_TYPE_ABBR.get(_p.get('code', ''), _p.get('code', ''))
+
+        _cur_inn = linescore.get('currentInning') or 0
+        _inn_state = linescore.get('inningState', '')
+        _is_top = _inn_state in ('Top', 'Middle')
+        half_inning_plays = []
+        for _ap in plays.get('allPlays', []):
+            _about = _ap.get('about', {})
+            if (
+                _about.get('inning') == _cur_inn and
+                bool(_about.get('isTopInning')) == _is_top and
+                _about.get('isComplete', False)
+            ):
+                _ap_et = (_ap.get('result', {}).get('eventType') or '').lower().replace(' ', '_')
+                if _ap_et not in _SUBST_EVENT_TYPES:
+                    _desc = (_ap.get('result', {}).get('description') or '').strip()
+                    if _desc:
+                        half_inning_plays.append(_desc)
+        half_inning_plays = half_inning_plays[-3:]
+
         return {
             'pitch_count': pitch_count,
             'batter_hits': batter_hits,
@@ -464,6 +487,8 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             'last_play_rbi': live_last_play_rbi,
             'last_play_inning': live_last_play_inning,
             'last_play_is_top': live_last_play_is_top,
+            'ab_pitches': ab_pitches,
+            'half_inning_plays': half_inning_plays,
         }
     except Exception:
         return {}

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -50,7 +50,7 @@ def fetch_live_feed(game_pk):
 
 
 def _extract_pitches_detailed(plays):
-    """Extract pitch data with velocity and pitch type from current or last at-bat."""
+    """Extract pitch data with velocity, pitch type, and per-batter zone bounds."""
     sources = [plays.get('currentPlay', {})]
     all_plays = plays.get('allPlays', [])
     if all_plays:
@@ -74,7 +74,11 @@ def _extract_pitches_detailed(plays):
                 'seq': seq,
                 'px': px,
                 'pz': pz,
+                'sz_top': pitch_data.get('strikeZoneTop'),
+                'sz_bot': pitch_data.get('strikeZoneBottom'),
                 'code': details.get('type', {}).get('code', ''),
+                # Result/call code (B/C/S/F/X/D/E…) — drives strike-zone fill.
+                'call': details.get('call', {}).get('code', '') or details.get('code', ''),
                 'pitch_type': details.get('type', {}).get('description', ''),
                 'description': details.get('description', ''),
                 'is_strike': details.get('isStrike', False),
@@ -430,28 +434,83 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             live_last_play_rbi = int(_lp.get('result', {}).get('rbi') or 0)
             break
 
-        # Wide-cell extras: current AB pitches (locations + type) and last 3 half-inning play descriptions.
+        # Wide-cell extras: current AB pitches (locations + type) and the last 5 game events.
         ab_pitches = _extract_pitches_detailed(plays)
         for _p in ab_pitches:
             _p['pt_abbr'] = _PITCH_TYPE_ABBR.get(_p.get('code', ''), _p.get('code', ''))
 
-        _cur_inn = linescore.get('currentInning') or 0
-        _inn_state = linescore.get('inningState', '')
-        _is_top = _inn_state in ('Top', 'Middle')
-        half_inning_plays = []
+        # Mid-at-bat "action" events worth surfacing in the header, oldest-first.
+        _ACTION_CODES = {
+            'stolen_base':      'SB',
+            'caught_stealing':  'CS',
+            'pickoff':          'PK',
+            'wild_pitch':       'WP',
+            'passed_ball':      'PB',
+            'balk':             'BLK',
+            'pitching_substitution': 'PC',
+        }
+
+        def _action_code(et):
+            for _k, _v in _ACTION_CODES.items():
+                if et.startswith(_k):
+                    return _v
+            return None
+
+        # Last 7 events of the whole game for the header, oldest-first, in scorecard
+        # notation (e.g. '6-3', 'K', 'F9', '3R HR'). Runs-batted-in plays are prefixed
+        # with the run count. Includes in-play actions (steals, pickoffs, wild pitches,
+        # pitching changes) and challenge/replay reviews.
+        # A '+' token is inserted wherever the half-inning changes so the renderer can
+        # display it as an inning-break delimiter.
+        game_plays = []
+        _last_play_half = None   # (inning, isTopInning) of the last appended play
         for _ap in plays.get('allPlays', []):
             _about = _ap.get('about', {})
-            if (
-                _about.get('inning') == _cur_inn and
-                bool(_about.get('isTopInning')) == _is_top and
-                _about.get('isComplete', False)
-            ):
-                _ap_et = (_ap.get('result', {}).get('eventType') or '').lower().replace(' ', '_')
-                if _ap_et not in _SUBST_EVENT_TYPES:
-                    _desc = (_ap.get('result', {}).get('description') or '').strip()
-                    if _desc:
-                        half_inning_plays.append(_desc)
-        half_inning_plays = half_inning_plays[-3:]
+            _this_half = (_about.get('inning', 0), bool(_about.get('isTopInning', True)))
+            # In-play actions and challenge/replay reviews, in the order they occurred.
+            _review_added = False
+            for _pe in _ap.get('playEvents', []):
+                if _pe.get('type') == 'action':
+                    _code = _action_code((_pe.get('details', {}).get('eventType') or '').lower())
+                    if _code and (not game_plays or game_plays[-1] != _code):
+                        if _last_play_half and _this_half != _last_play_half:
+                            game_plays.append('+')
+                        game_plays.append(_code)
+                        _last_play_half = _this_half
+                _rd = _pe.get('reviewDetails')
+                if _rd and not _rd.get('inProgress') and not _review_added:
+                    game_plays.append('OVR' if _rd.get('isOverturned') else 'CHAL')
+                    _review_added = True
+            # Final result of a completed at-bat.
+            if _ap.get('about', {}).get('isComplete', False):
+                _result = _ap.get('result', {})
+                _ap_et = (_result.get('eventType') or '').lower().replace(' ', '_')
+                if _ap_et == 'pitching_substitution':
+                    if not game_plays or game_plays[-1] != 'PC':
+                        game_plays.append('PC')
+                elif _ap_et not in _SUBST_EVENT_TYPES:
+                    _ev = (_result.get('event') or '').strip()
+                    if _ev:
+                        # Same scorecard notation + RBI prefixes the normal cells use.
+                        _note = _build_scorecard_notation(_ap)
+                        _rbi = int(_result.get('rbi') or 0)
+                        _is_err = _note.startswith('E') or ' E' in _note
+                        if _rbi > 0 and not _is_err:
+                            if _note == 'HR':
+                                if _rbi == 4:
+                                    _note = 'Grand Slam'
+                                elif _rbi >= 2:
+                                    _note = f'{_rbi}R HR'
+                                # solo HR: no prefix
+                            elif _rbi == 1:
+                                _note = f'RBI {_note}'
+                            else:
+                                _note = f'{_rbi}RBI {_note}'
+                        if _last_play_half and _this_half != _last_play_half:
+                            game_plays.append('+')
+                        game_plays.append(_note)
+                        _last_play_half = _this_half
+        half_inning_plays = game_plays[-7:]
 
         # K strikeouts for wide-cell header: track swinging (K) vs looking (L) per pitcher side
         away_pitcher_ks = []   # Ks by away pitcher (home batters struck out, isTopInning=False)
@@ -973,6 +1032,24 @@ def _map_event_to_code(event):
     return _EVENT_CODE_MAP.get(event, event[:3] if event else '')
 
 
+_POS_KEYWORDS_FETCH = [
+    ('center fielder', '8'), ('right fielder', '9'), ('left fielder', '7'),
+    ('first baseman', '3'), ('second baseman', '4'), ('third baseman', '5'),
+    ('shortstop', '6'), ('catcher', '2'), ('pitcher', '1'),
+]
+
+
+def _pos_from_desc(description):
+    """Return the primary putout fielder position code from a play description."""
+    if not description:
+        return ''
+    dl = description.lower()
+    for kw, code in _POS_KEYWORDS_FETCH:
+        if kw in dl:
+            return code
+    return ''
+
+
 def _build_scorecard_notation(play):
     """Return scorecard notation (e.g. 'F7', '6-4-3 DP', 'K', '1B') from a play dict."""
     result  = play.get('result', {})
@@ -1047,23 +1124,37 @@ def _build_scorecard_notation(play):
             if p and p.isdigit():
                 putout_pos = p
 
+    _desc = result.get('description', '')
+
     if event in ('Flyout',):
         if is_dp and pos_seq:
             return '-'.join(pos_seq) + dp_suffix
-        return f'F{putout_pos}' if putout_pos else 'FO'
+        if putout_pos:
+            return f'F{putout_pos}'
+        _fp = _pos_from_desc(_desc)
+        return f'F{_fp}' if _fp else 'FO'
 
     if event in ('Lineout',):
         if is_dp and pos_seq:
             return '-'.join(pos_seq) + dp_suffix
-        return f'L{putout_pos}' if putout_pos else 'LO'
+        if putout_pos:
+            return f'L{putout_pos}'
+        _fp = _pos_from_desc(_desc)
+        return f'L{_fp}' if _fp else 'LO'
 
     if event in ('Pop Out', 'Popout'):
-        return f'P{putout_pos}' if putout_pos else 'PO'
+        if putout_pos:
+            return f'P{putout_pos}'
+        _fp = _pos_from_desc(_desc)
+        return f'P{_fp}' if _fp else 'PO'
 
     if event in ('Sac Fly', 'Sac Fly Double Play'):
         if is_dp and pos_seq:
             return '-'.join(pos_seq) + dp_suffix
-        return f'SF{putout_pos}' if putout_pos else 'SF'
+        if putout_pos:
+            return f'SF{putout_pos}'
+        _fp = _pos_from_desc(_desc)
+        return f'SF{_fp}' if _fp else 'SF'
 
     if event in ('Sac Bunt', 'Sacrifice Bunt DP', 'Sac Bunt Double Play'):
         seq = '-'.join(pos_seq) if pos_seq else ''
@@ -1088,7 +1179,6 @@ def _build_scorecard_notation(play):
     # Credits absent — parse fielder positions from the play description.
     # Find every occurrence of each position keyword so repeated touches
     # (e.g. catcher in a rundown) are captured; cap at 5 fielders.
-    _desc = result.get('description', '')
     if _desc:
         _dl = _desc.lower()
         _pos_kws = [

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -453,6 +453,23 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
                         half_inning_plays.append(_desc)
         half_inning_plays = half_inning_plays[-3:]
 
+        # K strikeouts for wide-cell header: track swinging (K) vs looking (L) per pitcher side
+        away_pitcher_ks = []   # Ks by away pitcher (home batters struck out, isTopInning=False)
+        home_pitcher_ks = []   # Ks by home pitcher (away batters struck out, isTopInning=True)
+        for _kp in plays.get('allPlays', []):
+            if (_kp.get('result', {}).get('eventType') or '').lower() == 'strikeout':
+                _k_is_top = _kp.get('about', {}).get('isTopInning', True)
+                _k_last_code = ''
+                for _kpe in reversed(_kp.get('playEvents', [])):
+                    if _kpe.get('isPitch'):
+                        _k_last_code = _kpe.get('details', {}).get('code', '')
+                        break
+                _k_type = 'L' if _k_last_code == 'C' else 'K'
+                if _k_is_top:
+                    home_pitcher_ks.append(_k_type)
+                else:
+                    away_pitcher_ks.append(_k_type)
+
         return {
             'pitch_count': pitch_count,
             'batter_hits': batter_hits,
@@ -489,6 +506,8 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
             'last_play_is_top': live_last_play_is_top,
             'ab_pitches': ab_pitches,
             'half_inning_plays': half_inning_plays,
+            'away_pitcher_ks': away_pitcher_ks,
+            'home_pitcher_ks': home_pitcher_ks,
         }
     except Exception:
         return {}

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -193,9 +193,13 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
 
         Himage = ImageOps.invert(Himage.convert('L')).convert('1')
 
-        # Partial refresh for live fullscreen: if only bottom-panel fields changed
-        # (count, pitch info, pitcher/batter, win %), refresh just y=277..479.
-        # Top section (scores, bases, outs) requires a full refresh when it changes.
+        # Partial refresh for live fullscreen: map changed fields to display zones and
+        # refresh only the affected zones.  Three zones:
+        #   Header  y=0..75   — inning label, last-play event
+        #   Score   y=69..276 — R/H/E rows, bases, outs, challenges
+        #   Bottom  y=277..479 — B/S/O, pitch info, pitcher/batter, win %
+        # (Header and Score overlap slightly at y=69..75 to cover the thick divider line.)
+        # If all three zones change, fall back to a full refresh (empty list).
         _fs_regions = []
         if not bypass_cache and featured_game:
             _ds = featured_game.get('detailed_state', '')
@@ -204,19 +208,48 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
                 _feat_pk = str(featured_game.get('game_pk', ''))
                 _old_feat = old_by_pk.get(_feat_pk)
                 if _old_feat is not None:
-                    _BOTTOM_ONLY = frozenset({
+                    _HEADER_FIELDS = frozenset({
+                        'inningState', 'inningHalf', 'current_inning', 'currentInningOrdinal',
+                        'last_play', 'last_review_result', 'last_play_description',
+                        'sub_event', 'last_play_rbi',
+                    })
+                    _SCORE_FIELDS = frozenset({
+                        'away_runs', 'home_runs', 'away_hits', 'home_hits',
+                        'away_errors', 'home_errors',
+                        'runner_on_first', 'runner_on_second', 'runner_on_third',
+                        'runner_first_number', 'runner_second_number', 'runner_third_number',
+                        'num_of_outs',
+                        'away_challenges_remaining', 'home_challenges_remaining',
+                        'away_replay_remaining', 'home_replay_remaining', 'abs_challenge_max',
+                        'save_situation', 'detailed_state',
+                    })
+                    _BOTTOM_FIELDS = frozenset({
                         'balls', 'strikes', 'strike_calls',
                         'last_pitch_speed', 'last_pitch_type', 'pitch_count',
                         'current_pitcher',
                         'current_play_batter', 'current_hitter',
                         'due_up', 'next_batter_1', 'next_batter_2', 'next_batter_3', 'in_hole',
-                        'current_at_bat_complete',
+                        'current_at_bat_complete', 'next_pitcher',
                         'away_win_probability', 'home_win_probability',
+                        'away_inning_runs', 'home_inning_runs',
+                        'inningState', 'inningHalf', 'current_inning',
+                        'num_of_outs',
                     })
+                    _ALL_KNOWN = _HEADER_FIELDS | _SCORE_FIELDS | _BOTTOM_FIELDS
                     _changed_fields = {k for k in set(featured_game) | set(_old_feat)
                                        if featured_game.get(k) != _old_feat.get(k)}
-                    if _changed_fields and _changed_fields.issubset(_BOTTOM_ONLY):
-                        _fs_regions = [(0, 277, 800, 203)]  # situation area + win% bar
+                    if _changed_fields and not (_changed_fields - _ALL_KNOWN):
+                        _zones = []
+                        if _changed_fields & _HEADER_FIELDS:
+                            _zones.append((0, 0, 800, 76))    # header + thick border
+                        if _changed_fields & _SCORE_FIELDS:
+                            _zones.append((0, 69, 800, 208))  # R/H/E rows through divider
+                        if _changed_fields & _BOTTOM_FIELDS:
+                            _zones.append((0, 277, 800, 203)) # situation + win% bar
+                        if len(_zones) < 3:
+                            _fs_regions = _zones
+                        else:
+                            _fs_regions = [(0, 0, 800, 480)]  # all zones → full-screen partial
 
         return (Himage, _fs_regions)
 
@@ -272,8 +305,8 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
             rh = 150
             changed_regions.append((rx, ry, rw, rh))
 
-    # If 10+ cells changed, signal full refresh with empty list; fewer → partial per cell
+    # If 10+ cells changed, refresh the whole canvas as one partial region
     if len(changed_regions) >= 10:
-        changed_regions = []
+        changed_regions = [(0, 0, 800, 480)]
 
     return (Himage, changed_regions)

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -2122,46 +2122,85 @@ _SZ_PZ_LO  = 1.5
 _SZ_PZ_HI  = 3.5
 
 
+def _draw_backward_k(Himage, x, y, font):
+    """Paste a horizontally-mirrored K (looking strikeout) at (x, y)."""
+    bbox = font.getbbox('K')
+    w = max(bbox[2] - bbox[0] + 2, 4)
+    h = max(bbox[3] - bbox[1] + 4, 8)
+    tmp = Image.new('1', (w, h), 1)
+    ImageDraw.Draw(tmp).text((-bbox[0] + 1, -bbox[1] + 1), 'K', font=font, fill=0)
+    Himage.paste(tmp.transpose(Image.FLIP_LEFT_RIGHT), (int(x), int(y)))
+
+
 def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_data, team_data, use_logos=False, scale=1):
-    """Strike zone with current AB pitches + bases/batter + last 3 half-inning events."""
+    """Right panel of 2-cell wide tile.
+
+    Header strip (20 px): K strikeouts for each pitcher.
+    Content (110 px):
+      Left column  (x+0 .. x+88):  bases (top), outs, B/S indicators
+      Right column (x+88 .. x+148): strike zone (no fill) + pitch list below
+      Full-width rows: P: pitcher | AB: batter | events
+    """
     s = scale
+    font14 = _get_font(14 * s)
+    font11 = _get_font(11 * s)
     font9  = _get_font(9 * s)
     font7  = _get_font(max(7 * s, 7))
 
     state = game_data.get('detailed_state', '')
+    _between_innings = game_data.get('inningState') in ('Middle', 'End')
+
+    # ── Header: K strikeouts for each pitcher ──────────────────────────
+    # Left half = away pitcher's Ks (home batters struck out).
+    # Right half = home pitcher's Ks (away batters struck out).
+    away_ks = game_data.get('away_pitcher_ks') or []
+    home_ks = game_data.get('home_pitcher_ks') or []
+    _k_y = rp_y + 4 * s
+    _k_x = rp_x + 2 * s
+    _k_mid = rp_x + rp_w // 2
+    _k_bbox = font9.getbbox('K')
+    _k_w = _k_bbox[2] - _k_bbox[0] + 2
+
+    for _k in away_ks:
+        if _k_x + _k_w > _k_mid - 2:
+            break
+        if _k == 'L':
+            _draw_backward_k(Himage, int(_k_x), int(_k_y), font9)
+            draw = ImageDraw.Draw(Himage)
+        else:
+            draw.text((int(_k_x), int(_k_y)), 'K', font=font9, fill=0)
+        _k_x += _k_w
+
+    _k_x = _k_mid + 2 * s
+    for _k in home_ks:
+        if _k_x + _k_w > rp_x + rp_w - 2:
+            break
+        if _k == 'L':
+            _draw_backward_k(Himage, int(_k_x), int(_k_y), font9)
+            draw = ImageDraw.Draw(Himage)
+        else:
+            draw.text((int(_k_x), int(_k_y)), 'K', font=font9, fill=0)
+        _k_x += _k_w
+
     if state != 'In Progress':
         return
 
-    # Layout within right panel (150 × 130 px):
-    #   [header_h]  header strip (drawn by caller)
-    #   + 3 px pad
-    #   zone block  (taller than wide — more vertical)
-    #   bases + batter line (below zone, left side)
-    #   3 events (stacked)
+    # Count right-aligned in header, above zone
+    balls   = game_data.get('balls', 0) or 0
+    strikes = game_data.get('strikes', 0) or 0
+    count_str = f'{balls}-{strikes}'
+    _cnt_w = int(font9.getlength(count_str))
+    draw.text((rp_x + rp_w - _cnt_w - 2 * s, rp_y + 4 * s), count_str, font=font9, fill=0)
 
-    ZONE_W = 52 * s   # narrow width → taller ratio
-    ZONE_H = 68 * s   # taller than wide
-    zone_cx = rp_x + (rp_w - ZONE_W) // 2   # center zone in right panel
-    zone_lx = zone_cx
-    zone_rx = zone_cx + ZONE_W
-    zone_ty = rp_y + header_h + 10 * s
+    # ── Strike zone (RIGHT side, no fill) ─────────────────────────────
+    ZONE_W = 56 * s
+    ZONE_H = 58 * s
+    zone_rx = rp_x + rp_w - 2 * s
+    zone_lx = zone_rx - ZONE_W
+    zone_ty = rp_y + header_h + 2 * s
     zone_by = zone_ty + ZONE_H
 
-    # Outer border (solid black) — draw first so interior fill goes over it
     draw.rectangle([zone_lx, zone_ty, zone_rx, zone_by], outline=0)
-
-    # Interior fill with a dithered (50% gray) pattern to appear lighter than border
-    _zone_inner = Image.new('1', (int(ZONE_W) - 2, int(ZONE_H) - 2), 255)
-    _zpx = _zone_inner.load()
-    for _iy in range(_zone_inner.height):
-        for _ix in range(_zone_inner.width):
-            # Checker-board pattern at 2×2 resolution gives ~25% black = light gray
-            if (_ix // 2 + _iy // 2) % 2 == 0:
-                _zpx[_ix, _iy] = 0  # black dot
-    Himage.paste(_zone_inner, (int(zone_lx) + 1, int(zone_ty) + 1))
-    draw = ImageDraw.Draw(Himage)
-
-    # 9-zone grid lines (on top of filled interior)
     tw = ZONE_W // 3
     th = ZONE_H // 3
     draw.line([zone_lx + tw,     zone_ty, zone_lx + tw,     zone_by], fill=0)
@@ -2169,33 +2208,15 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
     draw.line([zone_lx, zone_ty + th,     zone_rx, zone_ty + th    ], fill=0)
     draw.line([zone_lx, zone_ty + 2 * th, zone_rx, zone_ty + 2 * th], fill=0)
 
-    # Count label above zone (left edge)
-    balls   = game_data.get('balls', 0) or 0
-    strikes = game_data.get('strikes', 0) or 0
-    count_str = f'{balls}-{strikes}'
-    draw.text((zone_lx, zone_ty - 9 * s), count_str, font=font9, fill=0)
-
-    # Pitch type legend: right of count, show types seen this AB (compact)
-    ab_pitches = game_data.get('ab_pitches') or []
-    _types_seen = []
-    for _p in ab_pitches:
-        _a = _p.get('pt_abbr') or _WIDE_PITCH_TYPE.get(_p.get('code', ''), '')
-        if _a and _a not in _types_seen:
-            _types_seen.append(_a)
-    if _types_seen:
-        _legend = ' '.join(_types_seen[:4])
-        _leg_w = int(font7.getlength(_legend))
-        draw.text((zone_rx - _leg_w, zone_ty - 9 * s), _legend, font=font7, fill=0)
-
     def _to_pixel(px_c, pz_c):
         tx = zone_lx + (px_c + _SZ_HALF_W) / (2 * _SZ_HALF_W) * ZONE_W
         ty = zone_by  - (pz_c - _SZ_PZ_LO)  / (_SZ_PZ_HI - _SZ_PZ_LO)  * ZONE_H
-        # Clamp inside zone (pitch markers at the edge are still visible)
-        tx = max(rp_x + 1 * s, min(rp_x + rp_w - 1 * s, tx))
-        ty = max(rp_y + header_h + 1 * s, min(rp_y + rp_h - 1 * s, ty))
+        tx = max(zone_lx + 1, min(zone_rx - 1, tx))
+        ty = max(zone_ty + 1, min(zone_by - 1, ty))
         return int(tx), int(ty)
 
-    # Plot pitches: filled circle = strike (with seq# inside), open = ball (with seq# inside)
+    # Pitch circles: filled + white seq# = strike; open + black seq# = ball
+    ab_pitches = game_data.get('ab_pitches') or []
     PITCH_R = max(5 * s, 5)
     for pitch_num, pitch in enumerate(ab_pitches, start=1):
         px_c, pz_c = pitch.get('px'), pitch.get('pz')
@@ -2205,87 +2226,168 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
         code = pitch.get('code', '')
         is_strike = code in ('S', 'C', 'T', 'W', 'O', 'M', 'Q', 'K')
         box = [bx - PITCH_R, by - PITCH_R, bx + PITCH_R, by + PITCH_R]
+        seq_str = str(pitch_num)
+        sw = int(font7.getlength(seq_str))
         if is_strike:
             draw.ellipse(box, fill=0, outline=0)
-            # Number inside (white text on black circle)
-            seq_str = str(pitch_num)
-            sw = int(font7.getlength(seq_str))
-            sh = 7 * s
-            draw.text((bx - sw // 2, by - sh // 2), seq_str, font=font7, fill=255)
+            draw.text((bx - sw // 2, by - 4 * s), seq_str, font=font7, fill=255)
         else:
             draw.ellipse(box, fill=255, outline=0)
-            # Number inside (black text on white circle)
-            seq_str = str(pitch_num)
-            sw = int(font7.getlength(seq_str))
-            sh = 7 * s
-            draw.text((bx - sw // 2, by - sh // 2), seq_str, font=font7, fill=0)
+            draw.text((bx - sw // 2, by - 4 * s), seq_str, font=font7, fill=0)
 
-    # --- Bases diamond + current batter (below zone) ---
-    BELOW_ZONE_Y = zone_by + 4 * s
-    BASES_SIZE   = 8 * s   # half-diagonal of each base diamond
-    DIAMOND_CX   = rp_x + 18 * s   # center of diamond cluster, left-ish
-    DIAMOND_CY   = BELOW_ZONE_Y + 10 * s
-
-    runner_first  = bool(game_data.get('runner_on_first'))
-    runner_second = bool(game_data.get('runner_on_second'))
-    runner_third  = bool(game_data.get('runner_on_third'))
-
-    def _base_diamond(cx, cy, filled):
-        pts = [(cx, cy - BASES_SIZE), (cx + BASES_SIZE, cy),
-               (cx, cy + BASES_SIZE), (cx - BASES_SIZE, cy)]
-        if filled:
-            draw.polygon(pts, fill=0, outline=0)
-        else:
-            draw.polygon(pts, fill=255, outline=0)
-
-    _base_diamond(DIAMOND_CX,              DIAMOND_CY - BASES_SIZE - 2 * s, runner_second)  # 2B (top)
-    _base_diamond(DIAMOND_CX + BASES_SIZE + 2 * s, DIAMOND_CY,              runner_first)   # 1B (right)
-    _base_diamond(DIAMOND_CX - BASES_SIZE - 2 * s, DIAMOND_CY,              runner_third)   # 3B (left)
-    # Home plate indicator (tiny square, never filled by runner)
-    _hp = BASES_SIZE // 2
-    draw.rectangle([DIAMOND_CX - _hp, DIAMOND_CY + BASES_SIZE + 1 * s,
-                    DIAMOND_CX + _hp, DIAMOND_CY + BASES_SIZE + 1 * s + _hp], outline=0)
-
-    # Current batter right of diamond
-    batter_name = _format_player_name(
-        game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
-    )
-    if batter_name:
-        _bat_x = rp_x + 38 * s
-        _bat_y = BELOW_ZONE_Y + 2 * s
-        _bat_max_w = rp_x + rp_w - _bat_x - 2 * s
-        _bat_str = batter_name
-        while _bat_str and int(font9.getlength(_bat_str)) > _bat_max_w:
-            _bat_str = _bat_str[:-1]
-        if _bat_str:
-            draw.text((int(_bat_x), int(_bat_y)), _bat_str, font=font9, fill=0)
-
-    # Outs indicator (small circles, right side)
-    _outs = game_data.get('num_of_outs') or 0
-    _out_cx = rp_x + rp_w - 8 * s
-    for _oi in range(3):
-        _oy = int(BELOW_ZONE_Y + (2 + _oi * 8) * s)
-        _filled = _oi < _outs
-        _or = max(3 * s, 3)
-        draw.ellipse([_out_cx - _or, _oy - _or, _out_cx + _or, _oy + _or],
-                     fill=(0 if _filled else 255), outline=0)
-
-    # --- Last 3 half-inning event descriptions ---
-    half_inning_plays = game_data.get('half_inning_plays') or []
-
-    EVENT_Y    = BELOW_ZONE_Y + 24 * s
-    EVENT_LINE = 13 * s
-    MAX_W      = rp_w - 4 * s
-
-    for i, desc in enumerate(half_inning_plays[-3:]):
-        ey = EVENT_Y + i * EVENT_LINE
-        if ey + EVENT_LINE > rp_y + rp_h + 2 * s:
+    # Pitch type list below zone: "1-FB  2-SL  3-CB"
+    _pt_y = zone_by + 2 * s
+    _pt_x = zone_lx
+    _pt_max_x = zone_rx
+    for _pn, _pp in enumerate(ab_pitches, start=1):
+        _abbr = _pp.get('pt_abbr') or _WIDE_PITCH_TYPE.get(_pp.get('code', ''), _pp.get('code', ''))
+        if not _abbr:
+            continue
+        _label = f'{_pn}-{_abbr}'
+        _lw = int(font7.getlength(_label)) + 2 * s
+        if _pt_x + _lw > _pt_max_x:
             break
-        text = str(desc)
-        while text and int(font9.getlength(text)) > MAX_W:
-            text = text[:-1]
-        if text:
-            draw.text((rp_x + 2 * s, int(ey)), text, font=font9, fill=0)
+        draw.text((int(_pt_x), int(_pt_y)), _label, font=font7, fill=0)
+        _pt_x += _lw + 1 * s
+
+    # ── Bases: same coordinates/size as single-cell mode ──────────────
+    # Single cell: 3B at (x+97, y+52), 2B at (x+109, y+40), 1B at (x+121, y+52), size=10
+    # Shift to top-left of right panel by mapping x+97→rp_x+18, keeping y unchanged.
+    _outs_count = game_data.get('num_of_outs') or 0
+    if not _between_innings and _outs_count < 3:
+        _hi_third  = isinstance(game_data.get('runner_on_third'), str)
+        _hi_second = isinstance(game_data.get('runner_on_second'), str)
+        _hi_first  = isinstance(game_data.get('runner_on_first'), str)
+        _b3x, _b3y = rp_x + 18 * s, rp_y + 52 * s
+        _b2x, _b2y = rp_x + 30 * s, rp_y + 40 * s
+        _b1x, _b1y = rp_x + 42 * s, rp_y + 52 * s
+        Himage = draw_diamond(Himage, (_b3x, _b3y), 10 * s, _hi_third)
+        Himage = draw_diamond(Himage, (_b2x, _b2y), 10 * s, _hi_second)
+        Himage = draw_diamond(Himage, (_b1x, _b1y), 10 * s, _hi_first)
+        draw = ImageDraw.Draw(Himage)
+        for _bfill, _bcx, _bcy, _bkey in (
+            (_hi_third,  _b3x, _b3y, 'runner_third_number'),
+            (_hi_second, _b2x, _b2y, 'runner_second_number'),
+            (_hi_first,  _b1x, _b1y, 'runner_first_number'),
+        ):
+            if _bfill:
+                _raw = game_data.get(_bkey)
+                _bnum = str(_raw) if _raw is not None else ''
+                _bnw = int(font9.getlength(_bnum)) if _bnum else 0
+                draw.text((_bcx - _bnw // 2, _bcy - 5 * s), _bnum, font=font9, fill=255)
+
+    # ── Outs circles (same style as single cell: radius 6, outline 2) ─
+    outs_list = [i + 1 <= _outs_count for i in range(3)]
+    Himage = draw_circle(Himage, (rp_x + 18 * s, rp_y + 73 * s), 6 * s, outs_list[0], outline_width=2)
+    Himage = draw_circle(Himage, (rp_x + 32 * s, rp_y + 73 * s), 6 * s, outs_list[1], outline_width=2)
+    Himage = draw_circle(Himage, (rp_x + 46 * s, rp_y + 73 * s), 6 * s, outs_list[2], outline_width=2)
+    draw = ImageDraw.Draw(Himage)
+
+    # ── Balls / Strikes indicators (same style as single cell) ─────────
+    if not _between_innings:
+        balls_list = [i + 1 <= balls for i in range(3)]
+        _num_strikes = game_data.get('strikes') or 0
+        strikes_list = [i + 1 <= _num_strikes for i in range(2)]
+        _strike_calls = game_data.get('strike_calls') or []
+
+        draw.text((rp_x + 2 * s, rp_y + 82 * s), 'B', font=font14, fill=0)
+        Himage = draw_circle(Himage, (rp_x + 19 * s, rp_y + 91 * s), 4 * s, balls_list[0])
+        Himage = draw_circle(Himage, (rp_x + 31 * s, rp_y + 91 * s), 4 * s, balls_list[1])
+        Himage = draw_circle(Himage, (rp_x + 43 * s, rp_y + 91 * s), 4 * s, balls_list[2])
+        draw = ImageDraw.Draw(Himage)
+
+        draw.text((rp_x + 54 * s, rp_y + 82 * s), 'S', font=font14, fill=0)
+        for _si, (_scx, _scy) in enumerate([
+            (rp_x + 70 * s, rp_y + 91 * s),
+            (rp_x + 82 * s, rp_y + 91 * s),
+        ]):
+            _call = _strike_calls[_si] if _si < len(_strike_calls) else None
+            if strikes_list[_si] and _call in ('S', 'F'):
+                _ir = max(4 * s - 2, 2)
+                Himage = draw_circle(Himage, (_scx, _scy), 4 * s, False)
+                draw = ImageDraw.Draw(Himage)
+                draw.ellipse([_scx - _ir, _scy - _ir, _scx + _ir, _scy + _ir], fill='black', outline='black')
+            else:
+                Himage = draw_circle(Himage, (_scx, _scy), 4 * s, strikes_list[_si])
+                draw = ImageDraw.Draw(Himage)
+
+    # ── Pitcher row ────────────────────────────────────────────────────
+    _py = rp_y + 97 * s
+    _max_w = rp_w - 4 * s
+    _pc = game_data.get('pitch_count')
+    _pt_last = game_data.get('last_pitch_type', '')
+    _lps = game_data.get('last_pitch_speed')
+    _pitcher_name = _format_player_name(game_data.get('current_pitcher') or '')
+
+    _right_badge = _pt_last if _pt_last else ''
+    _rb_w = int(font11.getlength(_right_badge)) + 2 * s if _right_badge else 0
+    _pit_avail = _max_w - _rb_w
+    _pit_str = f'P: {_pitcher_name}'
+    _pf = font14
+    if int(_pf.getlength(_pit_str)) > _pit_avail:
+        _pf = font11
+        if int(_pf.getlength(_pit_str)) > _pit_avail:
+            _pf = font9
+            while _pit_str and int(_pf.getlength(_pit_str)) > _pit_avail:
+                _pit_str = _pit_str[:-1]
+    draw.text((rp_x + 2 * s, _py), _pit_str, font=_pf, fill=0)
+    if _right_badge:
+        draw.text((rp_x + rp_w - _rb_w, _py), _right_badge, font=font11, fill=0)
+
+    # Pitch count + speed on same row right-side (below badge if no badge)
+    if _lps or _pc is not None:
+        _spd_str = str(int(_lps)) if _lps else ''
+        _pc_str  = f'{_pc}P' if _pc is not None else ''
+        _row2 = _py + 11 * s
+        _spd_w = int(font11.getlength(_spd_str)) + 2 * s if _spd_str else 0
+        _pc_w  = int(font11.getlength(_pc_str))  + 2 * s if _pc_str  else 0
+        if _spd_str:
+            draw.text((rp_x + rp_w - _spd_w, _row2), _spd_str, font=font11, fill=0)
+            draw.text((rp_x + rp_w - _spd_w + 1, _row2), _spd_str, font=font11, fill=0)
+        if _pc_str:
+            draw.text((rp_x + rp_w - _spd_w - _pc_w, _row2), _pc_str, font=font11, fill=0)
+
+    # ── Batter row ─────────────────────────────────────────────────────
+    _by = rp_y + 109 * s
+    _bh = game_data.get('batter_hits')
+    _ba = game_data.get('batter_at_bats')
+    _ba_str = f'{_bh}-{_ba}' if _bh is not None and _ba is not None else ''
+    _ba_w = int(font11.getlength(_ba_str)) + 2 * s if _ba_str else 0
+    _hit_avail = _max_w - _ba_w
+    _ab_done = game_data.get('current_at_bat_complete', False)
+    if _ab_done and not _is_game_effectively_over(game_data):
+        _next = _format_player_name(game_data.get('due_up') or game_data.get('next_batter_1') or '')
+        _batter_label = f'AB: {_next}' if _next else ''
+    else:
+        _hitter = _format_player_name(
+            game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
+        )
+        _batter_label = f'AB: {_hitter}'
+    if _batter_label:
+        _bf = font14
+        if int(_bf.getlength(_batter_label)) > _hit_avail:
+            _bf = font11
+            if int(_bf.getlength(_batter_label)) > _hit_avail:
+                _bf = font9
+                while _batter_label and int(_bf.getlength(_batter_label)) > _hit_avail:
+                    _batter_label = _batter_label[:-1]
+        draw.text((rp_x + 2 * s, _by), _batter_label, font=_bf, fill=0)
+    if _ba_str:
+        draw.text((rp_x + rp_w - _ba_w, _by), _ba_str, font=font11, fill=0)
+
+    # ── Last half-inning events (full play description, truncated to fit) ─
+    half_inning_plays = game_data.get('half_inning_plays') or []
+    _ev_y = rp_y + 119 * s
+    _ev_line = 11 * s
+    for _i, _desc in enumerate(half_inning_plays[-3:]):
+        _ey = _ev_y + _i * _ev_line
+        if _ey + _ev_line > rp_y + rp_h:
+            break
+        _txt = str(_desc)
+        while _txt and int(font9.getlength(_txt)) > _max_w:
+            _txt = _txt[:-1]
+        if _txt:
+            draw.text((rp_x + 2 * s, int(_ey)), _txt, font=font9, fill=0)
 
 
 def draw_wide_box(Himage, start_x, start_y, game_data, team_data,
@@ -2319,14 +2421,13 @@ def draw_wide_box(Himage, start_x, start_y, game_data, team_data,
         always_show_hits=True,
     )
 
-    # Extend top, header-separator, and bottom borders across the right panel
+    # Extend top, header-separator, and bottom borders across the right panel (no center divider)
     draw = ImageDraw.Draw(Himage)
     rp_x = start_x + CELL_W
     rp_right = start_x + TOTAL_W
-    draw.line((rp_x, start_y,                  rp_right, start_y),                  fill=0)  # top
-    draw.line((rp_x, start_y + HEADER_H,       rp_right, start_y + HEADER_H),       fill=0)  # header sep
-    draw.line((rp_x, start_y + TOTAL_H,        rp_right, start_y + TOTAL_H),        fill=0)  # bottom
-    draw.line((rp_x, start_y,                  rp_x,     start_y + TOTAL_H),        fill=0)  # divider
+    draw.line((rp_x, start_y,            rp_right, start_y),            fill=0)  # top
+    draw.line((rp_x, start_y + HEADER_H, rp_right, start_y + HEADER_H), fill=0)  # header sep
+    draw.line((rp_x, start_y + TOTAL_H,  rp_right, start_y + TOTAL_H),  fill=0)  # bottom
 
     # Right panel content
     _draw_wide_right_panel(

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -643,7 +643,7 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         _draw_half(home_game, home_start, strip_right)
 
 
-def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1):
+def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1, force_linescore=False, always_show_hits=False):
     s = scale
     # Normalize early-completion states (e.g. spring training games called after 6 innings)
     if game_data.get('detailed_state', '').startswith('Completed Early'):
@@ -967,9 +967,9 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _pit_w = int(_pit_fnt.getlength(_pit_name))
             draw.text((_right_x - _pit_w, _sep_y + 2 * s), _pit_name, font=_pit_fnt, fill=0)
     elif game_data['detailed_state'] == 'In Progress':
-        if _between_innings or _pitching_change:
+        if _between_innings or _pitching_change or force_linescore:
             draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos, scale=scale)
-        else:
+        if not _between_innings and not _pitching_change and not force_linescore:
             # Active play: pitch/pitcher/batter info
             _pc = game_data.get('pitch_count')
             _pt = game_data.get('last_pitch_type', '')   # e.g. "FB", "SL", "CH"
@@ -1534,13 +1534,14 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         draw.text((start_x + 68 * s + check_if_two_chars(away_runs), start_y + 25 * s), away_runs, font=font24, fill=0)
         draw.text((start_x + 68 * s + check_if_two_chars(home_runs), start_y + 55 * s), home_runs, font=font24, fill=0)
 
-        if is_game_finished:
+        if is_game_finished or always_show_hits:
             # hits
             away_hits = str(game_data.get('away_hits', 0) if game_data.get('away_hits', 0) is not None else 0)
             home_hits = str(game_data.get('home_hits', 0) if game_data.get('home_hits', 0) is not None else 0)
             draw.text((start_x + 95 * s + check_if_two_chars(away_hits), start_y + 25 * s),  away_hits, font=font24, fill=0)
             draw.text((start_x + 95 * s + check_if_two_chars(home_hits), start_y + 55 * s), home_hits , font=font24, fill=0)
 
+        if is_game_finished or always_show_hits:
             # errors
             draw.text((start_x + 123 * s, start_y + 25 * s),  str(game_data.get('away_errors', 0) if game_data.get('away_errors', 0) is not None else 0), font=font24, fill=0)
             draw.text((start_x + 123 * s, start_y + 55 * s),  str( game_data.get('home_errors', 0) if game_data.get('home_errors', 0) is not None else 0), font=font24, fill=0)
@@ -1845,8 +1846,9 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     # draw.line((vert_start_x, vert_start_y, end_x, end_y), fill = 0)
 
 
-    # Show bases/outs/count only once the game is actually in progress (first pitch thrown)
-    if game_data['detailed_state'] == 'In Progress':
+    # Show bases/outs/count only once the game is actually in progress (first pitch thrown).
+    # force_linescore (wide-cell mode) suppresses this block — the right panel handles live context.
+    if game_data['detailed_state'] == 'In Progress' and not force_linescore:
         if _between_innings and _game_ending_state:
             pass  # end of 9th+ with a lead — linescore shown, no next-batters panel
         elif _between_innings:
@@ -2099,5 +2101,243 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
        (is_game_finished or _active_no_no):
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
+
+    return Himage
+
+
+# ---------------------------------------------------------------------------
+# Wide (2-cell) featured game box
+# ---------------------------------------------------------------------------
+
+_WIDE_PITCH_TYPE = {
+    'FF': 'FB', 'FA': 'FB', 'FT': '2F', 'SI': 'SI',
+    'FC': 'CT', 'SL': 'SL', 'ST': 'SW', 'SW': 'SW',
+    'CH': 'CH', 'CU': 'CB', 'CS': 'CB', 'KC': 'KC',
+    'FS': 'SP', 'KN': 'KN', 'EP': 'EP',
+}
+
+# Strike zone coordinate bounds (MLB standard)
+_SZ_HALF_W = 0.708  # ±0.708 ft = 17-inch plate
+_SZ_PZ_LO  = 1.5
+_SZ_PZ_HI  = 3.5
+
+
+def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_data, team_data, use_logos=False, scale=1):
+    """Strike zone with current AB pitches + bases/batter + last 3 half-inning events."""
+    s = scale
+    font9  = _get_font(9 * s)
+    font7  = _get_font(max(7 * s, 7))
+
+    state = game_data.get('detailed_state', '')
+    if state != 'In Progress':
+        return
+
+    # Layout within right panel (150 × 130 px):
+    #   [header_h]  header strip (drawn by caller)
+    #   + 3 px pad
+    #   zone block  (taller than wide — more vertical)
+    #   bases + batter line (below zone, left side)
+    #   3 events (stacked)
+
+    ZONE_W = 52 * s   # narrow width → taller ratio
+    ZONE_H = 68 * s   # taller than wide
+    zone_cx = rp_x + (rp_w - ZONE_W) // 2   # center zone in right panel
+    zone_lx = zone_cx
+    zone_rx = zone_cx + ZONE_W
+    zone_ty = rp_y + header_h + 10 * s
+    zone_by = zone_ty + ZONE_H
+
+    # Outer border (solid black) — draw first so interior fill goes over it
+    draw.rectangle([zone_lx, zone_ty, zone_rx, zone_by], outline=0)
+
+    # Interior fill with a dithered (50% gray) pattern to appear lighter than border
+    _zone_inner = Image.new('1', (int(ZONE_W) - 2, int(ZONE_H) - 2), 255)
+    _zpx = _zone_inner.load()
+    for _iy in range(_zone_inner.height):
+        for _ix in range(_zone_inner.width):
+            # Checker-board pattern at 2×2 resolution gives ~25% black = light gray
+            if (_ix // 2 + _iy // 2) % 2 == 0:
+                _zpx[_ix, _iy] = 0  # black dot
+    Himage.paste(_zone_inner, (int(zone_lx) + 1, int(zone_ty) + 1))
+    draw = ImageDraw.Draw(Himage)
+
+    # 9-zone grid lines (on top of filled interior)
+    tw = ZONE_W // 3
+    th = ZONE_H // 3
+    draw.line([zone_lx + tw,     zone_ty, zone_lx + tw,     zone_by], fill=0)
+    draw.line([zone_lx + 2 * tw, zone_ty, zone_lx + 2 * tw, zone_by], fill=0)
+    draw.line([zone_lx, zone_ty + th,     zone_rx, zone_ty + th    ], fill=0)
+    draw.line([zone_lx, zone_ty + 2 * th, zone_rx, zone_ty + 2 * th], fill=0)
+
+    # Count label above zone (left edge)
+    balls   = game_data.get('balls', 0) or 0
+    strikes = game_data.get('strikes', 0) or 0
+    count_str = f'{balls}-{strikes}'
+    draw.text((zone_lx, zone_ty - 9 * s), count_str, font=font9, fill=0)
+
+    # Pitch type legend: right of count, show types seen this AB (compact)
+    ab_pitches = game_data.get('ab_pitches') or []
+    _types_seen = []
+    for _p in ab_pitches:
+        _a = _p.get('pt_abbr') or _WIDE_PITCH_TYPE.get(_p.get('code', ''), '')
+        if _a and _a not in _types_seen:
+            _types_seen.append(_a)
+    if _types_seen:
+        _legend = ' '.join(_types_seen[:4])
+        _leg_w = int(font7.getlength(_legend))
+        draw.text((zone_rx - _leg_w, zone_ty - 9 * s), _legend, font=font7, fill=0)
+
+    def _to_pixel(px_c, pz_c):
+        tx = zone_lx + (px_c + _SZ_HALF_W) / (2 * _SZ_HALF_W) * ZONE_W
+        ty = zone_by  - (pz_c - _SZ_PZ_LO)  / (_SZ_PZ_HI - _SZ_PZ_LO)  * ZONE_H
+        # Clamp inside zone (pitch markers at the edge are still visible)
+        tx = max(rp_x + 1 * s, min(rp_x + rp_w - 1 * s, tx))
+        ty = max(rp_y + header_h + 1 * s, min(rp_y + rp_h - 1 * s, ty))
+        return int(tx), int(ty)
+
+    # Plot pitches: filled circle = strike (with seq# inside), open = ball (with seq# inside)
+    PITCH_R = max(5 * s, 5)
+    for pitch_num, pitch in enumerate(ab_pitches, start=1):
+        px_c, pz_c = pitch.get('px'), pitch.get('pz')
+        if px_c is None or pz_c is None:
+            continue
+        bx, by = _to_pixel(px_c, pz_c)
+        code = pitch.get('code', '')
+        is_strike = code in ('S', 'C', 'T', 'W', 'O', 'M', 'Q', 'K')
+        box = [bx - PITCH_R, by - PITCH_R, bx + PITCH_R, by + PITCH_R]
+        if is_strike:
+            draw.ellipse(box, fill=0, outline=0)
+            # Number inside (white text on black circle)
+            seq_str = str(pitch_num)
+            sw = int(font7.getlength(seq_str))
+            sh = 7 * s
+            draw.text((bx - sw // 2, by - sh // 2), seq_str, font=font7, fill=255)
+        else:
+            draw.ellipse(box, fill=255, outline=0)
+            # Number inside (black text on white circle)
+            seq_str = str(pitch_num)
+            sw = int(font7.getlength(seq_str))
+            sh = 7 * s
+            draw.text((bx - sw // 2, by - sh // 2), seq_str, font=font7, fill=0)
+
+    # --- Bases diamond + current batter (below zone) ---
+    BELOW_ZONE_Y = zone_by + 4 * s
+    BASES_SIZE   = 8 * s   # half-diagonal of each base diamond
+    DIAMOND_CX   = rp_x + 18 * s   # center of diamond cluster, left-ish
+    DIAMOND_CY   = BELOW_ZONE_Y + 10 * s
+
+    runner_first  = bool(game_data.get('runner_on_first'))
+    runner_second = bool(game_data.get('runner_on_second'))
+    runner_third  = bool(game_data.get('runner_on_third'))
+
+    def _base_diamond(cx, cy, filled):
+        pts = [(cx, cy - BASES_SIZE), (cx + BASES_SIZE, cy),
+               (cx, cy + BASES_SIZE), (cx - BASES_SIZE, cy)]
+        if filled:
+            draw.polygon(pts, fill=0, outline=0)
+        else:
+            draw.polygon(pts, fill=255, outline=0)
+
+    _base_diamond(DIAMOND_CX,              DIAMOND_CY - BASES_SIZE - 2 * s, runner_second)  # 2B (top)
+    _base_diamond(DIAMOND_CX + BASES_SIZE + 2 * s, DIAMOND_CY,              runner_first)   # 1B (right)
+    _base_diamond(DIAMOND_CX - BASES_SIZE - 2 * s, DIAMOND_CY,              runner_third)   # 3B (left)
+    # Home plate indicator (tiny square, never filled by runner)
+    _hp = BASES_SIZE // 2
+    draw.rectangle([DIAMOND_CX - _hp, DIAMOND_CY + BASES_SIZE + 1 * s,
+                    DIAMOND_CX + _hp, DIAMOND_CY + BASES_SIZE + 1 * s + _hp], outline=0)
+
+    # Current batter right of diamond
+    batter_name = _format_player_name(
+        game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
+    )
+    if batter_name:
+        _bat_x = rp_x + 38 * s
+        _bat_y = BELOW_ZONE_Y + 2 * s
+        _bat_max_w = rp_x + rp_w - _bat_x - 2 * s
+        _bat_str = batter_name
+        while _bat_str and int(font9.getlength(_bat_str)) > _bat_max_w:
+            _bat_str = _bat_str[:-1]
+        if _bat_str:
+            draw.text((int(_bat_x), int(_bat_y)), _bat_str, font=font9, fill=0)
+
+    # Outs indicator (small circles, right side)
+    _outs = game_data.get('num_of_outs') or 0
+    _out_cx = rp_x + rp_w - 8 * s
+    for _oi in range(3):
+        _oy = int(BELOW_ZONE_Y + (2 + _oi * 8) * s)
+        _filled = _oi < _outs
+        _or = max(3 * s, 3)
+        draw.ellipse([_out_cx - _or, _oy - _or, _out_cx + _or, _oy + _or],
+                     fill=(0 if _filled else 255), outline=0)
+
+    # --- Last 3 half-inning event descriptions ---
+    half_inning_plays = game_data.get('half_inning_plays') or []
+
+    EVENT_Y    = BELOW_ZONE_Y + 24 * s
+    EVENT_LINE = 13 * s
+    MAX_W      = rp_w - 4 * s
+
+    for i, desc in enumerate(half_inning_plays[-3:]):
+        ey = EVENT_Y + i * EVENT_LINE
+        if ey + EVENT_LINE > rp_y + rp_h + 2 * s:
+            break
+        text = str(desc)
+        while text and int(font9.getlength(text)) > MAX_W:
+            text = text[:-1]
+        if text:
+            draw.text((rp_x + 2 * s, int(ey)), text, font=font9, fill=0)
+
+
+def draw_wide_box(Himage, start_x, start_y, game_data, team_data,
+                  score_changed=False, use_logos=False, logo_x_offset=2,
+                  streak_map=None, scale=1):
+    """Featured 2-cell (285×130 px) game tile.
+
+    Left panel (135 px): standard draw_box content with linescore always
+    visible and hits shown even in-progress.
+    Right panel (150 px): strike zone with current AB pitch locations +
+    last 3 half-inning play descriptions in full wording.
+    """
+    s = scale
+    CELL_W  = 135 * s   # left panel — same as normal cell width
+    RIGHT_W = 150 * s   # right panel
+    TOTAL_W = CELL_W + RIGHT_W  # 285 px
+    HEADER_H = 20 * s
+    TOTAL_H  = 130 * s
+
+    # Left panel via draw_box: force linescore + always show hits; no win-prob bar
+    Himage = draw_box(
+        Himage, start_x, start_y, game_data, team_data,
+        score_changed=score_changed,
+        use_logos=use_logos,
+        logo_x_offset=logo_x_offset,
+        show_win_prob=False,
+        streak_map=streak_map,
+        show_winner_logo=True,
+        scale=scale,
+        force_linescore=True,
+        always_show_hits=True,
+    )
+
+    # Extend top, header-separator, and bottom borders across the right panel
+    draw = ImageDraw.Draw(Himage)
+    rp_x = start_x + CELL_W
+    rp_right = start_x + TOTAL_W
+    draw.line((rp_x, start_y,                  rp_right, start_y),                  fill=0)  # top
+    draw.line((rp_x, start_y + HEADER_H,       rp_right, start_y + HEADER_H),       fill=0)  # header sep
+    draw.line((rp_x, start_y + TOTAL_H,        rp_right, start_y + TOTAL_H),        fill=0)  # bottom
+    draw.line((rp_x, start_y,                  rp_x,     start_y + TOTAL_H),        fill=0)  # divider
+
+    # Right panel content
+    _draw_wide_right_panel(
+        draw, Himage,
+        rp_x=rp_x, rp_y=start_y,
+        rp_w=RIGHT_W, rp_h=TOTAL_H,
+        header_h=HEADER_H,
+        game_data=game_data,
+        team_data=team_data,
+        use_logos=use_logos,
+        scale=scale,
+    )
 
     return Himage

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -643,7 +643,7 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         _draw_half(home_game, home_start, strip_right)
 
 
-def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1, force_linescore=False, always_show_hits=False):
+def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False, use_logos=False, logo_x_offset=2, show_win_prob=False, streak_map=None, show_winner_logo=True, scale=1, force_linescore=False, always_show_hits=False, hide_last_play=False, skip_header_invert=False):
     s = scale
     # Normalize early-completion states (e.g. spring training games called after 6 innings)
     if game_data.get('detailed_state', '').startswith('Completed Early'):
@@ -967,9 +967,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
             _pit_w = int(_pit_fnt.getlength(_pit_name))
             draw.text((_right_x - _pit_w, _sep_y + 2 * s), _pit_name, font=_pit_fnt, fill=0)
     elif game_data['detailed_state'] == 'In Progress':
-        if _between_innings or _pitching_change or force_linescore:
+        # A mid-inning pitching change keeps the active (bases/diamond) display —
+        # only between-inning/start-of-inning PCs swap in the linescore grid.
+        _pc_grid = _pitching_change and not _mid_inning_pc
+        _show_grid = _between_innings or _pc_grid or force_linescore
+        if _show_grid:
             draw, Himage = _draw_linescore_grid(draw, Himage, start_x, start_y, game_data, team_data, use_logos, scale=scale)
-        if not _between_innings and not _pitching_change and not force_linescore:
+        if not _show_grid:
             # Active play: pitch/pitcher/batter info
             _pc = game_data.get('pitch_count')
             _pt = game_data.get('last_pitch_type', '')   # e.g. "FB", "SL", "CH"
@@ -1461,7 +1465,10 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                                 _draw_backwards_k(Himage, _cx, _py, _fnt)
                                 _cx += int(_fnt.getlength('K'))
 
-        if _active_no_no:
+        if hide_last_play:
+            # Wide cell: events live in the spanning header, not the left cell.
+            pass
+        elif _active_no_no:
             # Right-align label; inning state stays on left as-is
             _nh_label = 'Perfect Game' if game_data.get('perfect_game') else 'No-Hitter'
             _nh_lw = int(font14.getlength(_nh_label))
@@ -2049,31 +2056,6 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         if game_data.get('home_team_is_winner'):
             draw.text((start_x + 7 * s, start_y + 55 * s), home_team_name, font=font24, fill=0)
 
-    # Batting team indicator: ▲ left of away logo row when top half (away batting),
-    # ▼ left of home logo row when bottom half (home batting). Live games only.
-    # Suppress when 3 outs are recorded (API lag before inningState flips to Middle/End).
-    _bi_state = game_data.get('inningState') or ''
-    if (game_data['detailed_state'] == 'In Progress' and _bi_state in ('Top', 'Bottom')
-            and (game_data.get('num_of_outs') or 0) < 3):
-        _r = 4 * s
-        _bi_cx = start_x + _r - 8
-        if _bi_state == 'Top':
-            _bi_cy = start_y + 25 * s + 14 * s  # vertical center of away logo row
-            # ▲ up-pointing triangle
-            draw.polygon([
-                (_bi_cx,          _bi_cy - _r),
-                (_bi_cx - _r,     _bi_cy + _r),
-                (_bi_cx + _r,     _bi_cy + _r),
-            ], fill=0)
-        else:
-            _bi_cy = start_y + 55 * s + 14 * s  # vertical center of home logo row
-            # ▼ down-pointing triangle
-            draw.polygon([
-                (_bi_cx - _r,     _bi_cy - _r),
-                (_bi_cx + _r,     _bi_cy - _r),
-                (_bi_cx,          _bi_cy + _r),
-            ], fill=0)
-
     # Bold-offset score for winner (both modes)
     if game_data.get('away_team_is_winner'):
         draw.text((start_x + 69 * s + check_if_two_chars(away_runs), start_y + 25 * s), away_runs, font=font24, fill=0)
@@ -2082,7 +2064,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
 
     # Invert header to indicate a score change or run-scoring play during an active game
     _run_scored = game_data['detailed_state'] == 'In Progress' and not is_game_finished and int(game_data.get('last_play_rbi') or 0) > 0
-    if (score_changed or _run_scored) and is_game_started and not is_game_finished and not _between_innings and not _pitching_change:
+    if (score_changed or _run_scored) and is_game_started and not is_game_finished and not _between_innings and not _pitching_change and not skip_header_invert:
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
@@ -2092,13 +2074,13 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
         game_data['detailed_state'] == 'In Progress' and not is_game_finished and not _between_innings and not _pitching_change and
         ('stolen base' in _lp_lower or _lp_lower == 'sb')
     )
-    if _sb_event:
+    if _sb_event and not skip_header_invert:
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
     # Invert header for special states: no-hitter (>= 6 innings), perfect game
     if (game_data.get('no_hitter') or game_data.get('perfect_game')) and \
-       (is_game_finished or _active_no_no):
+       (is_game_finished or _active_no_no) and not skip_header_invert:
         header_box = Himage.crop((start_x, start_y, start_x + horizonta_len + 1 * s, start_y + 21 * s))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
 
@@ -2135,14 +2117,16 @@ def _draw_backward_k(Himage, x, y, font):
 def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_data, team_data, use_logos=False, scale=1):
     """Right panel of 2-cell wide tile.
 
-    Header strip (20 px): K strikeouts for each pitcher.
-    Content (110 px):
-      Left column  (x+0 .. x+88):  bases (top), outs, B/S indicators
-      Right column (x+88 .. x+148): strike zone (no fill) + pitch list below
-      Full-width rows: P: pitcher | AB: batter | events
+    Header strip (20 px): last half-inning event (cycling 8-sec) + count right-aligned.
+    Active at-bat content:
+      Left strip  (x+0 .. x+~32):  pitch list vertically from top (1-FB, 2-SL …)
+      Middle      (x+42 .. x+88):  bases (shifted right) + outs
+      Right       (x+90 .. x+148): strike zone (location-based fill)
+      Lower rows: P: pitcher | AB: batter (same font) | B/S indicators
+    Between-innings content: next 3 batters (outs hidden).
+    Bottom strip (below rp_h): K strikeouts for each pitcher.
     """
     s = scale
-    font14 = _get_font(14 * s)
     font11 = _get_font(11 * s)
     font9  = _get_font(9 * s)
     font7  = _get_font(max(7 * s, 7))
@@ -2150,156 +2134,213 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
     state = game_data.get('detailed_state', '')
     _between_innings = game_data.get('inningState') in ('Middle', 'End')
 
-    # ── Header: K strikeouts for each pitcher ──────────────────────────
-    # Left half = away pitcher's Ks (home batters struck out).
-    # Right half = home pitcher's Ks (away batters struck out).
-    away_ks = game_data.get('away_pitcher_ks') or []
-    home_ks = game_data.get('home_pitcher_ks') or []
-    _k_y = rp_y + 4 * s
-    _k_x = rp_x + 2 * s
-    _k_mid = rp_x + rp_w // 2
-    _k_bbox = font9.getbbox('K')
-    _k_w = _k_bbox[2] - _k_bbox[0] + 2
+    # ── Header: last 5 game events + count ─────────────────────────────
+    # Events render in the same size as the single-cell last-play text (font12),
+    # bold, on the inning's baseline, spanning the full two-cell width (the left
+    # cell no longer draws its own event).
+    font14 = _get_font(14 * s)   # inning label size, used to reserve its width
+    font12 = _get_font(12 * s)   # event text size (matches 1-cell last-play)
+    balls   = min(game_data.get('balls', 0) or 0, 3)
+    strikes = min(game_data.get('strikes', 0) or 0, 2)
 
-    for _k in away_ks:
-        if _k_x + _k_w > _k_mid - 2:
-            break
-        if _k == 'L':
-            _draw_backward_k(Himage, int(_k_x), int(_k_y), font9)
-            draw = ImageDraw.Draw(Himage)
-        else:
-            draw.text((int(_k_x), int(_k_y)), 'K', font=font9, fill=0)
-        _k_x += _k_w
+    # The ball-strike count lives in the panel body (B/S rows); no count in the header.
+    _cnt_w = 0
 
-    _k_x = _k_mid + 2 * s
-    for _k in home_ks:
-        if _k_x + _k_w > rp_x + rp_w - 2:
+    # Reserve space for the inning label drawn in the left cell ("Top 7", "Bot 12"…).
+    _tile_left = rp_x - 135 * s
+    _inn_state = game_data.get('inningState') or ''
+    _inn_label = {'Top': 'Top', 'Bottom': 'Bot', 'Middle': 'Mid', 'End': 'End'}.get(
+        _inn_state, (_inn_state[:3] or ''))
+    _inn_text = f"{_inn_label} {game_data.get('current_inning') or 1}".strip()
+    _inn_w = int(font14.getlength(_inn_text)) + 2 * s   # +2 for the inning's bold strike
+
+    half_inning_plays = game_data.get('half_inning_plays') or []
+    _recent_plays = list(half_inning_plays[-7:])
+    # Right-anchor against the count; left bound clears the inning label.
+    _hdr_left = _tile_left + 2 * s + _inn_w + 6 * s
+    _hdr_right = rp_x + rp_w - _cnt_w - (7 * s if _cnt_w else 3 * s)
+    _hdr_max_w = _hdr_right - _hdr_left - 1 * s   # -1 for the bold double-strike
+
+    def _events_to_str(plays):
+        """Join play tokens into display string; '+' tokens become ' + ' inning-break separator."""
+        parts = []
+        next_sep = ''
+        for ev in plays:
+            if ev == '+':
+                next_sep = ' + '
+            else:
+                parts.append(next_sep + str(ev) if next_sep else str(ev))
+                next_sep = ' | '
+        return ''.join(parts)
+
+    def _measure_events(text):
+        return int(font12.getlength(text.replace('Kl', 'K')))
+
+    def _draw_events(x, y, text):
+        """Render event string with backwards-K support (bold via 1px double-strike)."""
+        if 'Kl' not in text:
+            draw.text((x,         y), text, font=font12, fill=0)
+            draw.text((x + 1 * s, y), text, font=font12, fill=0)
+            return
+        _parts = text.split('Kl')
+        for _bx in (x, x + 1 * s):
+            _cx = _bx
+            for _i, _seg in enumerate(_parts):
+                if _seg:
+                    draw.text((_cx, y), _seg, font=font12, fill=0)
+                    _cx += int(font12.getlength(_seg))
+                if _i < len(_parts) - 1:
+                    _draw_backwards_k(Himage, _cx, y, font12)
+                    _cx += int(font12.getlength('K'))
+
+    # Show up to the last 7 events; drop oldest (leftmost) until it fits so the
+    # most recent events always stay visible.
+    _hdr_event = ''
+    while _recent_plays:
+        _hdr_event = _events_to_str(_recent_plays)
+        if _measure_events(_hdr_event) <= _hdr_max_w:
             break
-        if _k == 'L':
-            _draw_backward_k(Himage, int(_k_x), int(_k_y), font9)
-            draw = ImageDraw.Draw(Himage)
-        else:
-            draw.text((int(_k_x), int(_k_y)), 'K', font=font9, fill=0)
-        _k_x += _k_w
+        _recent_plays.pop(0)
+        # Don't leave a lone '+' boundary marker at the front
+        if _recent_plays and _recent_plays[0] == '+':
+            _recent_plays.pop(0)
+    if _recent_plays and _hdr_event:
+        _tx = max(_hdr_left, _hdr_right - _measure_events(_hdr_event))
+        _draw_events(_tx, rp_y + 4 * s, _hdr_event)
 
     if state != 'In Progress':
         return
 
-    # Count right-aligned in header, above zone
-    balls   = game_data.get('balls', 0) or 0
-    strikes = game_data.get('strikes', 0) or 0
-    count_str = f'{balls}-{strikes}'
-    _cnt_w = int(font9.getlength(count_str))
-    draw.text((rp_x + rp_w - _cnt_w - 2 * s, rp_y + 4 * s), count_str, font=font9, fill=0)
+    ab_pitches = game_data.get('ab_pitches') or []
 
-    # ── Strike zone (RIGHT side, no fill) ─────────────────────────────
+    # ── Strike zone bounds: use per-batter sz from pitch data ──────────
+    _zone_top = _SZ_PZ_HI
+    _zone_bot = _SZ_PZ_LO
+    for _p in ab_pitches:
+        _st = _p.get('sz_top')
+        _sb = _p.get('sz_bot')
+        if _st is not None and _sb is not None:
+            _zone_top = float(_st)
+            _zone_bot = float(_sb)
+            break
+
+    # ── Strike zone (RIGHT side, fixed pixel dimensions) ───────────────
     ZONE_W = 56 * s
     ZONE_H = 58 * s
-    zone_rx = rp_x + rp_w - 2 * s
+    zone_rx = rp_x + rp_w - 17 * s   # nudged left 7px more to leave room for outside pitches
     zone_lx = zone_rx - ZONE_W
-    zone_ty = rp_y + header_h + 2 * s
+    zone_ty = rp_y + header_h + 12 * s   # nudged down
     zone_by = zone_ty + ZONE_H
 
-    draw.rectangle([zone_lx, zone_ty, zone_rx, zone_by], outline=0)
-    tw = ZONE_W // 3
-    th = ZONE_H // 3
-    draw.line([zone_lx + tw,     zone_ty, zone_lx + tw,     zone_by], fill=0)
-    draw.line([zone_lx + 2 * tw, zone_ty, zone_lx + 2 * tw, zone_by], fill=0)
-    draw.line([zone_lx, zone_ty + th,     zone_rx, zone_ty + th    ], fill=0)
-    draw.line([zone_lx, zone_ty + 2 * th, zone_rx, zone_ty + 2 * th], fill=0)
-
-    def _to_pixel(px_c, pz_c):
-        tx = zone_lx + (px_c + _SZ_HALF_W) / (2 * _SZ_HALF_W) * ZONE_W
-        ty = zone_by  - (pz_c - _SZ_PZ_LO)  / (_SZ_PZ_HI - _SZ_PZ_LO)  * ZONE_H
-        tx = max(zone_lx + 1, min(zone_rx - 1, tx))
-        ty = max(zone_ty + 1, min(zone_by - 1, ty))
-        return int(tx), int(ty)
-
-    # Pitch circles: filled + white seq# = strike; open + black seq# = ball
-    ab_pitches = game_data.get('ab_pitches') or []
-    PITCH_R = max(5 * s, 5)
-    for pitch_num, pitch in enumerate(ab_pitches, start=1):
-        px_c, pz_c = pitch.get('px'), pitch.get('pz')
-        if px_c is None or pz_c is None:
-            continue
-        bx, by = _to_pixel(px_c, pz_c)
-        code = pitch.get('code', '')
-        is_strike = code in ('S', 'C', 'T', 'W', 'O', 'M', 'Q', 'K')
-        box = [bx - PITCH_R, by - PITCH_R, bx + PITCH_R, by + PITCH_R]
-        seq_str = str(pitch_num)
-        sw = int(font7.getlength(seq_str))
-        if is_strike:
-            draw.ellipse(box, fill=0, outline=0)
-            draw.text((bx - sw // 2, by - 4 * s), seq_str, font=font7, fill=255)
-        else:
-            draw.ellipse(box, fill=255, outline=0)
-            draw.text((bx - sw // 2, by - 4 * s), seq_str, font=font7, fill=0)
-
-    # Pitch type list below zone: "1-FB  2-SL  3-CB"
-    _pt_y = zone_by + 2 * s
-    _pt_x = zone_lx
-    _pt_max_x = zone_rx
-    for _pn, _pp in enumerate(ab_pitches, start=1):
-        _abbr = _pp.get('pt_abbr') or _WIDE_PITCH_TYPE.get(_pp.get('code', ''), _pp.get('code', ''))
-        if not _abbr:
-            continue
-        _label = f'{_pn}-{_abbr}'
-        _lw = int(font7.getlength(_label)) + 2 * s
-        if _pt_x + _lw > _pt_max_x:
-            break
-        draw.text((int(_pt_x), int(_pt_y)), _label, font=font7, fill=0)
-        _pt_x += _lw + 1 * s
-
-    # ── Bases: same coordinates/size as single-cell mode ──────────────
-    # Single cell: 3B at (x+97, y+52), 2B at (x+109, y+40), 1B at (x+121, y+52), size=10
-    # Shift to top-left of right panel by mapping x+97→rp_x+18, keeping y unchanged.
-    _outs_count = game_data.get('num_of_outs') or 0
-    if not _between_innings and _outs_count < 3:
-        _hi_third  = isinstance(game_data.get('runner_on_third'), str)
-        _hi_second = isinstance(game_data.get('runner_on_second'), str)
-        _hi_first  = isinstance(game_data.get('runner_on_first'), str)
-        _b3x, _b3y = rp_x + 18 * s, rp_y + 52 * s
-        _b2x, _b2y = rp_x + 30 * s, rp_y + 40 * s
-        _b1x, _b1y = rp_x + 42 * s, rp_y + 52 * s
-        Himage = draw_diamond(Himage, (_b3x, _b3y), 10 * s, _hi_third)
-        Himage = draw_diamond(Himage, (_b2x, _b2y), 10 * s, _hi_second)
-        Himage = draw_diamond(Himage, (_b1x, _b1y), 10 * s, _hi_first)
-        draw = ImageDraw.Draw(Himage)
-        for _bfill, _bcx, _bcy, _bkey in (
-            (_hi_third,  _b3x, _b3y, 'runner_third_number'),
-            (_hi_second, _b2x, _b2y, 'runner_second_number'),
-            (_hi_first,  _b1x, _b1y, 'runner_first_number'),
-        ):
-            if _bfill:
-                _raw = game_data.get(_bkey)
-                _bnum = str(_raw) if _raw is not None else ''
-                _bnw = int(font9.getlength(_bnum)) if _bnum else 0
-                draw.text((_bcx - _bnw // 2, _bcy - 5 * s), _bnum, font=font9, fill=255)
-
-    # ── Outs circles (same style as single cell: radius 6, outline 2) ─
-    outs_list = [i + 1 <= _outs_count for i in range(3)]
-    Himage = draw_circle(Himage, (rp_x + 18 * s, rp_y + 73 * s), 6 * s, outs_list[0], outline_width=2)
-    Himage = draw_circle(Himage, (rp_x + 32 * s, rp_y + 73 * s), 6 * s, outs_list[1], outline_width=2)
-    Himage = draw_circle(Himage, (rp_x + 46 * s, rp_y + 73 * s), 6 * s, outs_list[2], outline_width=2)
-    draw = ImageDraw.Draw(Himage)
-
-    # ── Balls / Strikes indicators (same style as single cell) ─────────
     if not _between_innings:
+        draw.rectangle([zone_lx, zone_ty, zone_rx, zone_by], outline=0)
+        tw = ZONE_W // 3
+        th = ZONE_H // 3
+        draw.line([zone_lx + tw,     zone_ty, zone_lx + tw,     zone_by], fill=0)
+        draw.line([zone_lx + 2 * tw, zone_ty, zone_lx + 2 * tw, zone_by], fill=0)
+        draw.line([zone_lx, zone_ty + th,     zone_rx, zone_ty + th    ], fill=0)
+        draw.line([zone_lx, zone_ty + 2 * th, zone_rx, zone_ty + 2 * th], fill=0)
+
+        # Called balls (incl. intentional 'I', pitchout 'P', automatic ball 'V')
+        # are highlighted/filled; everything else (strikes, fouls, in-play) is outlined.
+        _BALL_CODES = frozenset({'B', 'I', 'P', 'V'})
+
+        def _to_pixel(px_c, pz_c):
+            tx = zone_lx + (px_c + _SZ_HALF_W) / (2 * _SZ_HALF_W) * ZONE_W
+            ty = zone_by  - (pz_c - _zone_bot)  / (_zone_top - _zone_bot)  * ZONE_H
+            return int(tx), int(ty)
+
+        # Pitch circles: invert only strikes that are in the zone
+        PITCH_R = max(5 * s, 5)
+        for pitch_num, pitch in enumerate(ab_pitches, start=1):
+            px_c, pz_c = pitch.get('px'), pitch.get('pz')
+            if px_c is None or pz_c is None:
+                continue
+            bx, by = _to_pixel(px_c, pz_c)
+            # Clip pitches that are entirely outside the tile (far wide/high), but
+            # allow pitches that overlap the zone border to show as "off the plate".
+            if by < rp_y - PITCH_R or by > rp_y + rp_h + PITCH_R:
+                continue
+            # Prefer the result/call code; fall back to 'code' for callers that
+            # supply the call code there directly.
+            _code = (pitch.get('call') or pitch.get('code') or '').upper()
+            # Highlight (fill) called balls; strikes / fouls / contact are outlines.
+            filled = _code in _BALL_CODES
+            box = [bx - PITCH_R, by - PITCH_R, bx + PITCH_R, by + PITCH_R]
+            seq_str = str(pitch_num)
+            sw = int(font7.getlength(seq_str))
+            if filled:
+                draw.ellipse(box, fill=0, outline=0)
+                draw.text((bx - sw // 2, by - 4 * s), seq_str, font=font7, fill=255)
+            else:
+                draw.ellipse(box, fill=255, outline=0)
+                draw.text((bx - sw // 2, by - 4 * s), seq_str, font=font7, fill=0)
+
+        # ── Bases: left side of panel ──────────────────────────────────
+        _outs_count = game_data.get('num_of_outs') or 0
+        if _outs_count < 3:
+            _hi_third  = isinstance(game_data.get('runner_on_third'), str)
+            _hi_second = isinstance(game_data.get('runner_on_second'), str)
+            _hi_first  = isinstance(game_data.get('runner_on_first'), str)
+            _b3x, _b3y = rp_x + 18 * s, rp_y + 52 * s
+            _b2x, _b2y = rp_x + 30 * s, rp_y + 40 * s
+            _b1x, _b1y = rp_x + 42 * s, rp_y + 52 * s
+            Himage = draw_diamond(Himage, (_b3x, _b3y), 9 * s, _hi_third)
+            Himage = draw_diamond(Himage, (_b2x, _b2y), 9 * s, _hi_second)
+            Himage = draw_diamond(Himage, (_b1x, _b1y), 9 * s, _hi_first)
+            draw = ImageDraw.Draw(Himage)
+            for _bfill, _bcx, _bcy, _bkey in (
+                (_hi_third,  _b3x, _b3y, 'runner_third_number'),
+                (_hi_second, _b2x, _b2y, 'runner_second_number'),
+                (_hi_first,  _b1x, _b1y, 'runner_first_number'),
+            ):
+                if _bfill:
+                    _raw = game_data.get(_bkey)
+                    _bnum = str(_raw) if _raw is not None else ''
+                    _bnw = int(font9.getlength(_bnum)) if _bnum else 0
+                    draw.text((_bcx - _bnw // 2, _bcy - 5 * s), _bnum, font=font9, fill=255)
+
+        # ── Outs circles: left side, below bases ──────────────────────
+        outs_list = [i + 1 <= _outs_count for i in range(3)]
+        Himage = draw_circle(Himage, (rp_x + 18 * s, rp_y + 71 * s), 5 * s, outs_list[0], outline_width=2)
+        Himage = draw_circle(Himage, (rp_x + 30 * s, rp_y + 71 * s), 5 * s, outs_list[1], outline_width=2)
+        Himage = draw_circle(Himage, (rp_x + 42 * s, rp_y + 71 * s), 5 * s, outs_list[2], outline_width=2)
+        draw = ImageDraw.Draw(Himage)
+
+        # ── Pitch list: vertical, right of bases/outs, left of zone ───
+        # Anchored to a fixed top (not the zone) so moving the zone down doesn't
+        # shrink the list — keeps room to show more of the at-bat's pitches.
+        _pt_x = rp_x + 56 * s   # nudged 3px right
+        _pt_max_w = zone_lx - _pt_x - 2 * s
+        _pt_step = 9 * s
+        _pt_top = rp_y + header_h + 2 * s
+        for _pn, _pp in enumerate(ab_pitches, start=1):
+            _ey = _pt_top + (_pn - 1) * _pt_step
+            if _ey + _pt_step > rp_y + rp_h - 37 * s:
+                break
+            _abbr = _pp.get('pt_abbr') or _WIDE_PITCH_TYPE.get(_pp.get('code', ''), _pp.get('code', ''))
+            _label = f'{_pn}-{_abbr}' if _abbr else str(_pn)
+            _lw = int(font7.getlength(_label))
+            if _lw > _pt_max_w:
+                _label = _label[:4]
+            draw.text((int(_pt_x), int(_ey)), _label, font=font7, fill=0)
+
+        # ── Balls / Strikes indicators (pushed below pitch list) ───────
         balls_list = [i + 1 <= balls for i in range(3)]
-        _num_strikes = game_data.get('strikes') or 0
+        _num_strikes = min(game_data.get('strikes') or 0, 2)
         strikes_list = [i + 1 <= _num_strikes for i in range(2)]
         _strike_calls = game_data.get('strike_calls') or []
 
-        draw.text((rp_x + 2 * s, rp_y + 82 * s), 'B', font=font14, fill=0)
-        Himage = draw_circle(Himage, (rp_x + 19 * s, rp_y + 91 * s), 4 * s, balls_list[0])
-        Himage = draw_circle(Himage, (rp_x + 31 * s, rp_y + 91 * s), 4 * s, balls_list[1])
-        Himage = draw_circle(Himage, (rp_x + 43 * s, rp_y + 91 * s), 4 * s, balls_list[2])
+        draw.text((rp_x + 2 * s, rp_y + 93 * s), 'B', font=font11, fill=0)
+        Himage = draw_circle(Himage, (rp_x + 19 * s, rp_y + 102 * s), 4 * s, balls_list[0])
+        Himage = draw_circle(Himage, (rp_x + 31 * s, rp_y + 102 * s), 4 * s, balls_list[1])
+        Himage = draw_circle(Himage, (rp_x + 43 * s, rp_y + 102 * s), 4 * s, balls_list[2])
         draw = ImageDraw.Draw(Himage)
 
-        draw.text((rp_x + 54 * s, rp_y + 82 * s), 'S', font=font14, fill=0)
+        draw.text((rp_x + 54 * s, rp_y + 93 * s), 'S', font=font11, fill=0)
         for _si, (_scx, _scy) in enumerate([
-            (rp_x + 70 * s, rp_y + 91 * s),
-            (rp_x + 82 * s, rp_y + 91 * s),
+            (rp_x + 70 * s, rp_y + 102 * s),
+            (rp_x + 82 * s, rp_y + 102 * s),
         ]):
             _call = _strike_calls[_si] if _si < len(_strike_calls) else None
             if strikes_list[_si] and _call in ('S', 'F'):
@@ -2311,8 +2352,26 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
                 Himage = draw_circle(Himage, (_scx, _scy), 4 * s, strikes_list[_si])
                 draw = ImageDraw.Draw(Himage)
 
-    # ── Pitcher row: "P: Name" left, "SL 87 10P" right (type+speed+pc, font9) ──
-    _py = rp_y + 97 * s
+    else:
+        # ── Between innings: next 3 batters, outs hidden ───────────────
+        _batter_names = [
+            _last_name(game_data.get('next_batter_1') or game_data.get('current_hitter') or ''),
+            _last_name(game_data.get('next_batter_2') or game_data.get('due_up') or ''),
+            _last_name(game_data.get('next_batter_3') or game_data.get('in_hole') or ''),
+        ]
+        _bat_y = rp_y + header_h + 10 * s
+        _bat_max_w = rp_w - 4 * s
+        for _nm in _batter_names:
+            if _nm:
+                _bat_str = _nm
+                while _bat_str and int(font11.getlength(_bat_str)) > _bat_max_w:
+                    _bat_str = _bat_str[:-1]
+                if _bat_str:
+                    draw.text((rp_x + 2 * s, _bat_y), _bat_str, font=font11, fill=0)
+            _bat_y += 16 * s
+
+    # ── Pitcher row (pushed below B/S indicators) ──────────────────────
+    _py = rp_y + 107 * s
     _max_w = rp_w - 4 * s
     _pc = game_data.get('pitch_count')
     _pt_last = game_data.get('last_pitch_type', '') or ''
@@ -2328,68 +2387,101 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
     _rb_w = int(font9.getlength(_right_badge)) + 2 * s if _right_badge else 0
     _pit_avail = _max_w - _rb_w
     _pit_str = f'P: {_pitcher_name}'
-    _pf = font14
+    _pf = font11
     if int(_pf.getlength(_pit_str)) > _pit_avail:
-        _pf = font11
-        if int(_pf.getlength(_pit_str)) > _pit_avail:
-            _pf = font9
-            while _pit_str and int(_pf.getlength(_pit_str)) > _pit_avail:
-                _pit_str = _pit_str[:-1]
+        _pf = font9
+        while _pit_str and int(font9.getlength(_pit_str)) > _pit_avail:
+            _pit_str = _pit_str[:-1]
     draw.text((rp_x + 2 * s, _py), _pit_str, font=_pf, fill=0)
     if _right_badge:
         draw.text((rp_x + rp_w - _rb_w, _py), _right_badge, font=font9, fill=0)
 
-    # ── Batter row ─────────────────────────────────────────────────────
-    _by = rp_y + 110 * s
-    _bh = game_data.get('batter_hits')
-    _ba = game_data.get('batter_at_bats')
-    _ba_str = f'{_bh}-{_ba}' if _bh is not None and _ba is not None else ''
-    _ba_w = int(font11.getlength(_ba_str)) + 2 * s if _ba_str else 0
-    _hit_avail = _max_w - _ba_w
-    _ab_done = game_data.get('current_at_bat_complete', False)
-    if _ab_done and not _is_game_effectively_over(game_data):
-        _next = _format_player_name(game_data.get('due_up') or game_data.get('next_batter_1') or '')
-        _batter_label = f'AB: {_next}' if _next else ''
-    else:
-        _hitter = _format_player_name(
-            game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
-        )
-        _batter_label = f'AB: {_hitter}'
-    if _batter_label:
-        # Cap at font11 so the batter row stays 11px tall, leaving room for events
-        _bf = font11
-        if int(_bf.getlength(_batter_label)) > _hit_avail:
-            _bf = font9
-            while _batter_label and int(_bf.getlength(_batter_label)) > _hit_avail:
-                _batter_label = _batter_label[:-1]
-        draw.text((rp_x + 2 * s, _by), _batter_label, font=_bf, fill=0)
-    if _ba_str:
-        draw.text((rp_x + rp_w - _ba_w, _by), _ba_str, font=font9, fill=0)
+    # ── Batter row (hidden between innings — no one is at bat, and the
+    #    linescore's current-batter fields go stale during the break) ────
+    if not _between_innings:
+        _by = rp_y + 117 * s
+        _bh = game_data.get('batter_hits')
+        _ba = game_data.get('batter_at_bats')
+        _ba_str = f'{_bh}-{_ba}' if _bh is not None and _ba is not None else ''
+        _ba_w = int(font9.getlength(_ba_str)) + 2 * s if _ba_str else 0
+        _hit_avail = _max_w - _ba_w
+        _ab_done = game_data.get('current_at_bat_complete', False)
+        if _ab_done and not _is_game_effectively_over(game_data):
+            _next = _format_player_name(game_data.get('due_up') or game_data.get('next_batter_1') or '')
+            _batter_label = f'AB: {_next}' if _next else ''
+        else:
+            _hitter = _format_player_name(
+                game_data.get('current_play_batter') or game_data.get('current_hitter') or ''
+            )
+            _batter_label = f'AB: {_hitter}'
+        if _batter_label:
+            _bf = font11
+            if int(_bf.getlength(_batter_label)) > _hit_avail:
+                _bf = font9
+                while _batter_label and int(font9.getlength(_batter_label)) > _hit_avail:
+                    _batter_label = _batter_label[:-1]
+            draw.text((rp_x + 2 * s, _by), _batter_label, font=_bf, fill=0)
+        if _ba_str:
+            draw.text((rp_x + rp_w - _ba_w, _by), _ba_str, font=font9, fill=0)
 
-    # ── Last half-inning events (full play description, truncated to fit) ─
-    half_inning_plays = game_data.get('half_inning_plays') or []
-    _ev_y = rp_y + 121 * s
-    _ev_line = 10 * s
-    for _i, _desc in enumerate(half_inning_plays[-3:]):
-        _ey = _ev_y + _i * _ev_line
-        if _ey + _ev_line > rp_y + rp_h:
+    # ── K strikeouts: current pitcher only, full width — hide between innings ─
+    if _between_innings:
+        return Himage
+    # Top half → home team pitching; Bottom half → away team pitching
+    _inning_state = game_data.get('inningState', '')
+    if _inning_state in ('Top', 'Middle'):
+        _pitcher_ks = game_data.get('home_pitcher_ks') or []
+    else:
+        _pitcher_ks = game_data.get('away_pitcher_ks') or []
+    if not _pitcher_ks:
+        return Himage
+    # Bold via a 1px horizontal double-strike. Shrink the font (from the WIN/LOSS
+    # size down) until ALL of this pitcher's Ks fit across the strip on one line.
+    _k_gap = max(2 * s, 2)
+    _k_avail = rp_w - 4 * s
+    _k_font = None
+    _k_bbox = None
+    for _px in range(18, 6, -1):
+        _f = _get_font(_px * s)
+        _bb = _f.getbbox('K')
+        _adv = (_bb[2] - _bb[0]) + 3   # +1 for the bold strike, +2 tmp padding
+        if len(_pitcher_ks) * (_adv + _k_gap) - _k_gap <= _k_avail:
+            _k_font, _k_bbox = _f, _bb
             break
-        _txt = str(_desc)
-        while _txt and int(font9.getlength(_txt)) > _max_w:
-            _txt = _txt[:-1]
-        if _txt:
-            draw.text((rp_x + 2 * s, int(_ey)), _txt, font=font9, fill=0)
+    if _k_font is None:                # still doesn't fit at 7px — use 7px anyway
+        _k_font = _get_font(7 * s)
+        _k_bbox = _k_font.getbbox('K')
+    _k_glyph_h = _k_bbox[3] - _k_bbox[1]
+    _k_tmp_w = max(_k_bbox[2] - _k_bbox[0] + 3, 4)
+    _k_tmp_h = max(_k_glyph_h + 2, 4)
+    # Center the glyphs vertically in the 20px gap below the tile border.
+    _k_strip_y = rp_y + rp_h + (20 * s - _k_glyph_h) // 2 - 1 * s
+    _k_spacing = _k_tmp_w + _k_gap
+    _k_x = rp_x + 2 * s
+    for _k in _pitcher_ks:
+        if _k_x + _k_tmp_w > rp_x + rp_w - 2:
+            break
+        _k_tmp = Image.new('1', (_k_tmp_w, _k_tmp_h), 1)
+        _ktd = ImageDraw.Draw(_k_tmp)
+        _ktd.text((1 - _k_bbox[0], 1 - _k_bbox[1]), 'K', font=_k_font, fill=0)
+        _ktd.text((2 - _k_bbox[0], 1 - _k_bbox[1]), 'K', font=_k_font, fill=0)  # bold strike
+        if _k == 'L':
+            _k_tmp = _k_tmp.transpose(Image.FLIP_LEFT_RIGHT)
+        Himage.paste(_k_tmp, (int(_k_x), int(_k_strip_y)))
+        draw = ImageDraw.Draw(Himage)
+        _k_x += _k_spacing
 
 
 def draw_wide_box(Himage, start_x, start_y, game_data, team_data,
                   score_changed=False, use_logos=False, logo_x_offset=2,
-                  streak_map=None, scale=1):
+                  show_win_prob=False, streak_map=None, scale=1):
     """Featured 2-cell (285×130 px) game tile.
 
     Left panel (135 px): standard draw_box content with linescore always
-    visible and hits shown even in-progress.
-    Right panel (150 px): strike zone with current AB pitch locations +
-    last 3 half-inning play descriptions in full wording.
+    visible and hits shown even in-progress. Win probability bar shown when
+    show_win_prob=True (same as single cells).
+    Right panel (150 px): pitch list (vertical left), strike zone (right),
+    bases/outs/count, pitcher/batter rows, K strip below.
     """
     s = scale
     CELL_W  = 135 * s   # left panel — same as normal cell width
@@ -2398,18 +2490,20 @@ def draw_wide_box(Himage, start_x, start_y, game_data, team_data,
     HEADER_H = 20 * s
     TOTAL_H  = 130 * s
 
-    # Left panel via draw_box: force linescore + always show hits; no win-prob bar
+    # Left panel via draw_box: force linescore + always show hits
     Himage = draw_box(
         Himage, start_x, start_y, game_data, team_data,
         score_changed=score_changed,
         use_logos=use_logos,
         logo_x_offset=logo_x_offset,
-        show_win_prob=False,
+        show_win_prob=show_win_prob,
         streak_map=streak_map,
         show_winner_logo=True,
         scale=scale,
         force_linescore=True,
         always_show_hits=True,
+        hide_last_play=True,
+        skip_header_invert=True,   # the wide cell inverts the full header itself
     )
 
     # Extend top, header-separator, and bottom borders across the right panel (no center divider)
@@ -2431,5 +2525,17 @@ def draw_wide_box(Himage, start_x, start_y, game_data, team_data,
         use_logos=use_logos,
         scale=scale,
     )
+
+    # Invert the whole two-cell header when a run scores (or the score changed),
+    # spanning both cells — mirrors the single-cell run-scored header flash.
+    _between = game_data.get('inningState') in ('Middle', 'End')
+    _run_scored = (
+        game_data.get('detailed_state') == 'In Progress'
+        and int(game_data.get('last_play_rbi') or 0) > 0
+    )
+    if (score_changed or _run_scored) and not _between:
+        header_box = Himage.crop((start_x, start_y, start_x + TOTAL_W, start_y + HEADER_H))
+        Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
+        draw = ImageDraw.Draw(Himage)
 
     return Himage

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -2311,16 +2311,21 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
                 Himage = draw_circle(Himage, (_scx, _scy), 4 * s, strikes_list[_si])
                 draw = ImageDraw.Draw(Himage)
 
-    # ── Pitcher row ────────────────────────────────────────────────────
+    # ── Pitcher row: "P: Name" left, "SL 87 10P" right (type+speed+pc, font9) ──
     _py = rp_y + 97 * s
     _max_w = rp_w - 4 * s
     _pc = game_data.get('pitch_count')
-    _pt_last = game_data.get('last_pitch_type', '')
+    _pt_last = game_data.get('last_pitch_type', '') or ''
     _lps = game_data.get('last_pitch_speed')
     _pitcher_name = _format_player_name(game_data.get('current_pitcher') or '')
 
-    _right_badge = _pt_last if _pt_last else ''
-    _rb_w = int(font11.getlength(_right_badge)) + 2 * s if _right_badge else 0
+    _rb_parts = [p for p in [
+        _pt_last,
+        str(int(_lps)) if _lps else '',
+        f'{_pc}P' if _pc is not None else '',
+    ] if p]
+    _right_badge = ' '.join(_rb_parts)
+    _rb_w = int(font9.getlength(_right_badge)) + 2 * s if _right_badge else 0
     _pit_avail = _max_w - _rb_w
     _pit_str = f'P: {_pitcher_name}'
     _pf = font14
@@ -2332,23 +2337,10 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
                 _pit_str = _pit_str[:-1]
     draw.text((rp_x + 2 * s, _py), _pit_str, font=_pf, fill=0)
     if _right_badge:
-        draw.text((rp_x + rp_w - _rb_w, _py), _right_badge, font=font11, fill=0)
-
-    # Pitch count + speed on same row right-side (below badge if no badge)
-    if _lps or _pc is not None:
-        _spd_str = str(int(_lps)) if _lps else ''
-        _pc_str  = f'{_pc}P' if _pc is not None else ''
-        _row2 = _py + 11 * s
-        _spd_w = int(font11.getlength(_spd_str)) + 2 * s if _spd_str else 0
-        _pc_w  = int(font11.getlength(_pc_str))  + 2 * s if _pc_str  else 0
-        if _spd_str:
-            draw.text((rp_x + rp_w - _spd_w, _row2), _spd_str, font=font11, fill=0)
-            draw.text((rp_x + rp_w - _spd_w + 1, _row2), _spd_str, font=font11, fill=0)
-        if _pc_str:
-            draw.text((rp_x + rp_w - _spd_w - _pc_w, _row2), _pc_str, font=font11, fill=0)
+        draw.text((rp_x + rp_w - _rb_w, _py), _right_badge, font=font9, fill=0)
 
     # ── Batter row ─────────────────────────────────────────────────────
-    _by = rp_y + 109 * s
+    _by = rp_y + 110 * s
     _bh = game_data.get('batter_hits')
     _ba = game_data.get('batter_at_bats')
     _ba_str = f'{_bh}-{_ba}' if _bh is not None and _ba is not None else ''
@@ -2364,21 +2356,20 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
         )
         _batter_label = f'AB: {_hitter}'
     if _batter_label:
-        _bf = font14
+        # Cap at font11 so the batter row stays 11px tall, leaving room for events
+        _bf = font11
         if int(_bf.getlength(_batter_label)) > _hit_avail:
-            _bf = font11
-            if int(_bf.getlength(_batter_label)) > _hit_avail:
-                _bf = font9
-                while _batter_label and int(_bf.getlength(_batter_label)) > _hit_avail:
-                    _batter_label = _batter_label[:-1]
+            _bf = font9
+            while _batter_label and int(_bf.getlength(_batter_label)) > _hit_avail:
+                _batter_label = _batter_label[:-1]
         draw.text((rp_x + 2 * s, _by), _batter_label, font=_bf, fill=0)
     if _ba_str:
-        draw.text((rp_x + rp_w - _ba_w, _by), _ba_str, font=font11, fill=0)
+        draw.text((rp_x + rp_w - _ba_w, _by), _ba_str, font=font9, fill=0)
 
     # ── Last half-inning events (full play description, truncated to fit) ─
     half_inning_plays = game_data.get('half_inning_plays') or []
-    _ev_y = rp_y + 119 * s
-    _ev_line = 11 * s
+    _ev_y = rp_y + 121 * s
+    _ev_line = 10 * s
     for _i, _desc in enumerate(half_inning_plays[-3:]):
         _ey = _ev_y + _i * _ev_line
         if _ey + _ev_line > rp_y + rp_h:

--- a/src/image_featured.py
+++ b/src/image_featured.py
@@ -404,9 +404,11 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
 
         _bot = WIN_PCT_Y - 4
 
-        # ---- Linescore grid: innings 1-9, centered on canvas ----
+        # ---- Linescore grid: innings 1-9 (or sliding window in extra innings) ----
         _ls_col_t  = 44           # team abbreviation column width
         _ls_n_cols = 9
+        # In extra innings slide the window so the current inning is rightmost
+        _ls_first_inn = max(1, _cur_inn - _ls_n_cols + 1)
         _ls_col_w  = 37           # each inning column width
         _ls_grid_w = _ls_col_t + _ls_n_cols * _ls_col_w  # 377
         _ls_x0     = (800 - _ls_grid_w) // 2             # 211
@@ -434,9 +436,9 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             _vx = _ls_div_x + _k * _ls_col_w
             draw.line((_vx, DIV_Y, _vx, WIN_PCT_Y - 1), fill=0, width=1)
 
-        # Inning number headers (1-9)
+        # Inning number headers (sliding window: 1-9 normally, or e.g. 3-11 in extras)
         for _k in range(_ls_n_cols):
-            _inn_n   = str(_k + 1)
+            _inn_n   = str(_ls_first_inn + _k)
             _cell_cx = _ls_div_x + _k * _ls_col_w + _ls_col_w // 2
             _hdr_cy  = _ls_y_top + _ls_hdr_h // 2
             _nw = int(f_ls_hdr.getlength(_inn_n))
@@ -458,15 +460,16 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             draw.text((_ax,     _ay), _t_abbr, font=f_ls_team, fill=0)
             draw.text((_ax + 1, _ay), _t_abbr, font=f_ls_team, fill=0)
 
-        # Per-inning run values (skip None cells)
+        # Per-inning run values (skip None cells; index offset for extra-innings window)
         for _k in range(_ls_n_cols):
             _cell_cx = _ls_div_x + _k * _ls_col_w + _ls_col_w // 2
+            _inn_idx = _ls_first_inn - 1 + _k   # 0-based index into inning runs list
             for _runs_list, _row_y, _row_h in (
                 (away_inn_runs, _ls_y1, _ls_row_h),
                 (home_inn_runs, _ls_y2, _ls_y_bot - _ls_y2),
             ):
-                if _k < len(_runs_list) and _runs_list[_k] is not None:
-                    _rv = str(_runs_list[_k])
+                if _inn_idx < len(_runs_list) and _runs_list[_inn_idx] is not None:
+                    _rv = str(_runs_list[_inn_idx])
                     _rw = int(f_ls_runs.getlength(_rv))
                     _rx = _cell_cx - _rw // 2
                     _ry = _row_y + (_row_h - 36) // 2

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -619,22 +619,29 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
     _wide_idx = _find_wide_game(game_list, config, team_data)
     _use_wide = _wide_idx is not None
 
-    # Move the wide game to the front of game_list
-    if _use_wide and _wide_idx != 0:
-        game_list = list(game_list)
-        game_list.insert(0, game_list.pop(_wide_idx))
+    # If the wide game would fall on the last column (col 4) it can't span right —
+    # fall back to a normal single cell for that game.
+    if _use_wide and (_wide_idx % 5) >= 4:
+        _use_wide = False
 
-    # Build an ordered list of (slot_type, grid_x, grid_y) for each rendered game
+    # Build an ordered list of (slot_type, grid_x, grid_y) keeping games in their
+    # natural display order (no move-to-front).
     if _use_wide:
-        # Wide slot at (col=0, row=0) consumes columns 0 and 1 of row 0
-        _slots = [('wide', 0, 0)]
-        for _gy in range(3):
-            for _gx in range(5):
-                if _gy == 0 and _gx in (0, 1):
-                    continue
-                _slots.append(('normal', _gx, _gy))
+        # Walk through every game in order; the wide game consumes 2 horizontal
+        # slot units, all others consume 1.  Track a running slot_idx counter.
+        _slots = []
+        _slot_idx = 0
+        for _gi in range(len(game_list)):
+            _row = _slot_idx // 5
+            _col = _slot_idx % 5
+            if _gi == _wide_idx:
+                _slots.append(('wide', _col, _row))
+                _slot_idx += 2
+            else:
+                _slots.append(('normal', _col, _row))
+                _slot_idx += 1
     else:
-        _slots = [('normal', _gx, _gy) for _gy in range(3) for _gx in range(5)]
+        _slots = [('normal', _gi % 5, _gi // 5) for _gi in range(len(game_list))]
 
     for game, slot_info in zip(game_list, _slots):
         slot_type, gx, gy = slot_info

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -496,42 +496,93 @@ def generate_standings(Himage, col_start=100, row_start=320):
     return Himage
 
 
-def _find_wide_game(game_list, config, team_data):
-    """Return the index in game_list of the game to show as the wide featured cell.
+def _find_wide_games(game_list, config, team_data):
+    """Return the set of game_list indices to show as wide (2-cell) tiles.
 
-    Priority: primary team's In Progress game first; otherwise the live game
-    farthest along (highest inning, then most outs as tiebreak).
-    Returns None when game_list has 15+ games (no room for a wide slot).
+    Each wide cell consumes one extra grid slot, and the 5×3 grid holds only
+    15 slot units total. So at most ``15 - len(game_list)`` games can be widened
+    without pushing a game off the grid — e.g. with 13 games only 2 may be wide.
+    When more games are in progress than that budget allows, the games farthest
+    along (by inning) are chosen.
+
+    When wide_cell_always=true in config, always show exactly one wide cell —
+    the in-progress game farthest into the game by inning — even with 15+ games
+    (one game will be dropped from the grid to accommodate the extra slot).
+
+    Geometry fix-up (col=4 conflicts) is handled separately by _reorder_for_wide,
+    which swaps in-progress games with adjacent normal games so they land at a
+    valid column. This function selects purely by priority.
     """
-    if len(game_list) >= 15:
-        return None
+    in_progress = [i for i, g in enumerate(game_list) if g.get('detailed_state') == 'In Progress']
 
-    primary  = config.get('primary', '')
-    abbr_map = team_data.get('team_abbreviation', {})
+    # Find the in-progress game farthest along:
+    # 1. highest inning  2. Bottom > Top  3. most outs  4. earliest start time
+    def _progress(idx):
+        g = game_list[idx]
+        inning = g.get('current_inning') or 0
+        # Order within an inning: Top < Middle (break) < Bottom < End (break). This
+        # keeps a game that just went to break ranked at/above where it was, so it
+        # doesn't lose its wide slot to another game when the inning turns over.
+        half  = {'Top': 0, 'Middle': 1, 'Bottom': 2, 'End': 3}.get(g.get('inningState'), 0)
+        outs  = g.get('num_of_outs') or 0
+        # Earlier start = higher priority when all else equal; negate so max() works
+        start = g.get('game_datetime') or ''
+        return (inning, half, outs, start)
 
-    # Check if primary team's game is live
-    if primary:
-        for i, g in enumerate(game_list):
-            away_a = abbr_map.get(str(g.get('away_team_id', '')), '')
-            home_a = abbr_map.get(str(g.get('home_team_id', '')), '')
-            if primary in (away_a, home_a) and g.get('detailed_state') == 'In Progress':
-                return i
+    if len(game_list) < 15:
+        # Only widen as many games as there are spare slots (15 - games).
+        max_wide = 15 - len(game_list)
+        if len(in_progress) <= max_wide:
+            return set(in_progress)
+        return set(sorted(in_progress, key=_progress, reverse=True)[:max_wide])
 
-    # Fall back to highest-inning live game (most outs as tiebreak)
-    best_i = None
-    best_inn = -1
-    best_outs = -1
-    for i, g in enumerate(game_list):
-        if g.get('detailed_state') != 'In Progress':
-            continue
-        inn  = g.get('current_inning') or 0
-        outs = g.get('num_of_outs') or 0
-        if inn > best_inn or (inn == best_inn and outs > best_outs):
-            best_inn  = inn
-            best_outs = outs
-            best_i    = i
+    if not config.get('wide_cell_always', False) or not in_progress:
+        return set()
 
-    return best_i
+    return {max(in_progress, key=_progress)}
+
+
+def _reorder_for_wide(game_list, wide_set):
+    """Reorder game_list so every game in wide_set can actually render wide.
+
+    A wide cell must start at col 0-3 (can't span from col 4 into col 5).
+    When a wide game lands at col 4, swap it with the normal game immediately
+    after it; the wide game shifts to col 0 of the next row and can span right.
+    If the next game is also wide (can't swap), drop the conflicting wide game.
+
+    Returns (new_game_list, new_wide_set).
+    """
+    game_list = list(game_list)
+    wide_set = set(wide_set)
+
+    for _ in range(len(wide_set) + 1):  # converges in at most one pass per wide game
+        slot = 0
+        conflict = None
+        for gi in range(len(game_list)):
+            if slot >= 15:
+                break
+            col = slot % 5
+            if gi in wide_set:
+                if col >= 4:
+                    conflict = gi
+                    break
+                slot += 2
+            else:
+                slot += 1
+
+        if conflict is None:
+            break
+
+        b = conflict
+        next_b = b + 1
+        if next_b < len(game_list) and next_b not in wide_set:
+            game_list[b], game_list[next_b] = game_list[next_b], game_list[b]
+            wide_set.discard(b)
+            wide_set.add(next_b)
+        else:
+            wide_set.discard(b)
+
+    return game_list, wide_set
 
 
 def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=None, changed_game_ids=None, use_logos=False, logo_x_offset=2, show_win_prob=False):
@@ -602,7 +653,7 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
             game_list.remove(_ppd_g)
             game_list.append(_ppd_g)
 
-    # Build per-team stats lookup {str(team_id): {'streak': ..., 'l10_wins': ..., 'l10_losses': ...}}
+    # Build per-team stats lookup {str(team_id): {'streak', 'l10_wins', 'l10_losses', 'wins', 'losses'}}
     _standings = load_json_file('standings.json')
     streak_map = {}
     for _div_teams in _standings.get('standings', {}).values():
@@ -613,28 +664,30 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
                     'streak': _t.get('streak'),
                     'l10_wins': _t.get('last_ten_wins'),
                     'l10_losses': _t.get('last_ten_losses'),
+                    'wins': _t.get('league_record_wins'),
+                    'losses': _t.get('league_record_losses'),
                 }
 
-    # Determine whether to show a wide (2-cell) featured game
-    _wide_idx = _find_wide_game(game_list, config, team_data)
-    _use_wide = _wide_idx is not None
+    # Determine which games show as wide (2-cell) tiles: all In Progress games.
+    # _reorder_for_wide swaps any wide game that would land at col=4 with the
+    # normal game after it, ensuring it can span rightward.
+    _wide_set = _find_wide_games(game_list, config, team_data)
+    if _wide_set:
+        game_list, _wide_set = _reorder_for_wide(game_list, _wide_set)
 
-    # If the wide game would fall on the last column (col 4) it can't span right —
-    # fall back to a normal single cell for that game.
-    if _use_wide and (_wide_idx % 5) >= 4:
-        _use_wide = False
-
-    # Build an ordered list of (slot_type, grid_x, grid_y) keeping games in their
-    # natural display order (no move-to-front).
-    if _use_wide:
-        # Walk through every game in order; the wide game consumes 2 horizontal
-        # slot units, all others consume 1.  Track a running slot_idx counter.
+    # Build an ordered list of (slot_type, grid_x, grid_y).
+    # Each wide game consumes 2 horizontal slot units; normal games consume 1.
+    # Wide games on the last column (col 4) fall back to normal (can't span right).
+    # Stop adding slots once the 5×3 grid is full (15 slot units).
+    if _wide_set:
         _slots = []
         _slot_idx = 0
         for _gi in range(len(game_list)):
+            if _slot_idx >= 15:
+                break
             _row = _slot_idx // 5
             _col = _slot_idx % 5
-            if _gi == _wide_idx:
+            if _gi in _wide_set and _col < 4:
                 _slots.append(('wide', _col, _row))
                 _slot_idx += 2
             else:
@@ -655,6 +708,7 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
                 score_changed=score_changed,
                 use_logos=use_logos,
                 logo_x_offset=logo_x_offset,
+                show_win_prob=show_win_prob,
                 streak_map=streak_map,
             )
         else:

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -15,7 +15,7 @@ from image_utils import (
     _pitcher_line, _clean_venue_name,
 )
 from image_standings import _WC_STRIP_H
-from image_box import draw_box
+from image_box import draw_box, draw_wide_box
 
 
 def generate_linescore(col_start, row_start, team_abbr, Himage, new_image_dict):
@@ -496,6 +496,44 @@ def generate_standings(Himage, col_start=100, row_start=320):
     return Himage
 
 
+def _find_wide_game(game_list, config, team_data):
+    """Return the index in game_list of the game to show as the wide featured cell.
+
+    Priority: primary team's In Progress game first; otherwise the live game
+    farthest along (highest inning, then most outs as tiebreak).
+    Returns None when game_list has 15+ games (no room for a wide slot).
+    """
+    if len(game_list) >= 15:
+        return None
+
+    primary  = config.get('primary', '')
+    abbr_map = team_data.get('team_abbreviation', {})
+
+    # Check if primary team's game is live
+    if primary:
+        for i, g in enumerate(game_list):
+            away_a = abbr_map.get(str(g.get('away_team_id', '')), '')
+            home_a = abbr_map.get(str(g.get('home_team_id', '')), '')
+            if primary in (away_a, home_a) and g.get('detailed_state') == 'In Progress':
+                return i
+
+    # Fall back to highest-inning live game (most outs as tiebreak)
+    best_i = None
+    best_inn = -1
+    best_outs = -1
+    for i, g in enumerate(game_list):
+        if g.get('detailed_state') != 'In Progress':
+            continue
+        inn  = g.get('current_inning') or 0
+        outs = g.get('num_of_outs') or 0
+        if inn > best_inn or (inn == best_inn and outs > best_outs):
+            best_inn  = inn
+            best_outs = outs
+            best_i    = i
+
+    return best_i
+
+
 def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=None, changed_game_ids=None, use_logos=False, logo_x_offset=2, show_win_prob=False):
 
     draw = ImageDraw.Draw(Himage)
@@ -577,16 +615,50 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
                     'l10_losses': _t.get('last_ten_losses'),
                 }
 
-    counter = 0
-    for y in range(0,3):
-        for x in range(0,5):
-            if counter > len(game_list) - 1:
-                continue
-            if game_list[counter]:
-                game_pk_key = str(game_list[counter].get('game_pk', ''))
-                score_changed = changed_game_ids is not None and game_pk_key in changed_game_ids
-                Himage = draw_box(Himage, x * 150 + x_start, y * 150 + y_start, game_list[counter], team_data, score_changed=score_changed, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob, streak_map=streak_map)
-            counter += 1
+    # Determine whether to show a wide (2-cell) featured game
+    _wide_idx = _find_wide_game(game_list, config, team_data)
+    _use_wide = _wide_idx is not None
+
+    # Move the wide game to the front of game_list
+    if _use_wide and _wide_idx != 0:
+        game_list = list(game_list)
+        game_list.insert(0, game_list.pop(_wide_idx))
+
+    # Build an ordered list of (slot_type, grid_x, grid_y) for each rendered game
+    if _use_wide:
+        # Wide slot at (col=0, row=0) consumes columns 0 and 1 of row 0
+        _slots = [('wide', 0, 0)]
+        for _gy in range(3):
+            for _gx in range(5):
+                if _gy == 0 and _gx in (0, 1):
+                    continue
+                _slots.append(('normal', _gx, _gy))
+    else:
+        _slots = [('normal', _gx, _gy) for _gy in range(3) for _gx in range(5)]
+
+    for game, slot_info in zip(game_list, _slots):
+        slot_type, gx, gy = slot_info
+        game_pk_key = str(game.get('game_pk', ''))
+        score_changed = changed_game_ids is not None and game_pk_key in changed_game_ids
+        sx = gx * 150 + x_start
+        sy = gy * 150 + y_start
+        if slot_type == 'wide':
+            Himage = draw_wide_box(
+                Himage, sx, sy, game, team_data,
+                score_changed=score_changed,
+                use_logos=use_logos,
+                logo_x_offset=logo_x_offset,
+                streak_map=streak_map,
+            )
+        else:
+            Himage = draw_box(
+                Himage, sx, sy, game, team_data,
+                score_changed=score_changed,
+                use_logos=use_logos,
+                logo_x_offset=logo_x_offset,
+                show_win_prob=show_win_prob,
+                streak_map=streak_map,
+            )
 
     Himage.save('score_board.bmp')
     return Himage

--- a/src/refresh_tracker.py
+++ b/src/refresh_tracker.py
@@ -4,7 +4,6 @@ import time
 
 STATE_FILE = os.path.join(os.path.dirname(__file__), '..', 'data', 'refresh_state.json')
 FULL_REFRESH_INTERVAL = 3600  # 1 hour in seconds
-PARTIAL_REFRESH_BEFORE_FULL = 20  # force full refresh after this many partial refreshes
 
 
 def _load_state():
@@ -16,15 +15,12 @@ def _load_state():
 
 
 def needs_full_refresh():
-    """Return True if 1+ hour since last full refresh, or >= 10 partial refreshes since last full."""
+    """Return True if 1+ hour has passed since the last full refresh."""
     state = _load_state()
     last = state.get('last_full_refresh')
     if last is None:
         return True
-    if (time.time() - last) >= FULL_REFRESH_INTERVAL:
-        return True
-    partial_count = state.get('partial_refresh_count', 0)
-    return partial_count >= PARTIAL_REFRESH_BEFORE_FULL
+    return (time.time() - last) >= FULL_REFRESH_INTERVAL
 
 
 def record_full_refresh():

--- a/src/render_scoreboard.py
+++ b/src/render_scoreboard.py
@@ -13,6 +13,7 @@ import argparse
 # Allow running as a standalone script from any directory
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from PIL import Image, ImageChops
 from util import load_json_file
 from config_loader import load_config, add_config_arg
 from generate_image import orchestrate_score_board
@@ -79,6 +80,72 @@ def _render_single_game_mode(mode, game_state_data, team_data, config, output_pa
         return None
 
 
+def _pixel_diff_bands(old_img, new_img, row_gap=4):
+    """Return tight (x, y, w, h) rectangles for every cluster of changed pixels.
+
+    Algorithm:
+      1. Pixel-diff the two images (converted to 8-bit grayscale).
+      2. Per row: find the leftmost and rightmost changed pixel (if any).
+      3. Group contiguous changed rows — tolerating up to `row_gap` unchanged
+         rows between them — into a band.
+      4. Per band: take the union of each row's x-range for the tightest box.
+      5. Align x down and x+w up to 8-pixel boundaries (e-ink driver requirement).
+
+    Returns:
+        list of (x, y, w, h)  — partial-refresh exactly these rectangles
+        []                     — >70 % of rows changed; caller should full-refresh
+        None                   — exception; caller keeps its own region list
+    """
+    try:
+        W, H = new_img.size
+        diff = ImageChops.difference(old_img.convert('L'), new_img.convert('L'))
+        raw = diff.tobytes()   # one byte per pixel in 'L' mode
+
+        # Build per-row (min_x, max_x) for every row that has at least one change
+        row_x: dict[int, tuple[int, int]] = {}
+        for y in range(H):
+            row = raw[y * W: y * W + W]
+            # Short-circuit: skip unchanged rows cheaply
+            if not any(row):
+                continue
+            min_x = next(x for x, b in enumerate(row) if b)
+            max_x = W - 1 - next(x for x, b in enumerate(reversed(row)) if b)
+            row_x[y] = (min_x, max_x)
+
+        if not row_x:
+            return []
+
+        changed_rows = sorted(row_x)
+        if len(changed_rows) > H * 0.70:   # too much changed → full-screen partial
+            return [(0, 0, W, H)]
+
+        # Group rows into bands and track the union x-range per band
+        bands = []
+        start = prev = changed_rows[0]
+        bx0, bx1 = row_x[start]
+
+        for y in changed_rows[1:]:
+            if y - prev > row_gap:
+                # Align to 8-pixel boundaries required by the e-ink driver
+                xa = (bx0 // 8) * 8
+                xb = ((bx1 + 8) // 8) * 8
+                bands.append((xa, start, xb - xa, prev - start + 1))
+                start = y
+                bx0, bx1 = row_x[y]
+            else:
+                mx0, mx1 = row_x[y]
+                bx0 = min(bx0, mx0)
+                bx1 = max(bx1, mx1)
+            prev = y
+
+        xa = (bx0 // 8) * 8
+        xb = ((bx1 + 8) // 8) * 8
+        bands.append((xa, start, xb - xa, prev - start + 1))
+        return bands
+    except Exception:
+        return None   # caller falls back to its own region list
+
+
 def render(config, date_str=None, output_path=None, bypass_cache=False):
     """
     Render display from cached data/games.json.
@@ -105,12 +172,36 @@ def render(config, date_str=None, output_path=None, bypass_cache=False):
     if mode in ('field', 'scorecard', 'pitch'):
         image = _render_single_game_mode(mode, game_state_data, team_data, config, output_path)
         if image:
-            return (image, [])
+            return (image, [(0, 0, image.width, image.height)])
         return None
+
+    # Snapshot the current saved image before overwriting so we can pixel-diff it.
+    # Only used for the fullscreen single-game display where partial updates are
+    # most valuable; the multi-game scoreboard already uses per-cell regions.
+    _is_fullscreen = os.environ.get('FEATURED_TEAM_FULLSCREEN', '').lower() in ('true', '1', 'yes')
+    _old_snap = None
+    if _is_fullscreen and not bypass_cache and os.path.isfile(output_path):
+        try:
+            _old_snap = Image.open(output_path).copy()
+        except Exception:
+            pass
 
     result = orchestrate_score_board(game_state_data, team_data, date_str, bypass_cache=bypass_cache, config=config)
     if result:
         image, changed_regions = result
+
+        # Fullscreen: replace zone-based regions with pixel-exact diff bands.
+        # _pixel_diff_bands returns None on error (keep zone-based fallback),
+        # [] when too much changed or nothing changed (full refresh), or a
+        # list of (x, y, w, h) bands for a precise partial refresh.
+        if _is_fullscreen and _old_snap is not None and _old_snap.size == image.size:
+            _bands = _pixel_diff_bands(_old_snap, image)
+            if _bands is not None:
+                changed_regions = _bands
+                if _bands:
+                    total_h = sum(b[3] for b in _bands)
+                    print(f"Pixel diff: {len(_bands)} band(s), {total_h}px of {image.size[1]}px refreshed")
+
         image.save(output_path)
         print(f"Image saved to {output_path}")
         return (image, changed_regions)

--- a/tests/test_scoreboard_rules.py
+++ b/tests/test_scoreboard_rules.py
@@ -2491,12 +2491,12 @@ class TestBuildScorecardNotation:
 # ===========================================================================
 
 class TestArrowSuppression:
-    """Batting-team arrows must vanish when num_of_outs >= 3, even if
-    inningState hasn't flipped to Middle/End yet (API lag after final out)."""
+    """The batting-team ▲/▼ indicator has been removed: no arrow should ever be
+    drawn in the indicator region just left of the box, in any game state."""
 
-    # Triangle sits just left of start_x=32.  _bi_cx = 32+4-8 = 28, _r = 4.
-    _AWAY_ARROW = (22, 63, 35, 76)   # ▲ for Top-half (away batting)
-    _HOME_ARROW = (22, 93, 35, 106)  # ▼ for Bottom-half (home batting)
+    # Triangle used to sit just left of start_x=32.  _bi_cx = 32+4-8 = 28, _r = 4.
+    _AWAY_ARROW = (22, 63, 35, 76)   # ▲ region for Top-half (away batting)
+    _HOME_ARROW = (22, 93, 35, 106)  # ▼ region for Bottom-half (home batting)
 
     def _render(self, game, team_data):
         img = Image.new('1', (800, 480), 255)
@@ -2504,42 +2504,20 @@ class TestArrowSuppression:
         return img
 
     @needs_pil
-    def test_arrow_visible_when_top_and_less_than_3_outs(self, minimal_team_data):
-        """▲ appears when inningState='Top' and fewer than 3 outs."""
-        game = _in_progress_game(inningState='Top', num_of_outs=0)
-        img = self._render(game, minimal_team_data)
-        assert _has_dark_pixels(img, *self._AWAY_ARROW), \
-            "▲ should be drawn for top-half with 0 outs"
+    def test_no_arrow_top_half(self, minimal_team_data):
+        for outs in (0, 1, 2, 3):
+            game = _in_progress_game(inningState='Top', num_of_outs=outs)
+            img = self._render(game, minimal_team_data)
+            assert not _has_dark_pixels(img, *self._AWAY_ARROW), \
+                f"▲ indicator should be removed (outs={outs})"
 
     @needs_pil
-    def test_arrow_visible_home_batting_2_outs(self, minimal_team_data):
-        """▼ appears when inningState='Bottom' and 2 outs."""
-        game = _in_progress_game(inningState='Bottom', num_of_outs=2)
-        img = self._render(game, minimal_team_data)
-        assert _has_dark_pixels(img, *self._HOME_ARROW), \
-            "▼ should be drawn for bottom-half with 2 outs"
-
-    @needs_pil
-    def test_arrow_suppressed_when_3_outs_top(self, minimal_team_data):
-        """▲ must NOT appear when num_of_outs=3 (API lag — inningState still 'Top')."""
-        game_3 = _in_progress_game(inningState='Top', num_of_outs=3)
-        game_0 = _in_progress_game(inningState='Top', num_of_outs=0)
-        img_3 = self._render(game_3, minimal_team_data)
-        img_0 = self._render(game_0, minimal_team_data)
-        assert _has_dark_pixels(img_0, *self._AWAY_ARROW), "sanity: arrow exists at 0 outs"
-        assert not _has_dark_pixels(img_3, *self._AWAY_ARROW), \
-            "▲ must be suppressed when 3 outs recorded"
-
-    @needs_pil
-    def test_arrow_suppressed_when_3_outs_bottom(self, minimal_team_data):
-        """▼ must NOT appear when num_of_outs=3 (API lag — inningState still 'Bottom')."""
-        game_3 = _in_progress_game(inningState='Bottom', num_of_outs=3)
-        game_1 = _in_progress_game(inningState='Bottom', num_of_outs=1)
-        img_3 = self._render(game_3, minimal_team_data)
-        img_1 = self._render(game_1, minimal_team_data)
-        assert _has_dark_pixels(img_1, *self._HOME_ARROW), "sanity: arrow exists at 1 out"
-        assert not _has_dark_pixels(img_3, *self._HOME_ARROW), \
-            "▼ must be suppressed when 3 outs recorded"
+    def test_no_arrow_bottom_half(self, minimal_team_data):
+        for outs in (0, 1, 2, 3):
+            game = _in_progress_game(inningState='Bottom', num_of_outs=outs)
+            img = self._render(game, minimal_team_data)
+            assert not _has_dark_pixels(img, *self._HOME_ARROW), \
+                f"▼ indicator should be removed (outs={outs})"
 
     @needs_pil
     def test_arrow_absent_for_final_game(self, minimal_team_data):

--- a/tests/test_wide_cell.py
+++ b/tests/test_wide_cell.py
@@ -1,0 +1,406 @@
+"""
+Smoke tests for the wide-cell (2-slot) scoreboard feature.
+
+Covers:
+  1. draw_wide_box: in-progress, between-innings, no-pitch-data edge cases
+  2. _draw_wide_right_panel: pitch rendering with missing/partial data
+  3. _find_wide_games: slot selection logic for <15 and 15+ game slates
+  4. draw_out_of_town_score_board: end-to-end grid with wide cells
+"""
+
+import pytest
+from unittest.mock import patch
+
+try:
+    from PIL import Image
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+needs_pil = pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not installed")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def white_image():
+    return Image.new('1', (800, 480), 255)
+
+
+@pytest.fixture
+def team_data():
+    return {
+        'team_abbreviation': {
+            '119': 'LAD',
+            '137': 'SF',
+            '133': 'OAK',
+            '144': 'ATL',
+            '147': 'NYY',
+            '111': 'BOS',
+        }
+    }
+
+
+def _base_game(**overrides):
+    g = {
+        'game_pk': 1001,
+        'away_team_id': 119,
+        'home_team_id': 137,
+        'away_team_name': 'LAD',
+        'home_team_name': 'SF',
+        'detailed_state': 'Final',
+        'away_runs': 3,
+        'home_runs': 5,
+        'away_hits': 8,
+        'home_hits': 10,
+        'away_errors': 0,
+        'home_errors': 1,
+        'away_team_is_winner': False,
+        'home_team_is_winner': True,
+        'winner_name': 'Logan Webb',
+        'loser_name': 'Clayton Kershaw',
+        'saver_name': None,
+        'winner_record': '5-2',
+        'loser_record': '3-4',
+        'saver_saves': None,
+        'current_inning': 9,
+        'inningState': 'End',
+        'away_inning_runs': [0, 1, 0, 0, 0, 2, 0, 0, 0],
+        'home_inning_runs': [1, 0, 2, 0, 0, 0, 1, 0, 1],
+        'away_team_record_wins': 40,
+        'away_team_record_losses': 30,
+        'home_team_record_wins': 45,
+        'home_team_record_losses': 25,
+        'num_of_outs': 3,
+        'balls': None,
+        'strikes': None,
+        'runner_on_first': None,
+        'runner_on_second': None,
+        'runner_on_third': None,
+        'game_start': '7:05 PM',
+        'game_datetime': '2026-06-20T23:05:00Z',
+        'away_probable': None,
+        'home_probable': None,
+        'away_probable_note': None,
+        'home_probable_note': None,
+        'no_hitter': False,
+        'perfect_game': False,
+        'save_situation': False,
+        'walk_off': False,
+        'last_play': None,
+        'venue': 'Oracle Park',
+        'current_hitter': None,
+        'current_pitcher': None,
+        'due_up': None,
+        'in_hole': None,
+        'game_duration_minutes': None,
+        'series_result': '',
+        'series_game_number': 1,
+        'series_total_games': 3,
+        'series_wins': 0,
+        'series_losses': 0,
+        'series_is_tied': False,
+        'series_is_over': False,
+    }
+    g.update(overrides)
+    return g
+
+
+def _live_game(**overrides):
+    """In-progress game with pitch data."""
+    g = _base_game(
+        detailed_state='In Progress',
+        current_inning=7,
+        inningState='Top',
+        num_of_outs=1,
+        balls=2,
+        strikes=1,
+        strike_calls=['C', 'S'],
+        runner_on_first='Mookie Betts',
+        runner_on_second=None,
+        runner_on_third=None,
+        runner_first_number=50,
+        runner_second_number=None,
+        runner_third_number=None,
+        current_pitcher='Logan Webb',
+        current_hitter='Mookie Betts',
+        current_play_batter='Mookie Betts',
+        pitch_count=82,
+        last_pitch_type='FB',
+        last_pitch_speed=93.4,
+        batter_hits=2,
+        batter_at_bats=3,
+        current_at_bat_complete=False,
+        ab_pitches=[
+            {'seq': 1, 'px': -0.3, 'pz': 2.8, 'sz_top': 3.4, 'sz_bot': 1.6,
+             'code': 'C', 'pt_abbr': 'FB'},
+            {'seq': 2, 'px': 0.9,  'pz': 1.2, 'sz_top': 3.4, 'sz_bot': 1.6,
+             'code': 'B', 'pt_abbr': 'SL'},
+            {'seq': 3, 'px': 0.1,  'pz': 2.5, 'sz_top': 3.4, 'sz_bot': 1.6,
+             'code': 'S', 'pt_abbr': 'CH'},
+        ],
+        half_inning_plays=['K', '1B'],
+        home_pitcher_ks=['K', 'K', 'L', 'K'],
+        away_pitcher_ks=['K', 'L'],
+        away_win_probability=42.0,
+        home_win_probability=58.0,
+    )
+    g.update(overrides)
+    return g
+
+
+def _between_innings_game(**overrides):
+    g = _live_game(
+        inningState='Middle',
+        num_of_outs=3,
+        ab_pitches=[],
+        next_batter_1='Freddie Freeman',
+        next_batter_2='Will Smith',
+        next_batter_3='Max Muncy',
+    )
+    g.update(overrides)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# 1. draw_wide_box smoke tests
+# ---------------------------------------------------------------------------
+
+@needs_pil
+def test_wide_box_in_progress(white_image, team_data):
+    from image_box import draw_wide_box
+    result = draw_wide_box(white_image, 0, 0, _live_game(), team_data)
+    assert isinstance(result, Image.Image)
+    assert result.size == (800, 480)
+
+
+@needs_pil
+def test_wide_box_between_innings(white_image, team_data):
+    from image_box import draw_wide_box
+    result = draw_wide_box(white_image, 0, 0, _between_innings_game(), team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_wide_box_no_pitches(white_image, team_data):
+    from image_box import draw_wide_box
+    result = draw_wide_box(white_image, 0, 0, _live_game(ab_pitches=[]), team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_wide_box_missing_optional_fields(white_image, team_data):
+    """All optional right-panel fields absent — must not raise."""
+    from image_box import draw_wide_box
+    game = _live_game()
+    for field in ('current_pitcher', 'current_hitter', 'current_play_batter',
+                  'pitch_count', 'last_pitch_type', 'last_pitch_speed',
+                  'batter_hits', 'batter_at_bats', 'half_inning_plays',
+                  'home_pitcher_ks', 'away_pitcher_ks',
+                  'away_win_probability', 'home_win_probability'):
+        game.pop(field, None)
+    result = draw_wide_box(white_image, 0, 0, game, team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_wide_box_no_sz_bounds(white_image, team_data):
+    """Pitches without sz_top/sz_bot fall back to MLB average constants."""
+    from image_box import draw_wide_box
+    game = _live_game(ab_pitches=[
+        {'seq': 1, 'px': 0.0, 'pz': 2.5, 'code': 'C', 'pt_abbr': 'FB'},
+    ])
+    result = draw_wide_box(white_image, 0, 0, game, team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_wide_box_none_pitch_coords(white_image, team_data):
+    """Pitches with None px/pz are skipped without crashing."""
+    from image_box import draw_wide_box
+    game = _live_game(ab_pitches=[
+        {'seq': 1, 'px': None, 'pz': None, 'code': 'B', 'pt_abbr': 'FB'},
+        {'seq': 2, 'px': 0.1,  'pz': 2.8,  'code': 'S', 'pt_abbr': 'SL'},
+    ])
+    result = draw_wide_box(white_image, 0, 0, game, team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_wide_box_many_pitches(white_image, team_data):
+    """10-pitch at-bat — zone list truncates, no crash."""
+    from image_box import draw_wide_box
+    pitches = [
+        {'seq': i, 'px': 0.1 * (i % 3 - 1), 'pz': 2.0 + 0.2 * i,
+         'sz_top': 3.4, 'sz_bot': 1.6, 'code': 'S' if i % 2 else 'B', 'pt_abbr': 'FB'}
+        for i in range(1, 11)
+    ]
+    result = draw_wide_box(white_image, 0, 0, _live_game(ab_pitches=pitches), team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_wide_box_with_win_prob(white_image, team_data):
+    from image_box import draw_wide_box
+    result = draw_wide_box(
+        white_image, 0, 0, _live_game(), team_data, show_win_prob=True
+    )
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_wide_box_many_ks(white_image, team_data):
+    """More Ks than fit in panel — strip truncates gracefully."""
+    from image_box import draw_wide_box
+    game = _live_game(home_pitcher_ks=['K'] * 20)
+    result = draw_wide_box(white_image, 0, 0, game, team_data)
+    assert isinstance(result, Image.Image)
+
+
+# ---------------------------------------------------------------------------
+# 2. _find_wide_games logic
+# ---------------------------------------------------------------------------
+
+def _make_game_list(states_and_innings):
+    """Build a minimal game list. Each entry: (detailed_state, inning, half)."""
+    games = []
+    for i, (state, inning, half) in enumerate(states_and_innings):
+        games.append({
+            'game_pk': 1000 + i,
+            'detailed_state': state,
+            'current_inning': inning,
+            'inningState': half,
+            'num_of_outs': 0,
+            'game_datetime': f'2026-06-20T2{i}:00:00Z',
+        })
+    return games
+
+
+def test_find_wide_games_fewer_than_15():
+    from image_grid import _find_wide_games
+    games = _make_game_list([
+        ('Final', 9, 'End'),
+        ('In Progress', 5, 'Top'),
+        ('Scheduled', 0, ''),
+    ])
+    result = _find_wide_games(games, {}, {})
+    assert result == {1}
+
+
+def test_find_wide_games_all_in_progress():
+    from image_grid import _find_wide_games
+    games = _make_game_list([('In Progress', i + 1, 'Top') for i in range(5)])
+    result = _find_wide_games(games, {}, {})
+    assert result == {0, 1, 2, 3, 4}
+
+
+def test_find_wide_games_caps_to_spare_slots():
+    """13 games with 4 in progress → only 2 spare slots, so 2 widest games chosen."""
+    from image_grid import _find_wide_games
+    states = [
+        ('In Progress', 3, 'Top'),    # 0
+        ('In Progress', 8, 'Top'),    # 1  ← farthest
+        ('In Progress', 6, 'Bottom'), # 2  ← second farthest
+        ('In Progress', 2, 'Top'),    # 3
+    ] + [('Final', 9, 'End')] * 9     # pad to 13
+    games = _make_game_list(states)
+    result = _find_wide_games(games, {}, {})
+    assert result == {1, 2}
+
+
+def test_find_wide_games_14_games_one_wide():
+    """14 games → 1 spare slot → exactly 1 wide cell."""
+    from image_grid import _find_wide_games
+    states = [('In Progress', 7, 'Top'), ('In Progress', 4, 'Top')] + \
+             [('Final', 9, 'End')] * 12
+    games = _make_game_list(states)
+    result = _find_wide_games(games, {}, {})
+    assert result == {0}
+
+
+def test_find_wide_games_15_plus_no_force():
+    from image_grid import _find_wide_games
+    games = _make_game_list([('In Progress', 7, 'Top')] * 15)
+    result = _find_wide_games(games, {'wide_cell_always': False}, {})
+    assert result == set()
+
+
+def test_find_wide_games_15_plus_force_picks_farthest():
+    from image_grid import _find_wide_games
+    games = _make_game_list([
+        ('In Progress', 5, 'Top'),   # 0
+        ('In Progress', 8, 'Top'),   # 1  ← highest inning
+        ('Final',       9, 'End'),   # 2  not in progress
+        ('In Progress', 7, 'Bottom'),# 3
+    ] + [('Final', 9, 'End')] * 11)  # pad to 15
+    result = _find_wide_games(games, {'wide_cell_always': True}, {})
+    assert result == {1}
+
+
+def test_find_wide_games_tiebreak_by_half():
+    from image_grid import _find_wide_games
+    games = _make_game_list([
+        ('In Progress', 7, 'Top'),    # 0
+        ('In Progress', 7, 'Bottom'), # 1  same inning, Bottom wins
+    ] + [('Final', 9, 'End')] * 13)
+    result = _find_wide_games(games, {'wide_cell_always': True}, {})
+    assert result == {1}
+
+
+def test_find_wide_games_tiebreak_by_outs():
+    from image_grid import _find_wide_games
+    games = [
+        {'game_pk': 0, 'detailed_state': 'In Progress', 'current_inning': 7,
+         'inningState': 'Top', 'num_of_outs': 0, 'game_datetime': 'A'},
+        {'game_pk': 1, 'detailed_state': 'In Progress', 'current_inning': 7,
+         'inningState': 'Top', 'num_of_outs': 2, 'game_datetime': 'B'},
+    ] + [{'game_pk': i + 2, 'detailed_state': 'Final', 'current_inning': 9,
+          'inningState': 'End', 'num_of_outs': 3, 'game_datetime': 'C'} for i in range(13)]
+    result = _find_wide_games(games, {'wide_cell_always': True}, {})
+    assert result == {1}
+
+
+def test_find_wide_games_15_plus_force_no_live_game():
+    """15+ games, force=True, but no in-progress games → empty set."""
+    from image_grid import _find_wide_games
+    games = _make_game_list([('Final', 9, 'End')] * 15)
+    result = _find_wide_games(games, {'wide_cell_always': True}, {})
+    assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end grid with wide cells
+# ---------------------------------------------------------------------------
+
+@needs_pil
+def test_grid_with_one_wide_game(white_image, team_data):
+    from image_grid import draw_out_of_town_score_board
+    games = [_live_game(game_pk=1)] + [
+        _base_game(game_pk=i + 2) for i in range(5)
+    ]
+    result = draw_out_of_town_score_board(white_image, games, team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_grid_15_games_no_wide(white_image, team_data):
+    """15 games, wide_cell_always off → all normal cells, no crash."""
+    from image_grid import draw_out_of_town_score_board
+    games = [_base_game(game_pk=i) for i in range(14)] + [_live_game(game_pk=99)]
+    result = draw_out_of_town_score_board(white_image, games, team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
+def test_grid_15_games_wide_cell_always(white_image, team_data):
+    """15 games, wide_cell_always on → one wide cell rendered, no crash."""
+    from image_grid import draw_out_of_town_score_board
+    games = [_base_game(game_pk=i) for i in range(14)] + [_live_game(game_pk=99)]
+    with patch('image_grid.load_yaml_file', return_value={
+        'wide_cell_always': True,
+        'scoreboard_live_details': False,
+    }):
+        result = draw_out_of_town_score_board(white_image, games, team_data)
+    assert isinstance(result, Image.Image)


### PR DESCRIPTION
## Summary
- When fewer than 15 games are scheduled, the most-advanced (or primary-team live) game expands to a 2-cell wide tile (285×130 px) in the 5-column scoreboard grid
- Left panel: standard game box with linescore grid always visible + R/H/E displayed even in-progress
- Right panel: 3×3 strike zone (lighter dithered interior, solid border), numbered pitch circles (filled=strike, open=ball, sequence# inside), bases diamond with runner state, current batter, outs indicators, and last 3 half-inning plays in full wording
- Remaining 14 slots fill normally with single-cell boxes (col2-4 row0, then rows 1-3)
- Extended `game_detail_fetch.py` to pull current AB pitch coordinates + half-inning play descriptions from live feed

## Test plan
- [ ] Render with 9-game cache (2 In Progress): wide cell appears top-left for highest-inning game
- [ ] R/H/E shows in left panel even for in-progress games
- [ ] Inject fake pitch data: numbered dots appear in zone (filled=strike, open=ball)
- [ ] Bases diamond reflects runner state (1B/3B occupied shows filled corners)
- [ ] Half-inning events truncated to fit right panel width
- [ ] With 15+ games: no wide cell, normal 5×3 grid used

🤖 Generated with [Claude Code](https://claude.com/claude-code)