### PR TITLE
Keep wide cell during challenge; fix 7-event count with markers

### DIFF
--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -511,7 +511,18 @@ def fetch_scoreboard_live_extras(game_pk, away_id=None, home_id=None):
                             game_plays.append('^' if _this_half[1] else 'v')
                         game_plays.append(_note)
                         _last_play_half = _this_half
-        half_inning_plays = game_plays[-7:]
+        # Keep the last 7 *events* (plus the half-inning markers that fall between
+        # them). Slicing game_plays[-7:] directly would count '^'/'v' markers as
+        # entries and leave fewer than 7 real events showing.
+        _kept = []
+        _event_count = 0
+        for _tok in reversed(game_plays):
+            _kept.append(_tok)
+            if _tok not in ('^', 'v'):
+                _event_count += 1
+                if _event_count >= 7:
+                    break
+        half_inning_plays = list(reversed(_kept))
 
         # K strikeouts for wide-cell header: track swinging (K) vs looking (L) per pitcher side
         away_pitcher_ks = []   # Ks by away pitcher (home batters struck out, isTopInning=False)

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -2155,7 +2155,17 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
     _inn_w = int(font14.getlength(_inn_text)) + 2 * s   # +2 for the inning's bold strike
 
     half_inning_plays = game_data.get('half_inning_plays') or []
-    _recent_plays = list(half_inning_plays[-7:])
+    # Keep the last 7 *events* plus intervening half-inning markers ('^'/'v').
+    # A plain [-7:] would count markers as entries and show fewer than 7 events.
+    _recent_plays = []
+    _rp_events = 0
+    for _tok in reversed(half_inning_plays):
+        _recent_plays.append(_tok)
+        if _tok not in ('^', 'v'):
+            _rp_events += 1
+            if _rp_events >= 7:
+                break
+    _recent_plays.reverse()
     # Right-anchor against the count; left bound clears the inning label.
     _hdr_left = _tile_left + 2 * s + _inn_w + 6 * s
     _hdr_right = rp_x + rp_w - _cnt_w - (7 * s if _cnt_w else 3 * s)

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -496,6 +496,11 @@ def generate_standings(Himage, col_start=100, row_start=320):
     return Himage
 
 
+# Live game states that qualify for a wide (2-cell) tile. Challenge/review states
+# are still an active game, so they must keep the wide slot they already had.
+_LIVE_WIDE_STATES = ('In Progress', 'Player challenge', 'Manager challenge')
+
+
 def _find_wide_games(game_list, config, team_data):
     """Return the set of game_list indices to show as wide (2-cell) tiles.
 
@@ -512,8 +517,12 @@ def _find_wide_games(game_list, config, team_data):
     Geometry fix-up (col=4 conflicts) is handled separately by _reorder_for_wide,
     which swaps in-progress games with adjacent normal games so they land at a
     valid column. This function selects purely by priority.
+
+    A game under review ('Player challenge'/'Manager challenge') is still live —
+    it is treated as in-progress so it keeps its wide tile instead of collapsing
+    to a single cell and handing the slot to another game mid-review.
     """
-    in_progress = [i for i, g in enumerate(game_list) if g.get('detailed_state') == 'In Progress']
+    in_progress = [i for i, g in enumerate(game_list) if g.get('detailed_state') in _LIVE_WIDE_STATES]
 
     # Find the in-progress game farthest along:
     # 1. highest inning  2. Bottom > Top  3. most outs  4. earliest start time

--- a/tests/test_wide_cell.py
+++ b/tests/test_wide_cell.py
@@ -271,6 +271,19 @@ def test_wide_box_events_with_inning_triangles(white_image, team_data):
 
 
 @needs_pil
+def test_wide_box_seven_events_with_markers(white_image, team_data):
+    """Half-inning markers ('^'/'v') must not count against the 7-event budget:
+    9 events with 2 interspersed markers should still surface 7 real events."""
+    from image_box import draw_wide_box
+    game = _live_game(
+        half_inning_plays=['K', '6-3', '1B', 'v', 'F9', 'L7', '2B', '^', 'Kl',
+                           '5-3', 'BB'],
+    )
+    result = draw_wide_box(white_image, 0, 0, game, team_data)
+    assert isinstance(result, Image.Image)
+
+
+@needs_pil
 def test_wide_box_events_leading_triangle_trimmed(white_image, team_data):
     """A leading boundary marker left after trimming doesn't crash or render alone."""
     from image_box import draw_wide_box
@@ -392,6 +405,30 @@ def test_find_wide_games_15_plus_force_no_live_game():
     games = _make_game_list([('Final', 9, 'End')] * 15)
     result = _find_wide_games(games, {'wide_cell_always': True}, {})
     assert result == set()
+
+
+def test_find_wide_games_challenge_state_stays_wide():
+    """A game under review ('Player challenge'/'Manager challenge') is still live
+    and must keep its wide tile rather than handing the slot to another game."""
+    from image_grid import _find_wide_games
+    games = _make_game_list([
+        ('Player challenge', 7, 'Top'),   # 0 — under review, still live
+        ('Manager challenge', 5, 'Bottom'),  # 1 — under review, still live
+    ] + [('Final', 9, 'End')] * 11)       # pad to 13 → 2 spare slots
+    result = _find_wide_games(games, {}, {})
+    assert result == {0, 1}
+
+
+def test_find_wide_games_challenge_does_not_displace_in_progress():
+    """With only 1 spare slot, an In Progress game farther along still wins, but a
+    challenge game counts toward the live pool (not silently dropped)."""
+    from image_grid import _find_wide_games
+    games = _make_game_list([
+        ('In Progress', 9, 'Bottom'),     # 0 — farthest along
+        ('Player challenge', 2, 'Top'),   # 1 — live but earlier
+    ] + [('Final', 9, 'End')] * 12)       # pad to 14 → 1 spare slot
+    result = _find_wide_games(games, {}, {})
+    assert result == {0}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Challenge state keeps the wide cell.** A game under review (`Player challenge` / `Manager challenge`) is still live, but `_find_wide_games` only counted `In Progress`, so a review would collapse the game's 2-cell tile and hand the slot to a different game. Now review states count as live and retain their wide tile.
- **7 events, not 6, in the 2-cell event strip.** The `[-7:]` slice counted the `^`/`v` half-inning markers as entries, so an event strip with markers showed only ~6 real events. Both the fetch (`half_inning_plays`) and the renderer now keep the last **7 real events** plus the markers between them.

## Already handled on this line of work (no change needed)
- **Up/down inning-break triangles** — shipped in #173.
- **Wide-cell strike-zone partial refresh on e-ink** — the zone lives in the right panel (right half of the tile). The old partial-refresh region was only 152px wide (left half), so the zone never refreshed on e-ink though it rendered fine in the Mac BMP. The 152→304px region fix in #173 already covers it; verified by reproducing a zone-only change and confirming the emitted region is `(32, 30, 304, 150)` — 8-aligned and fully covering the zone.

## Test plan
- [x] `tests/test_wide_cell.py` — added challenge-stays-wide, challenge-doesn't-displace, and 7-events-with-markers tests; 28 wide-cell tests pass, 479 total
- [ ] On-device: confirm a game entering a challenge keeps its wide tile, and the event strip shows 7 events across a half-inning boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)