### PR TITLE
Add wide_cell_featured: featured team gets the wide tile when live

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -107,6 +107,12 @@ scoreboard_live_details: true
 # even when there are 15+ games on the slate (one game will be dropped from the grid to make room).
 wide_cell_always: false
 
+# Wide cell featured team: when true, the wide (2-cell) tile always goes to the
+# featured (primary) team's game while it is live. If the featured team's game is
+# not live, the tile falls back to the in-progress game farthest along. Like
+# wide_cell_always, this shows a wide cell even with 15+ games on the slate.
+wide_cell_featured: false
+
 # Pre-game weather footer on Scheduled/Pre-Game/Warmup tiles (temp, wind, precip%).
 # Uses Open-Meteo (no API key required) with stadium coordinates from data/stadium_weather.json.
 weather:

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -514,6 +514,11 @@ def _find_wide_games(game_list, config, team_data):
     the in-progress game farthest into the game by inning — even with 15+ games
     (one game will be dropped from the grid to accommodate the extra slot).
 
+    When wide_cell_featured=true, the wide cell always goes to the featured
+    (primary) team's game when it is live; otherwise it falls back to the game
+    farthest along. Like wide_cell_always, this shows a wide cell even with 15+
+    games — but the choice prefers the featured team over raw game progress.
+
     Geometry fix-up (col=4 conflicts) is handled separately by _reorder_for_wide,
     which swaps in-progress games with adjacent normal games so they land at a
     valid column. This function selects purely by priority.
@@ -523,6 +528,20 @@ def _find_wide_games(game_list, config, team_data):
     to a single cell and handing the slot to another game mid-review.
     """
     in_progress = [i for i, g in enumerate(game_list) if g.get('detailed_state') in _LIVE_WIDE_STATES]
+
+    # Featured-team preference: index of the primary team's live game, if enabled.
+    featured_idx = None
+    if config.get('wide_cell_featured', False):
+        primary = config.get('primary', '')
+        if primary:
+            abbr_map = team_data.get('team_abbreviation', {})
+            for i in in_progress:
+                g = game_list[i]
+                away = abbr_map.get(str(g.get('away_team_id', '')), '')
+                home = abbr_map.get(str(g.get('home_team_id', '')), '')
+                if primary in (away, home):
+                    featured_idx = i
+                    break
 
     # Find the in-progress game farthest along:
     # 1. highest inning  2. Bottom > Top  3. most outs  4. earliest start time
@@ -538,17 +557,26 @@ def _find_wide_games(game_list, config, team_data):
         start = g.get('game_datetime') or ''
         return (inning, half, outs, start)
 
+    # Ranking used when a subset must be chosen: the featured live game outranks
+    # everything else; ties beyond that fall back to game progress.
+    def _rank(idx):
+        return (1 if idx == featured_idx else 0,) + _progress(idx)
+
     if len(game_list) < 15:
         # Only widen as many games as there are spare slots (15 - games).
         max_wide = 15 - len(game_list)
         if len(in_progress) <= max_wide:
             return set(in_progress)
-        return set(sorted(in_progress, key=_progress, reverse=True)[:max_wide])
+        return set(sorted(in_progress, key=_rank, reverse=True)[:max_wide])
 
-    if not config.get('wide_cell_always', False) or not in_progress:
+    # 15+ games: show a single wide cell if either always-on or featured preference
+    # is enabled. The pick prefers the featured live game (via _rank) and otherwise
+    # falls back to the game farthest along.
+    if not in_progress:
         return set()
-
-    return {max(in_progress, key=_progress)}
+    if config.get('wide_cell_always', False) or config.get('wide_cell_featured', False):
+        return {max(in_progress, key=_rank)}
+    return set()
 
 
 def _reorder_for_wide(game_list, wide_set):

--- a/tests/test_wide_cell.py
+++ b/tests/test_wide_cell.py
@@ -432,6 +432,63 @@ def test_find_wide_games_challenge_does_not_displace_in_progress():
 
 
 # ---------------------------------------------------------------------------
+# 3b. wide_cell_featured — featured team gets the wide tile when live
+# ---------------------------------------------------------------------------
+
+_FEAT_TD = {'team_abbreviation': {'147': 'NYY', '111': 'BOS', '119': 'LAD', '137': 'SF'}}
+
+
+def _g(pk, away_id, home_id, state, inning=5, half='Top'):
+    return {
+        'game_pk': pk, 'away_team_id': away_id, 'home_team_id': home_id,
+        'detailed_state': state, 'current_inning': inning, 'inningState': half,
+        'num_of_outs': 1, 'game_datetime': f'2026-06-20T{20 + pk % 4}:00:00Z',
+    }
+
+
+def test_featured_live_gets_wide_at_15_games():
+    """wide_cell_featured: the featured team's live game is the wide cell even at 15 games."""
+    from image_grid import _find_wide_games
+    games = [_g(i, 119, 137, 'Final', 9, 'End') for i in range(14)]
+    games.append(_g(99, 111, 147, 'In Progress', 3, 'Top'))   # index 14 — NYY (home) live
+    result = _find_wide_games(games, {'wide_cell_featured': True, 'primary': 'NYY'}, _FEAT_TD)
+    assert result == {14}
+
+
+def test_featured_not_live_falls_back_to_latest():
+    """wide_cell_featured: when the featured game is not live, the farthest-along game wins."""
+    from image_grid import _find_wide_games
+    games = [_g(i, 119, 137, 'Final', 9, 'End') for i in range(13)]
+    games.append(_g(50, 111, 133, 'In Progress', 4, 'Top'))   # index 13 — non-featured, earlier
+    games.append(_g(51, 137, 133, 'In Progress', 8, 'Top'))   # index 14 — non-featured, farther
+    # NYY isn't playing live → fall back to the game farthest along (index 14).
+    result = _find_wide_games(games, {'wide_cell_featured': True, 'primary': 'NYY'}, _FEAT_TD)
+    assert result == {14}
+
+
+def test_featured_preferred_over_farther_game_when_capping():
+    """wide_cell_featured beats raw progress: the featured game wins the lone slot
+    even though another live game is farther along."""
+    from image_grid import _find_wide_games
+    games = [_g(i, 119, 137, 'Final', 9, 'End') for i in range(12)]
+    games.append(_g(60, 111, 147, 'In Progress', 2, 'Top'))   # index 12 — NYY, earlier
+    games.append(_g(61, 137, 133, 'In Progress', 8, 'Top'))   # index 13 — non-featured, farther
+    # 14 games → 1 spare slot. Featured preference picks NYY (12) over the farther game.
+    result = _find_wide_games(games, {'wide_cell_featured': True, 'primary': 'NYY'}, _FEAT_TD)
+    assert result == {12}
+
+
+def test_featured_default_off_preserves_old_behavior():
+    """Without wide_cell_featured, 15 games with a live featured game shows no wide cell
+    (identical to the prior behavior)."""
+    from image_grid import _find_wide_games
+    games = [_g(i, 119, 137, 'Final', 9, 'End') for i in range(14)]
+    games.append(_g(99, 111, 147, 'In Progress', 3, 'Top'))   # NYY live
+    assert _find_wide_games(games, {'primary': 'NYY'}, _FEAT_TD) == set()
+    assert _find_wide_games(games, {'wide_cell_featured': False, 'primary': 'NYY'}, _FEAT_TD) == set()
+
+
+# ---------------------------------------------------------------------------
 # 3. End-to-end grid with wide cells
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
New config flag **`wide_cell_featured`** (default `false`, preserving prior behavior).

When enabled:
- The wide (2-cell) tile always goes to the **featured/primary team's game while it is live** — even with 15+ games on the slate.
- If the featured team isn't playing live, it **falls back to the game farthest along** (the previous default pick).
- When the grid can only fit one wide cell and multiple games are live, the featured live game **outranks** a farther-along game.

## Difference from `wide_cell_always`
- `wide_cell_always` → one wide cell = the game **farthest along** (raw progress).
- `wide_cell_featured` → one wide cell = the **featured team's** game if live, else farthest along.

Both can show a wide cell even at 15+ games; they only differ in *which* game is chosen.

## Test plan
- [x] `tests/test_wide_cell.py` — featured-live-at-15, fallback-to-latest, featured-preferred-when-capping, default-off-preserves-old-behavior; 32 wide-cell tests pass, 483 total
- [ ] On-device: enable `wide_cell_featured`, confirm the primary team's live game is the 2-cell tile and it reverts to the latest game when the primary isn't live

🤖 Generated with [Claude Code](https://claude.com/claude-code)