### PR TITLE
Suppress docs push failure when branch protection blocks

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -63,5 +63,5 @@ jobs:
             echo "No screenshot changes — nothing to commit."
           else
             git commit -m "chore: refresh docs screenshots [skip ci]"
-            git push
+            git push || echo "Push blocked by branch protection — grant github-actions[bot] bypass in Settings → Branches to enable auto-commit."
           fi


### PR DESCRIPTION
Workflow was failing red because `git push` to the protected `main` branch is blocked. This makes it exit gracefully with a message instead.

**Real fix:** Settings → Branches → main protection rule → "Allow specified actors to bypass required pull requests" → add `github-actions[bot]`. That re-enables actual screenshot auto-commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_017wo4tmusNEMrR1Uw8i2pXn