### PR TITLE
Force full e-ink refresh during morning alternating mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -553,7 +553,13 @@ Examples:
     image, changed_regions = result
 
     # 9. Send to display
-    refresh_mode = send_to_display(output_path, changed_regions)
+    # Morning alternating mode swaps the entire screen between last night's
+    # results and today's schedule every 5 minutes — a partial refresh can't
+    # fully clear the previous frame's residual charge across a change that
+    # large, causing visible ghosting/bleeding. Force a full (flashing)
+    # refresh on every render during this window instead.
+    _force_full = _morning_block is not None
+    refresh_mode = send_to_display(output_path, changed_regions, force_full=_force_full)
     print(f"Scoreboard: {refresh_mode} refresh ({len(changed_regions)} region(s))")
 
     print("\n✓ Display updated successfully!")


### PR DESCRIPTION
## What

During `morning_alternate_games` mode (between `night_end` and `morning_end`), the display swaps entirely between last night's results and today's schedule every 5 minutes. `send_to_display()` was called without `force_full`, so unless the hourly burn-in-prevention timer happened to coincide, every one of those swaps went through `display_partial_regions()` — a partial refresh that doesn't clear the e-ink panel's residual charge.

## Why this causes bleeding

Partial refresh is fine for small incremental changes (a score ticking up), but here the *entire* screen content changes — completely different games, completely different pixel patterns — every 5 minutes for up to 2-4 hours (longer on weekends via `morning_end_weekend`). Repeated full-content swaps without a clearing flash accumulate into visible ghosting.

## Fix

Force a full (flashing) refresh on every render while `_morning_block` is set — i.e. only during the actual alternating window. The non-alternating pre-9am path (always showing yesterday, `morning_alternate_games: false`) is untouched since there's no back-and-forth there to cause the issue.

## Test plan

- [x] Manually verified the branch logic across the whole morning window (weekday + weekend `morning_end`, `morning_alternate_games` on/off) — `force_full` is `True` exactly during alternating blocks, `False` everywhere else
- [x] `poetry run pytest -q --cov` — 1524 passed, 99.34% coverage (unchanged — `main.py` isn't part of the measured `src/` surface, consistent with the rest of the orchestrator having no dedicated unit tests)
- [x] `poetry run ruff check .` / `poetry run mypy` — clean
- [ ] Confirm on real hardware next morning that the 7-9am alternation no longer ghosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnZxyMkqK6dVzExpo52mMZ