### PR TITLE
Pack wide scoreboard tiles bottom-up with zero gaps

### DIFF
--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -1,4 +1,5 @@
 import os
+from collections import deque
 # import socket  # disabled with QR code feature
 
 # import qrcode  # disabled — not supported on this Pi build
@@ -32,9 +33,9 @@ def _find_wide_games(game_list, config, team_data):
     farthest along. Like wide_cell_always, this shows a wide cell even with 15+
     games — but the choice prefers the featured team over raw game progress.
 
-    Geometry fix-up (col=4 conflicts) is handled separately by _reorder_for_wide,
-    which swaps in-progress games with adjacent normal games so they land at a
-    valid column. This function selects purely by priority.
+    Geometry fix-up (col=4 conflicts) is handled separately in
+    compute_grid_layout's slot builder, which skips a wide game to the next
+    row rather than dropping it. This function selects purely by priority.
 
     A game under review ('Player challenge'/'Manager challenge') is still live —
     it is treated as in-progress so it keeps its wide tile instead of collapsing
@@ -92,50 +93,125 @@ def _find_wide_games(game_list, config, team_data):
     return set()
 
 
-def _reorder_for_wide(game_list, wide_set):
-    """Reorder game_list so every game in wide_set can actually render wide.
+def _pack_grid(game_list, wide_set):
+    """Pack games into 5-unit-wide rows, filling every row completely (no
+    blank gap columns) while pushing wide (2-cell) tiles into the lowest
+    rows the zero-gap constraint allows.
 
-    A wide cell must start at col 0-3 (can't span from col 4 into col 5).
-    When a wide game lands at col 4, swap it with the normal game immediately
-    after it; the wide game shifts to col 0 of the next row and can span right.
-    If the next game is also wide (can't swap), drop the conflicting wide game.
+    Index 0 (the favorite team's game when favorite_team_first is set) is
+    always placed first, in row 0 col 0 — it must stay the most prominent
+    tile regardless of wide-cell placement.
 
-    Returns (new_game_list, new_wide_set).
+    Everything else is allocated row-by-row from the BOTTOM of the grid
+    upward: the last row is filled first (as many wide tiles as fit, 2 units
+    each, then normal games as filler), then the row above it, and so on,
+    ending with whatever capacity is left in row 0 after the pinned game.
+    Filling bottom-up like this means a row only takes fewer wide tiles than
+    it could when there simply aren't enough left — the densest wide rows
+    always end up lowest. Within each row, later-queued wide/normal games
+    are preferred for lower rows so original relative order still reads
+    top-to-bottom.
+
+    Only the very last row may end up short (fewer than 5 units) since
+    there's nothing left to place there — that's a normal grid edge, not a
+    gap. If there are more games than the 15-slot grid can hold, this falls
+    back to simple front-to-back packing for the overflow, since some games
+    won't be shown regardless of arrangement.
+
+    Returns (new_game_list, positions) where positions is a list of
+    (slot_type, grid_col, grid_row) parallel to new_game_list.
     """
-    game_list = list(game_list)
-    wide_set = set(wide_set)
+    if not game_list:
+        return [], []
 
-    for _ in range(len(wide_set) + 1):  # converges in at most one pass per wide game
-        slot = 0
-        conflict = None
-        for gi in range(len(game_list)):
-            if slot >= 15:
-                break
-            col = slot % 5
-            if gi in wide_set:
-                if col >= 4:
-                    conflict = gi
-                    break
-                slot += 2
+    pinned_wide = 0 in wide_set
+    pinned_cost = 2 if pinned_wide else 1
+
+    rest = range(1, len(game_list))
+    wide_queue = [i for i in rest if i in wide_set]
+    normal_queue = [i for i in rest if i not in wide_set]
+
+    remaining_capacity = 15 - pinned_cost
+    total_wanted = 2 * len(wide_queue) + len(normal_queue)
+
+    new_order = [0]
+    positions = [('wide', 0, 0) if pinned_wide else ('normal', 0, 0)]
+
+    if total_wanted > remaining_capacity:
+        # More games than the grid can hold — no reordering can fit them
+        # all, so just pack front-to-back (wide-first) up to the cap.
+        slot_idx = pinned_cost
+        wi = ni = 0
+        while slot_idx < 15 and (wi < len(wide_queue) or ni < len(normal_queue)):
+            col = slot_idx % 5
+            row = slot_idx // 5
+            cap_left = 5 - col
+            if wi < len(wide_queue) and cap_left >= 2:
+                new_order.append(wide_queue[wi])
+                positions.append(('wide', col, row))
+                wi += 1
+                slot_idx += 2
+            elif ni < len(normal_queue):
+                new_order.append(normal_queue[ni])
+                positions.append(('normal', col, row))
+                ni += 1
+                slot_idx += 1
+            elif wi < len(wide_queue) and cap_left == 1:
+                slot_idx += cap_left
             else:
-                slot += 1
+                break
+        return [game_list[i] for i in new_order], positions
 
-        if conflict is None:
-            break
+    # No overflow: split the remaining capacity into row-sized buckets —
+    # row 0's leftover space after the pin, then full 5-unit rows, ending
+    # with whatever's left over (the trailing row, possibly short).
+    row_caps = [5 - pinned_cost]
+    left = total_wanted - row_caps[0]
+    while left > 5:
+        row_caps.append(5)
+        left -= 5
+    if left > 0 or len(row_caps) == 1:
+        row_caps.append(left)
 
-        b = conflict
-        next_b = b + 1
-        if next_b < len(game_list) and next_b not in wide_set:
-            game_list[b], game_list[next_b] = game_list[next_b], game_list[b]
-            wide_set.discard(b)
-            wide_set.add(next_b)
-        else:
-            wide_set.discard(b)
+    # Fill buckets from the last (bottom) to the first (row 0's leftover),
+    # taking wide games first (2 units each) then normal as filler. Pop from
+    # the end of each queue so later-queued games land in lower rows,
+    # keeping original relative order reading top-to-bottom overall.
+    wide_dq = deque(wide_queue)
+    normal_dq = deque(normal_queue)
+    bucket_tokens = [None] * len(row_caps)
+    for bi in range(len(row_caps) - 1, -1, -1):
+        cap = row_caps[bi]
+        wide_tokens = []
+        normal_tokens = []
+        while cap >= 2 and wide_dq:
+            wide_tokens.append(('wide', wide_dq.pop()))
+            cap -= 2
+        while cap >= 1 and normal_dq:
+            normal_tokens.append(('normal', normal_dq.pop()))
+            cap -= 1
+        # Each pop() took the highest-index (latest) remaining game for this
+        # row; reverse each group back to ascending order, wide tiles first
+        # (leading columns) so they read left-to-right like a normal row.
+        wide_tokens.reverse()
+        normal_tokens.reverse()
+        bucket_tokens[bi] = wide_tokens + normal_tokens
 
-    return game_list, wide_set
+    slot_idx = pinned_cost
+    for tokens in bucket_tokens:
+        row = slot_idx // 5
+        col = slot_idx % 5
+        for slot_type, gi in tokens:
+            new_order.append(gi)
+            positions.append((slot_type, col, row))
+            step = 2 if slot_type == 'wide' else 1
+            col += step
+            slot_idx += step
+
+    return [game_list[i] for i in new_order], positions
 
 
-def _move_non_live_to_fillers(game_list, wide_set):
+def _move_non_live_to_fillers(game_list, positions):
     """Swap live games out of filler slots in wide rows.
 
     Every row that contains a wide (2-cell) tile must also have at least one
@@ -144,27 +220,17 @@ def _move_non_live_to_fillers(game_list, wide_set):
     game wasted in a narrow filler cell is better placed as a normal single
     cell in a non-wide row.
 
+    ``positions`` is the (slot_type, col, row) list already computed for
+    ``game_list`` (by _pack_grid) — swapping two games that both sit in
+    'normal' slots never changes the geometry, so this can reshuffle
+    game_list in place without needing to recompute positions afterward.
+
     Scans the visible 15-slot boundary for live games sitting in filler slots
     (normal cells whose row contains at least one wide tile) and swaps each
     with the last non-live normal game from a non-wide row, perturbing the
     ordering as little as possible.  Returns the updated game_list.
     """
     game_list = list(game_list)
-
-    # Simulate slot positions for every game within the 15-unit boundary.
-    positions = []
-    slot_idx = 0
-    for gi in range(len(game_list)):
-        if slot_idx >= 15:
-            break
-        col = slot_idx % 5
-        row = slot_idx // 5
-        if gi in wide_set and col < 4:
-            positions.append(('wide', col, row))
-            slot_idx += 2
-        else:
-            positions.append(('normal', col, row))
-            slot_idx += 1
 
     wide_rows = {pos[2] for pos in positions if pos[0] == 'wide'}
     if not wide_rows:
@@ -233,34 +299,16 @@ def compute_grid_layout(game_state_data, team_data, config):
             game_list.remove(_ppd_g)
             game_list.append(_ppd_g)
 
-    # Determine which games show as wide (2-cell) tiles, then reorder so any
-    # wide game that would land at col=4 swaps with the normal game after it.
-    # Finally, move non-live games into the filler single-cell slots that exist
-    # in every wide row (e.g. 2-wide + 1-filler = 5 cols) so a live game never
-    # sits in a filler slot when a finished or not-yet-started game can take it.
+    # Determine which games show as wide (2-cell) tiles, then pack the grid
+    # row by row so normal games fill in around them with zero gaps (see
+    # _pack_grid). Finally, move non-live games into the filler single-cell
+    # slots that exist in every wide row (e.g. 2-wide + 1-filler = 5 cols) so
+    # a live game never sits in a filler slot when a finished or
+    # not-yet-started game can take it instead.
     _wide_set = _find_wide_games(game_list, config, team_data)
     if _wide_set:
-        game_list, _wide_set = _reorder_for_wide(game_list, _wide_set)
-        game_list = _move_non_live_to_fillers(game_list, _wide_set)
-
-    # Build an ordered list of (slot_type, grid_col, grid_row).
-    # Each wide game consumes 2 horizontal slot units; normal games consume 1.
-    # Wide games on the last column (col 4) fall back to normal (can't span right).
-    # Stop adding slots once the 5×3 grid is full (15 slot units).
-    if _wide_set:
-        _slots = []
-        _slot_idx = 0
-        for _gi in range(len(game_list)):
-            if _slot_idx >= 15:
-                break
-            _row = _slot_idx // 5
-            _col = _slot_idx % 5
-            if _gi in _wide_set and _col < 4:
-                _slots.append(('wide', _col, _row))
-                _slot_idx += 2
-            else:
-                _slots.append(('normal', _col, _row))
-                _slot_idx += 1
+        game_list, _slots = _pack_grid(game_list, _wide_set)
+        game_list = _move_non_live_to_fillers(game_list, _slots)
     else:
         _slots = [('normal', _gi % 5, _gi // 5) for _gi in range(len(game_list))]
 

--- a/tests/test_image_grid.py
+++ b/tests/test_image_grid.py
@@ -6,7 +6,7 @@ This file covers the still-active helpers.
 """
 import pytest
 
-from image_grid import _free_grid_slot, compute_grid_layout, _find_wide_games, _reorder_for_wide, _move_non_live_to_fillers
+from image_grid import _free_grid_slot, compute_grid_layout, _find_wide_games, _move_non_live_to_fillers
 
 
 # ---------------------------------------------------------------------------
@@ -38,47 +38,6 @@ class TestFreeGridSlot:
         slots = [('normal', 0, 0), ('normal', 1, 0), ('normal', 2, 0),
                  ('wide', 3, 0)]   # occupies col 3 and 4
         assert _free_grid_slot(slots) == (0, 1)
-
-
-# ---------------------------------------------------------------------------
-# _reorder_for_wide
-# ---------------------------------------------------------------------------
-
-class TestReorderForWide:
-    def _games(self, n):
-        return [{'game_pk': i} for i in range(n)]
-
-    def test_no_wide_games_returns_unchanged(self):
-        games = self._games(5)
-        new_games, new_wide = _reorder_for_wide(games, set())
-        assert [g['game_pk'] for g in new_games] == list(range(5))
-        assert new_wide == set()
-
-    def test_wide_game_at_col4_swaps_with_next(self):
-        # 5 games → slots 0-4; game at index 4 would be col=4; swap with next
-        games = self._games(6)  # 6 games; game[4] lands at col=4, swap with game[5]
-        wide_set = {4}
-        new_games, new_wide = _reorder_for_wide(games, wide_set)
-        # game[4] and game[5] should have been swapped
-        assert new_games[4]['game_pk'] == 5
-        assert new_games[5]['game_pk'] == 4
-        assert 5 in new_wide
-
-    def test_wide_game_not_at_col4_unchanged(self):
-        games = self._games(5)
-        wide_set = {0}  # col=0 — no conflict
-        new_games, new_wide = _reorder_for_wide(games, wide_set)
-        assert [g['game_pk'] for g in new_games] == list(range(5))
-        assert new_wide == {0}
-
-    def test_conflict_with_another_wide_drops_the_conflicting_game(self):
-        # Two consecutive wide games starting at col=3 (wide at 3, wide at 5?)
-        # Actually: index 4 is col=4. If the next game is also wide, can't swap → drop.
-        games = self._games(6)
-        wide_set = {4, 5}
-        new_games, new_wide = _reorder_for_wide(games, wide_set)
-        # The one at col=4 should have been dropped from wide_set
-        assert len(new_wide) <= 1
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +192,12 @@ class TestMoveNonLiveToFillers:
     def _g(self, pk, state='Scheduled'):
         return {'game_pk': pk, 'detailed_state': state}
 
+    # positions parallel to a 5-game row0 wide/wide/filler + row1 layout
+    _ROW0_WIDE_WIDE_FILLER = [
+        ('wide', 0, 0), ('wide', 2, 0), ('normal', 4, 0),
+        ('normal', 0, 1), ('normal', 1, 1),
+    ]
+
     def test_live_in_only_filler_slot_gets_swapped(self):
         # Two wide games at indices 0,1 leave a filler at index 2 (col=4, row=0).
         # If index 2 is live it should be swapped with a non-live game from row 1+.
@@ -243,7 +208,7 @@ class TestMoveNonLiveToFillers:
             self._g(3, self._SCHED),  # row 1, col 0 — candidate for swap
             self._g(4, self._SCHED),
         ]
-        result = _move_non_live_to_fillers(games, {0, 1})
+        result = _move_non_live_to_fillers(games, self._ROW0_WIDE_WIDE_FILLER)
         filler_game = result[2]
         assert filler_game['detailed_state'] != self._LIVE
 
@@ -257,12 +222,13 @@ class TestMoveNonLiveToFillers:
             self._g(4, self._SCHED),
         ]
         original = [g['game_pk'] for g in games]
-        result = _move_non_live_to_fillers(games, {0, 1})
+        result = _move_non_live_to_fillers(games, self._ROW0_WIDE_WIDE_FILLER)
         assert [g['game_pk'] for g in result] == original
 
     def test_no_wide_games_no_change(self):
         games = [self._g(i, self._SCHED) for i in range(5)]
-        result = _move_non_live_to_fillers(games, set())
+        positions = [('normal', i, 0) for i in range(5)]
+        result = _move_non_live_to_fillers(games, positions)
         assert [g['game_pk'] for g in result] == list(range(5))
 
     def test_all_games_preserved(self):
@@ -274,7 +240,7 @@ class TestMoveNonLiveToFillers:
             self._g(3, self._SCHED),
             self._g(4, self._DONE),
         ]
-        result = _move_non_live_to_fillers(games, {0, 1})
+        result = _move_non_live_to_fillers(games, self._ROW0_WIDE_WIDE_FILLER)
         assert {g['game_pk'] for g in result} == {0, 1, 2, 3, 4}
 
     def test_index_zero_never_displaced_to_filler(self):
@@ -287,5 +253,9 @@ class TestMoveNonLiveToFillers:
             self._g(3, self._LIVE),   # filler at col=4 — needs a non-live swap
             # No other non-live games available except index 0
         ]
-        result = _move_non_live_to_fillers(games, {1, 2})
+        # index 0 sits outside the wide row (row 1); row 0 is wide/wide/filler.
+        positions = [
+            ('normal', 0, 1), ('wide', 0, 0), ('wide', 2, 0), ('normal', 4, 0),
+        ]
+        result = _move_non_live_to_fillers(games, positions)
         assert result[0]['game_pk'] == 0  # featured game stays first

--- a/tests/test_wide_cell.py
+++ b/tests/test_wide_cell.py
@@ -602,10 +602,11 @@ def test_grid_15_games_wide_cell_always(white_image, team_data):
 
 @needs_pil
 def test_compute_grid_layout_two_wide_at_col0():
-    """Two in-progress games on a 13-game slate both land at col 0 (reordered)."""
+    """Two in-progress games on a 13-game slate both get wide tiles at col 0.
+    The first is pinned to row 0 (index 0, no favorite_team_first reorder
+    needed since it's already first); the second is pushed down to the
+    lowest row the zero-gap constraint allows rather than sharing row 0."""
     from image_grid import compute_grid_layout
-    # In-progress games at indices 0 and 3; reorder pushes the second to col 0
-    # of row 1 instead of leaving it stranded at col 4.
     games = _make_game_list(
         [('In Progress', 7, 'Top'),                       # 0
          ('Final', 9, 'End'), ('Final', 9, 'End'),         # 1, 2
@@ -616,21 +617,10 @@ def test_compute_grid_layout_two_wide_at_col0():
     wide_slots = [(gl.get('game_pk'), s) for gl, s in zip(game_list, slots)
                   if s[0] == 'wide']
     assert len(wide_slots) == 2
-    # Both wide tiles begin at column 0 so each can span rightward.
-    assert all(s[1] == 0 for _, s in wide_slots)
-
-
-def test_reorder_for_wide_stops_scanning_at_slot_cap():
-    """_reorder_for_wide's inner scan must stop once slot >= 15 even if more
-    games remain — the grid only has 15 slot units, so scanning further is
-    pointless. A single wide game at col 0 needs no swap; with 20 games the
-    scan should hit the slot>=15 guard before exhausting the list."""
-    from image_grid import _reorder_for_wide
-    game_list = [{'game_pk': i} for i in range(20)]
-    new_list, new_wide = _reorder_for_wide(game_list, {0})
-    # No conflict ever found (wide game already at col 0) so nothing changes.
-    assert new_wide == {0}
-    assert new_list == game_list
+    # Both wide tiles begin at col 0 (each leads its own row); the second one
+    # is pushed to the lowest row (row 2) rather than sharing row 0.
+    assert {s[1] for _, s in wide_slots} == {0}
+    assert {s[2] for _, s in wide_slots} == {0, 2}
 
 
 def test_compute_grid_layout_favorite_team_first_moves_game_to_front():
@@ -663,8 +653,9 @@ def test_compute_grid_layout_pushes_rainout_past_doubleheader():
 
 def test_compute_grid_layout_slot_building_stops_at_capacity():
     """With 16 games and one forced wide cell, the wide tile consumes 2 slot
-    units, so total slot demand (17) exceeds the 15-unit grid — the slot-
-    building loop must stop early instead of indexing past the grid."""
+    units, so total slot demand (17) exceeds the 15-unit grid — the packer
+    must stop placing games once 15 slot units are used rather than indexing
+    past the grid. The excluded game(s) simply aren't rendered."""
     from image_grid import compute_grid_layout
     games = _make_game_list(
         [('In Progress', 5, 'Top')] + [('Final', 9, 'End')] * 15
@@ -672,7 +663,7 @@ def test_compute_grid_layout_slot_building_stops_at_capacity():
     assert len(games) == 16
     config = {'wide_cell_always': True}
     game_list, slots = compute_grid_layout(games, {}, config)
-    assert len(slots) < len(game_list)
+    assert len(slots) == len(game_list) < 16
     assert any(s[0] == 'wide' for s in slots)
 
 


### PR DESCRIPTION
## Summary
- Fixed a bug where a live in-progress game would lose its wide (2-cell) tile whenever it landed back-to-back with another wide game at grid column 4 — the old geometry fixup just demoted it to a normal cell even when there was budget for both to be wide.
- Replaced the reorder/demote logic with `_pack_grid`, a row packer that fills every grid row completely (moving normal games around as filler) and pushes wide tiles into the lowest possible rows, so denser wide rows sink to the bottom of the display.
- Updated `_move_non_live_to_fillers` to operate on the packer's precomputed slot positions instead of re-deriving geometry, removing a source of drift between the two.

## Test plan
- [x] Full test suite passes (1519 passed, 15 skipped)
- [x] Verified against real `data/games.json` (3 in-progress games out of 8): all 3 now render as wide tiles with zero gaps, pushed to the lowest rows
- [x] Rendered actual scoreboard PNG and visually confirmed correct layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)