### PR TITLE
Shift tied-team --- divider up 1 more pixel

### DIFF
--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -466,8 +466,8 @@ def draw_standings_sidebar(Himage, standings_data, team_data, side='left', leagu
                 if cur_wl == nxt_wl:
                     # Center the 2px-tall dash strip in the gap between logos.
                     # (slot_h - logo_size - 2) // 2 leaves equal empty rows above and below;
-                    # shifted up 1px from center.
-                    gap_y = logo_y + _SIDEBAR_LOGO_SIZE + (slot_h - _SIDEBAR_LOGO_SIZE - 2) // 2 - 1
+                    # shifted up 2px from center.
+                    gap_y = logo_y + _SIDEBAR_LOGO_SIZE + (slot_h - _SIDEBAR_LOGO_SIZE - 2) // 2 - 2
                     dash_w, gap_w = 4, 2
                     total_dash_w = 3 * dash_w + 2 * gap_w
                     dash_start = 4 if side == 'left' else 800 - total_dash_w - 4


### PR DESCRIPTION
## Summary
- Nudges the tied-team `---` divider in the standings sidebar up 1 more pixel (now 2px above vertical center, total).

## Test plan
- [x] Standings tests pass (117 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)