### PR TITLE
Force full e-ink refresh when the scoreboard grid reshuffles

### DIFF
--- a/main.py
+++ b/main.py
@@ -558,7 +558,15 @@ Examples:
     # fully clear the previous frame's residual charge across a change that
     # large, causing visible ghosting/bleeding. Force a full (flashing)
     # refresh on every render during this window instead.
-    _force_full = _morning_block is not None
+    #
+    # Also force a full refresh whenever the scoreboard grid packing shifted
+    # a game to a different cell (e.g. another game going live repacked the
+    # wide-cell layout) — orchestrate_score_board flags this in
+    # force_full_refresh.json since a game whose own data is unchanged never
+    # gets a partial-refresh region, leaving its old cell showing a stale
+    # game behind.
+    _layout_changed = load_json_file('force_full_refresh.json').get('needed', False)
+    _force_full = _morning_block is not None or _layout_changed
     refresh_mode = send_to_display(output_path, changed_regions, force_full=_force_full)
     print(f"Scoreboard: {refresh_mode} refresh ({len(changed_regions)} region(s))")
 

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -300,4 +300,24 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
     if len(changed_regions) >= 10:
         changed_regions = [(0, 0, 800, 480)]
 
+    # A game can shift to a different cell purely because another game's live
+    # state changed the grid packing (see _pack_grid in image_grid.py) — its
+    # own data is identical, so it's never in refreshed_game_ids and its old
+    # cell never gets marked for partial refresh. Partial refresh only
+    # touches the regions we hand it, so that old cell keeps showing the
+    # stale game underneath (ghosting) until something else happens to touch
+    # it. Detect any such reshuffle and signal main.py to force a true full
+    # (flashing) refresh instead, which repaints the entire screen.
+    layout_changed = False
+    if not bypass_cache:
+        new_positions = {
+            str(game.get('game_pk', '')): list(slot_info)
+            for game, slot_info in zip(_ordered, _slots)
+            if game.get('game_pk', '')
+        }
+        old_positions = load_json_file('old_grid_positions.json') or {}
+        layout_changed = new_positions != old_positions
+        save_off_results(new_positions, 'old_grid_positions')
+        save_off_results({'needed': layout_changed}, 'force_full_refresh')
+
     return (Himage, changed_regions)

--- a/tests/test_generate_image_orchestrate.py
+++ b/tests/test_generate_image_orchestrate.py
@@ -886,3 +886,141 @@ def test_playoff_bracket_header_drawn_when_bracket_data_present():
 
     mock_bracket.assert_called_once()
     assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# force_full_refresh.json — a game shifting cells due to a repack (even with
+# its own data unchanged) must be flagged so main.py forces a true full
+# refresh instead of a partial one, since partial refresh never touches a
+# cell whose occupant's own data didn't change.
+# ---------------------------------------------------------------------------
+
+def _force_full_flag(mock_save):
+    """Pull the {'needed': bool} dict saved under 'force_full_refresh' out of
+    a mocked generate_image.save_off_results call list."""
+    for call in mock_save.call_args_list:
+        args = call.args
+        if len(args) >= 2 and args[1] == 'force_full_refresh':
+            return args[0]['needed']
+    raise AssertionError("save_off_results was never called with 'force_full_refresh'")
+
+
+@needs_pil
+def test_layout_reshuffle_forces_full_refresh_flag():
+    """game3's own data is identical between old and new, but game2 going
+    live repacks the grid (adds a wide tile) and pushes game3 from col 2 to
+    col 3. Partial refresh would never touch game3's old cell (col 2, not in
+    refreshed_game_ids), leaving the previous occupant's pixels stranded
+    there — so this must flag force_full_refresh.json as needed."""
+    import generate_image
+    import image_box
+
+    old_games = [
+        _base_game(game_pk=1),
+        _base_game(game_pk=2),
+        _base_game(game_pk=3),
+    ]
+    # Previously persisted layout for the 3-normal-game arrangement above:
+    # simple left-to-right, no wide games, no reordering.
+    old_positions = {
+        '1': ['normal', 0, 0],
+        '2': ['normal', 1, 0],
+        '3': ['normal', 2, 0],
+    }
+    new_games = [
+        _base_game(game_pk=1),
+        _live_game(game_pk=2),
+        _base_game(game_pk=3),
+    ]
+
+    mock_save = MagicMock()
+    with patch('generate_image.load_json_file',
+               side_effect=_fake_loader({
+                   'old_scoreboard_state.json': old_games,
+                   'old_grid_positions.json': old_positions,
+               })), \
+         patch('generate_image.save_off_results', mock_save), \
+         patch('image_grid.load_yaml_file', return_value=FIXED_CONFIG), \
+         patch('image_box.load_yaml_file', return_value=FIXED_CONFIG):
+        image_box.set_historical_mode(True)
+        try:
+            result = generate_image.orchestrate_score_board(
+                new_games, TEAM_DATA, date_str='2026-06-20', bypass_cache=False, config=FIXED_CONFIG,
+            )
+        finally:
+            image_box.set_historical_mode(False)
+
+    assert result is not None
+    assert _force_full_flag(mock_save) is True
+
+
+@needs_pil
+def test_unchanged_layout_does_not_force_full_refresh_flag():
+    """A score change alone (no live-state shift, no repack) must not flag
+    force_full_refresh.json — the grid arrangement is identical to last
+    render, so ordinary partial refresh is safe."""
+    import generate_image
+    import image_box
+
+    old_games = [
+        _base_game(game_pk=1, away_runs=1),
+        _base_game(game_pk=2),
+        _base_game(game_pk=3),
+    ]
+    old_positions = {
+        '1': ['normal', 0, 0],
+        '2': ['normal', 1, 0],
+        '3': ['normal', 2, 0],
+    }
+    new_games = [
+        _base_game(game_pk=1, away_runs=9),
+        _base_game(game_pk=2),
+        _base_game(game_pk=3),
+    ]
+
+    mock_save = MagicMock()
+    with patch('generate_image.load_json_file',
+               side_effect=_fake_loader({
+                   'old_scoreboard_state.json': old_games,
+                   'old_grid_positions.json': old_positions,
+               })), \
+         patch('generate_image.save_off_results', mock_save), \
+         patch('image_grid.load_yaml_file', return_value=FIXED_CONFIG), \
+         patch('image_box.load_yaml_file', return_value=FIXED_CONFIG):
+        image_box.set_historical_mode(True)
+        try:
+            result = generate_image.orchestrate_score_board(
+                new_games, TEAM_DATA, date_str='2026-06-20', bypass_cache=False, config=FIXED_CONFIG,
+            )
+        finally:
+            image_box.set_historical_mode(False)
+
+    assert result is not None
+    assert _force_full_flag(mock_save) is False
+
+
+@needs_pil
+def test_bypass_cache_skips_force_full_refresh_bookkeeping():
+    """bypass_cache=True (timelapse/GIF generation) must never write
+    force_full_refresh.json or old_grid_positions.json — those files drive
+    the live display pipeline only."""
+    import generate_image
+    import image_box
+
+    mock_save = MagicMock()
+    with patch('generate_image.load_json_file', return_value={}), \
+         patch('generate_image.save_off_results', mock_save), \
+         patch('image_grid.load_yaml_file', return_value=FIXED_CONFIG), \
+         patch('image_box.load_yaml_file', return_value=FIXED_CONFIG):
+        image_box.set_historical_mode(True)
+        try:
+            generate_image.orchestrate_score_board(
+                [_base_game(game_pk=1)], TEAM_DATA, date_str='2026-06-20',
+                bypass_cache=True, config=FIXED_CONFIG,
+            )
+        finally:
+            image_box.set_historical_mode(False)
+
+    saved_files = {call.args[1] for call in mock_save.call_args_list if len(call.args) >= 2}
+    assert 'force_full_refresh' not in saved_files
+    assert 'old_grid_positions' not in saved_files


### PR DESCRIPTION
## Summary
- Fixed ghosting: when a live-state change (e.g. a game going live) repacks the grid via `_pack_grid`, other games can shift to a different cell even though their own data is unchanged — partial refresh never marks those cells since only per-game data changes are tracked, so their old cell kept showing the previous occupant on the physical e-ink display.
- `orchestrate_score_board` now persists the computed grid layout (`old_grid_positions.json`) each render and writes `force_full_refresh.json` when any game's position differs from the previous render.
- `main.py` ORs this new signal into the existing `_force_full` check (alongside the morning-alternating-mode case) so a true full (flashing) refresh happens instead of a partial one whenever the layout reshuffles.

## Test plan
- [x] Full test suite passes (1522 passed, 15 skipped)
- [x] Added tests: layout reshuffle flags `needed: True`, unchanged layout flags `needed: False`, `bypass_cache=True` (timelapse/GIF) never writes these files
- [x] Verified manually against real `data/games.json` via `render_scoreboard.py` — flag file written correctly on first render and after data-only (no layout) changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)