### PR TITLE
Fix partial-refresh buffer overrun blanking first display column

### DIFF
--- a/src/waveshare_epd/epd7in5_V2.py
+++ b/src/waveshare_epd/epd7in5_V2.py
@@ -263,7 +263,7 @@ class EPD:
         self.send_data ((Yend-1)%256)  #y-end
         self.send_data (0x01)
 
-        image1 = [0xFF] * int(self.width * self.height / 8)
+        image1 = [0xFF] * (Width * Height)
         for j in range(Height):
                 for i in range(Width):
                     image1[i + j * Width] = ~Image[i + j * Width]


### PR DESCRIPTION
## Summary
- `display_Partial()` in `epd7in5_V2.py` allocated its outgoing SPI buffer at full-screen size (800*480/8 bytes) instead of the partial window's `Width * Height` bytes, then sent the whole oversized buffer for every partial refresh.
- The panel's partial-window RAM write only expects `Width*Height` bytes; the extra data overran the window and wrapped back to the start of the panel's frame buffer, which blanked the first display column on every partial update (reported: first column blanks only on partial refresh, never on full refresh).
- Fix: size `image1` to `Width * Height`, matching what the panel's partial window expects.

## Test plan
- [ ] Deploy to the Pi and trigger a partial-refresh update (e.g. one game's score changes) — confirm the first column no longer blanks.
- [ ] Confirm full refresh still works as before.
- [ ] `poetry run pytest` (already passing locally; hardware path is a no-op on macOS since `epd7in5_V2` isn't imported on Darwin).