### PR TITLE
Compute grid layout once per render, shared by drawing and refresh regions

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -252,7 +252,14 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
 
     # --- Normal scoreboard grid ---
     Himage = Image.new('1', (800, 480), 255)
-    Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob)
+    # Compute the grid layout once and share it with both the renderer and the
+    # partial-refresh region/reshuffle-detection math below — two independent
+    # compute_grid_layout() calls can silently diverge (e.g. config.yaml
+    # edited mid-render by the phone config server), leaving stale/blank
+    # cells behind since the refresh regions would no longer match what was
+    # actually drawn.
+    _ordered, _slots = compute_grid_layout(game_state_data, team_data, config)
+    Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob, layout=(_ordered, _slots))
 
     standings_data = None
     if config.get('show_wildcard_standings', False) or config.get('show_standings_sidebar', False):
@@ -276,12 +283,12 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         Himage = ImageOps.invert(Himage.convert('L')).convert('1')
 
     # --- Compute changed regions from changed_game_ids ---
-    # Use the exact same layout draw_out_of_town_score_board used, so wide
-    # (2-cell) games — which consume two slot units and may be reordered —
-    # get a region that covers the whole tile rather than only its left half.
+    # Reuses the exact _ordered/_slots draw_out_of_town_score_board was given
+    # above, so wide (2-cell) games — which consume two slot units and may be
+    # reordered — get a region that covers the whole tile rather than only
+    # its left half.
     x_start = 32
     y_start = 30
-    _ordered, _slots = compute_grid_layout(game_state_data, team_data, config)
     changed_regions = []
     for game, slot_info in zip(_ordered, _slots):
         slot_type, gx, gy = slot_info

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -356,7 +356,7 @@ def _free_grid_slot(slots):
 #     return Himage
 
 
-def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=None, changed_game_ids=None, use_logos=False, logo_x_offset=2, show_win_prob=False):
+def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=None, changed_game_ids=None, use_logos=False, logo_x_offset=2, show_win_prob=False, layout=None):
 
     draw = ImageDraw.Draw(Himage)
     config = load_yaml_file('config.yaml')
@@ -400,7 +400,17 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
     x_start = 32
     y_start = 30
 
-    game_list, _slots = compute_grid_layout(game_state_data, team_data, config)
+    # Accept a precomputed (game_list, slots) so callers that also need the
+    # layout for partial-refresh region math (generate_image.py) can compute
+    # it once and share it — two independent calls to compute_grid_layout
+    # (even with "the same" inputs) can silently diverge if config.yaml is
+    # edited mid-render (e.g. via the phone config server), since this
+    # function reloads config from disk itself while a caller-supplied
+    # layout was computed from whatever config snapshot it already had.
+    if layout is not None:
+        game_list, _slots = layout
+    else:
+        game_list, _slots = compute_grid_layout(game_state_data, team_data, config)
 
     # Build per-team stats lookup {str(team_id): {'streak', 'l10_wins', 'l10_losses', 'wins', 'losses'}}
     _standings = load_json_file('standings.json')

--- a/tests/test_generate_image_orchestrate.py
+++ b/tests/test_generate_image_orchestrate.py
@@ -506,6 +506,55 @@ def test_changed_region_for_normal_game_is_single_cell_width():
 
 
 @needs_pil
+def test_compute_grid_layout_called_once_per_render():
+    """orchestrate_score_board must compute the grid layout exactly once and
+    share it with draw_out_of_town_score_board, not call compute_grid_layout
+    independently in each place.
+
+    Previously each call recomputed its own layout. Both calls take the same
+    game_state_data/team_data, but draw_out_of_town_score_board reloads
+    config.yaml from disk itself rather than using the config
+    orchestrate_score_board was given — so if config.yaml is edited mid-render
+    (e.g. by the phone config server) between the two calls, they can use
+    different config snapshots and silently disagree on layout (e.g. whether
+    a live game is a wide tile), desyncing the drawn image from the
+    partial-refresh regions/reshuffle-detection math and leaving a stale or
+    blank cell on the physical display. Sharing one computed layout closes
+    that gap structurally instead of relying on both calls happening to
+    agree."""
+    import generate_image
+    import image_box
+    import image_grid
+
+    games = [_base_game(game_pk=1)]
+
+    real_compute = image_grid.compute_grid_layout
+    calls = []
+
+    def _spy(*args, **kwargs):
+        calls.append(1)
+        return real_compute(*args, **kwargs)
+
+    with patch('generate_image.load_json_file',
+               side_effect=_fake_loader({'old_scoreboard_state.json': []})), \
+         patch('generate_image.save_off_results'), \
+         patch('generate_image.compute_grid_layout', side_effect=_spy), \
+         patch('image_grid.compute_grid_layout', side_effect=_spy), \
+         patch('image_grid.load_yaml_file', return_value=FIXED_CONFIG), \
+         patch('image_box.load_yaml_file', return_value=FIXED_CONFIG):
+        image_box.set_historical_mode(True)
+        try:
+            result = generate_image.orchestrate_score_board(
+                games, TEAM_DATA, date_str='2026-06-20', bypass_cache=False, config=FIXED_CONFIG,
+            )
+        finally:
+            image_box.set_historical_mode(False)
+
+    assert result is not None
+    assert len(calls) == 1
+
+
+@needs_pil
 def test_config_none_loads_real_yaml_mocked():
     """config=None triggers load_yaml_file('config.yaml') — mocked so the
     real config/config.yaml (use_team_logos: True) never leaks in."""


### PR DESCRIPTION
## Summary
- `draw_out_of_town_score_board` and the changed-regions/reshuffle-detection math in `generate_image.py` each called `compute_grid_layout()` independently for the same render.
- The renderer reloads `config.yaml` from disk itself instead of using the `config` its caller was given, so a config edit landing mid-render (e.g. via the phone config server) could make the two calls disagree on layout — desyncing the drawn image from the partial-refresh window sent to the hardware, leaving a stale/blank grid cell on the physical e-ink display (the symptom reported: an entire grid column blank after a partial refresh, despite the buffer-overrun fix in #197 already being deployed).
- `generate_image.py` now computes the layout once and threads it into `draw_out_of_town_score_board` via a new optional `layout` param, so there's a single source of truth per render instead of relying on two independent calls happening to agree.

## Test plan
- [x] Added `test_compute_grid_layout_called_once_per_render`, which spies on `compute_grid_layout` and asserts exactly one call per render — verified it fails against the pre-fix code (2 calls) and passes against the fix (1 call).
- [x] Full suite: `poetry run pytest -q` → 1523 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TYCCFNLQxBGMWTSURz2NT