### PR TITLE
Codify branch protection rules in .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,20 @@
+repository:
+  # Managed by the Probot Settings app.
+  # https://github.com/repository-settings/app
+
+branches:
+  - name: main
+    protection:
+      enforce_admins: true
+      required_conversation_resolution: true
+      allow_force_pushes: false
+      allow_deletions: false
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 0
+      required_status_checks:
+        strict: true          # branch must be up-to-date before merge
+        contexts:
+          - test              # ci.yml  — lint, type-check, tests, coverage
+          - scan              # code-quality.yml — codequality baseline scan


### PR DESCRIPTION
## Summary
- Adds `.github/settings.yml` to document (and enable Probot-managed enforcement of) the `main` branch protection rules
- Requires both `test` (CI) and `scan` (code-quality) to pass before any PR can merge
- Blocks force-pushes and deletions; enforces admins; requires conversation resolution

## Test plan
- [ ] CI (`test`) passes on this PR
- [ ] Code quality (`scan`) passes on this PR
- [ ] Merge button is gated until both checks are green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TYCCFNLQxBGMWTSURz2NT