### PR TITLE
Add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  enable:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Enables `allow_auto_merge` on the repo (done via API already)
- Adds `.github/workflows/auto-merge.yml` — fires on PR open/ready-for-review, calls `gh pr merge --auto --squash`
- Branch protection still gates the actual merge; auto-merge just queues it so GitHub merges the moment checks go green

## Result
Open a PR → checks run → merge happens automatically. No babysitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_017TYCCFNLQxBGMWTSURz2NT