### PR TITLE
Add recent-transactions ticker for empty grid slots

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -124,6 +124,13 @@ wide_cell_featured: false
 show_leaders_panel: true
 leaders_rotation_minutes: 5
 
+# Transactions ticker: show recent MLB transactions (IL moves, call-ups, signings)
+# in an empty grid cell when fewer than 15 games are on the slate. Claims the
+# first free slot, ahead of the leaders panel. Refreshed periodically from the
+# MLB Stats API.
+show_transactions_ticker: false
+transactions_lookback_days: 2
+
 # Debug overlay: show system uptime and last successful game-data fetch time
 # in the bottom-right corner. Useful when the Pi loses network connectivity.
 show_debug_overlay: true

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from fetch_leaders import fetch_leaders
 from render_scoreboard import render
 from display import send_to_display
 from util import load_json_file
-from standings import get_standings, fetch_playoff_bracket
+from standings import get_standings, fetch_playoff_bracket, fetch_transactions
 from image_box import set_historical_mode
 
 
@@ -167,6 +167,7 @@ def _maybe_generate_video(date_str, config):
 
 _STANDINGS_MAX_AGE_HOURS = 20  # refresh if standings.json is older than this
 _LEADERS_MAX_AGE_HOURS = 24    # refresh if leaders.json is older than this
+_TRANSACTIONS_MAX_AGE_HOURS = 3  # refresh if transactions.json is older than this
 
 
 def _should_refresh_leaders(sched):
@@ -197,6 +198,24 @@ def _should_refresh_leaders(sched):
     }
     known_finals = set(sched.get('leaders_final_pks', []))
     return bool(current_finals - known_finals)
+
+
+def _should_refresh_transactions():
+    """Return True if transactions.json needs a refresh.
+
+    Unlike standings/leaders, transactions aren't tied to games going Final —
+    just a simple age check (missing or older than _TRANSACTIONS_MAX_AGE_HOURS).
+    """
+    transactions_path = _data_path('transactions.json')
+    if not os.path.exists(transactions_path):
+        return True
+
+    import time as _t
+    age_hours = (_t.time() - os.path.getmtime(transactions_path)) / 3600
+    if age_hours >= _TRANSACTIONS_MAX_AGE_HOURS:
+        print(f"Transactions stale ({age_hours:.1f}h old) — refreshing")
+        return True
+    return False
 
 
 def _should_refresh_standings(sched):
@@ -514,6 +533,11 @@ Examples:
                         fetch_playoff_bracket()
                     except Exception as _bp_e:
                         print(f"Warning: playoff bracket fetch on poll-skip: {_bp_e}")
+                if config.get('show_transactions_ticker', False) and _should_refresh_transactions():
+                    try:
+                        fetch_transactions(config.get('transactions_lookback_days', 2))
+                    except Exception as _tx_e:
+                        print(f"Warning: transactions fetch on poll-skip: {_tx_e}")
                 return
 
     # 6. Fetch
@@ -596,6 +620,15 @@ Examples:
             fetch_playoff_bracket()
         except Exception as e:
             print(f"Warning: playoff bracket fetch failed: {e}")
+
+    # 7c2. Transactions ticker refresh — recent IL moves/call-ups/signings,
+    # only when the panel is enabled, and only when the cache is stale
+    # (transactions don't change fast enough to warrant fetching every poll).
+    if config.get('show_transactions_ticker', False) and _should_refresh_transactions():
+        try:
+            fetch_transactions(config.get('transactions_lookback_days', 2))
+        except Exception as e:
+            print(f"Warning: transactions fetch failed: {e}")
 
     # 7d. Season leaders refresh (HR/AVG/ERA/Saves/Hits) — only when panel is
     # enabled, and only once games have gone Final (or cache is stale/missing),

--- a/src/config_server.py
+++ b/src/config_server.py
@@ -39,6 +39,7 @@ FIELD_SPECS = [
     {'key': 'league_mode', 'source': 'yaml', 'type': 'select',
      'label': 'League Mode', 'options': ['mlb', 'aaa']},
     {'key': 'show_leaders_panel', 'source': 'yaml', 'type': 'bool', 'label': 'Season Leaders Panel'},
+    {'key': 'show_transactions_ticker', 'source': 'yaml', 'type': 'bool', 'label': 'Transactions Ticker'},
     {'key': 'show_debug_overlay', 'source': 'yaml', 'type': 'bool', 'label': 'Debug Overlay'},
     {'key': 'use_team_logos', 'source': 'yaml', 'type': 'bool', 'label': 'Team Logos'},
     {'key': 'show_standings_sidebar', 'source': 'yaml', 'type': 'bool', 'label': 'Standings Sidebar'},

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -9,6 +9,7 @@ from image_assets import _get_font, ImageDraw, Image
 from image_standings import _WC_STRIP_H
 from image_box import draw_box, draw_wide_box
 from image_leaders import draw_leaders_cell, rotating_categories, _CATEGORIES as _LEADER_CATEGORIES
+from image_transactions import draw_transactions_cell
 
 
 # Live game states that qualify for a wide (2-cell) tile. Challenge/review states
@@ -626,27 +627,38 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
                 streak_map=streak_map,
             )
 
-    if config.get('show_leaders_panel', False):
-        _free_slots = _free_grid_slots(_slots)
-        if _free_slots:
-            _leaders_data = load_json_file('leaders.json').get('leaders', {})
-            _rotation_min = config.get('leaders_rotation_minutes', 5)
-            # One tile per category when there's room for all of them; with
-            # fewer free slots than categories, the subset shown slides over
-            # time (via rotating_categories) so every category still appears.
-            _n = min(len(_free_slots), len(_LEADER_CATEGORIES))
-            _cats = (
-                list(_LEADER_CATEGORIES) if _n == len(_LEADER_CATEGORIES)
-                else rotating_categories(_n, _rotation_min)
+    _free_slots = _free_grid_slots(_slots)
+
+    # Transactions ticker claims the first free slot, ahead of the leaders
+    # panel, whenever there's room (i.e. fewer than 15 games on the slate).
+    if config.get('show_transactions_ticker', False) and _free_slots:
+        _tx_col, _tx_row = _free_slots.pop(0)
+        _tx_data = load_json_file('transactions.json').get('transactions', [])
+        _tx_lx = _tx_col * 150 + x_start
+        _tx_ly = _tx_row * 150 + y_start
+        Himage = draw_transactions_cell(
+            Himage, _tx_lx, _tx_ly, _tx_data, team_data, use_logos=use_logos,
+        )
+
+    if config.get('show_leaders_panel', False) and _free_slots:
+        _leaders_data = load_json_file('leaders.json').get('leaders', {})
+        _rotation_min = config.get('leaders_rotation_minutes', 5)
+        # One tile per category when there's room for all of them; with
+        # fewer free slots than categories, the subset shown slides over
+        # time (via rotating_categories) so every category still appears.
+        _n = min(len(_free_slots), len(_LEADER_CATEGORIES))
+        _cats = (
+            list(_LEADER_CATEGORIES) if _n == len(_LEADER_CATEGORIES)
+            else rotating_categories(_n, _rotation_min)
+        )
+        for (_col, _row), _cat in zip(_free_slots, _cats):
+            _lx = _col * 150 + x_start
+            _ly = _row * 150 + y_start
+            Himage = draw_leaders_cell(
+                Himage, _lx, _ly, _leaders_data, team_data,
+                category=_cat,
+                use_logos=use_logos,
             )
-            for (_col, _row), _cat in zip(_free_slots, _cats):
-                _lx = _col * 150 + x_start
-                _ly = _row * 150 + y_start
-                Himage = draw_leaders_cell(
-                    Himage, _lx, _ly, _leaders_data, team_data,
-                    category=_cat,
-                    use_logos=use_logos,
-                )
 
     Himage.save('score_board.bmp')
     return Himage

--- a/src/image_transactions.py
+++ b/src/image_transactions.py
@@ -1,0 +1,110 @@
+"""Draw a recent-transactions ticker cell (150x150) for an empty grid slot.
+
+Shows the most recent MLB transactions (IL moves, call-ups/demotions,
+signings, etc.) fetched by standings.fetch_transactions(). Mirrors
+image_leaders.draw_leaders_cell's layout so it drops into a grid slot
+identically.
+"""
+from image_assets import _get_font, ImageDraw, _logo_small
+
+# Matches the visible footprint of a normal single-game grid box
+# (horizonta_len x vertical_len+20 in image_box.draw_box), not the full
+# 150x150 grid slot, so the two line up exactly.
+_CELL_W = 135
+_CELL_H = 130
+_PAD = 2
+_HEADER = 'Transactions'
+
+# Trim MLB's verbose typeDesc down to something that fits a narrow ticker row.
+_TYPE_ABBR = {
+    'Status Change':     'IL',
+    'Recalled':          'Recall',
+    'Optioned':          'Option',
+    'Selected':          'Select',
+    'Designated for Assignment': 'DFA',
+    'Released':          'Release',
+    'Signed':            'Sign',
+    'Trade':             'Trade',
+    'Claimed off Waivers': 'Waiver',
+    'Outrighted':        'Outright',
+}
+
+
+def draw_transactions_cell(Himage, sx, sy, transactions_data, team_data, max_rows=None, use_logos=False):
+    """Draw a recent-transactions panel into the cell at pixel position
+    (sx, sy), the same 150x150 footprint as a normal single-game grid cell.
+
+    transactions_data: the 'transactions' list from transactions.json
+    team_data: the teams dict (for team_abbreviation lookup, currently unused
+        since team_abbr is already embedded per-entry, kept for parity with
+        draw_leaders_cell's signature)
+    """
+    draw = ImageDraw.Draw(Himage)
+    entries = list(transactions_data or [])
+
+    font_hdr = _get_font(14)
+    # 9pt caused adjacent thin strokes to visually fuse together on the
+    # 1-bit e-ink render — never go below 10pt (mirrors image_leaders.py).
+    row_font_size = 12 if len(entries) <= 6 else 11
+    font_row = _get_font(row_font_size)
+
+    # Top border + header separator (matches draw_box's header row layout)
+    draw.line([(sx, sy), (sx + _CELL_W - 1, sy)], fill=0)
+    draw.line([(sx, sy + 20), (sx + _CELL_W - 1, sy + 20)], fill=0)
+    hdr_w = int(font_hdr.getlength(_HEADER))
+    hdr_x = sx + (_CELL_W - hdr_w) // 2
+    draw.text((hdr_x, sy + 3), _HEADER, font=font_hdr, fill=0)
+    draw.text((hdr_x + 1, sy + 3), _HEADER, font=font_hdr, fill=0)
+
+    # Bottom border
+    draw.line([(sx, sy + _CELL_H - 1), (sx + _CELL_W - 1, sy + _CELL_H - 1)], fill=0, width=1)
+
+    if not entries:
+        draw.text((sx + _PAD, sy + 60), 'No recent moves', font=font_row, fill=0)
+        return Himage
+
+    # Row count is capped by available vertical space; 13px is the smallest
+    # row height that stays legible at row_font_size 11 (mirrors image_leaders).
+    _max_by_height = (_CELL_H - 20) // 13
+    n_rows = min(len(entries), max_rows if max_rows is not None else _max_by_height, _max_by_height)
+    shown = entries[:n_rows]
+    row_h = (_CELL_H - 20) // max(n_rows, 1)
+    row_pad = 2 if row_h >= 13 else 1
+
+    logo_size = min(18, row_h)
+    abbr_col_w = max((int(font_row.getlength(e.get('team_abbr', '') + ' ')) for e in shown), default=0)
+    logo_col_x = sx + _PAD
+    name_x = logo_col_x + (logo_size + 2 if use_logos else abbr_col_w)
+
+    for i, entry in enumerate(shown):
+        ry = sy + 20 + i * row_h
+
+        abbr = entry.get('team_abbr', '')
+        team_id = entry.get('team_id', '')
+        name = entry.get('player_name', '')
+        type_desc = entry.get('type_desc', '')
+        tag = _TYPE_ABBR.get(type_desc, type_desc)
+
+        if use_logos and abbr:
+            try:
+                logo = _logo_small(abbr, team_id, size=logo_size)
+                if logo:
+                    logo_y = ry + (row_h - logo.height) // 2
+                    Himage.paste(logo, (logo_col_x, logo_y))
+            except Exception:
+                pass
+        else:
+            draw.text((sx + _PAD, ry + row_pad), abbr, font=font_row, fill=0)
+
+        # tag right-aligned; measured first so the name gets whatever's left.
+        tag_w = int(font_row.getlength(tag))
+        tag_x = sx + _CELL_W - tag_w - _PAD
+
+        max_name_w = tag_x - 2 - name_x
+        while name and int(font_row.getlength(name)) > max_name_w:
+            name = name[:-1]
+
+        draw.text((name_x, ry + row_pad), name, font=font_row, fill=0)
+        draw.text((tag_x, ry + row_pad), tag, font=font_row, fill=0)
+
+    return Himage

--- a/src/standings.py
+++ b/src/standings.py
@@ -1,7 +1,7 @@
 import requests
 import json
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 from util import save_off_results, load_json_file
@@ -310,6 +310,58 @@ def fetch_playoff_bracket(season=None):
     }
     save_off_results(bracket_data, 'playoff_bracket')
     return bracket_data
+
+
+def fetch_transactions(lookback_days=2):
+    """Fetch recent MLB transactions (IL moves, call-ups/demotions, signings, etc.)
+    and save to data/transactions.json.
+
+    Queries the transactions API for the window [today - lookback_days, today],
+    newest first.
+
+    Returns the transactions dict, or None on failure.
+    """
+    import time as _t
+    end = datetime.now()
+    start = end - timedelta(days=lookback_days)
+
+    url = (
+        f'https://statsapi.mlb.com/api/v1/transactions'
+        f'?sportId=1'
+        f'&startDate={start.strftime("%Y-%m-%d")}&endDate={end.strftime("%Y-%m-%d")}'
+    )
+    try:
+        resp = requests.get(url, timeout=10)
+        if resp.status_code != 200:
+            print(f'Warning: transactions fetch returned {resp.status_code}')
+            return None
+        data = resp.json()
+    except Exception as e:
+        print(f'Error fetching transactions: {e}')
+        return None
+
+    entries = []
+    for tx in data.get('transactions', []):
+        team = tx.get('toTeam') or tx.get('fromTeam') or {}
+        entries.append({
+            'date':        tx.get('date', ''),
+            'player_name': (tx.get('person') or {}).get('fullName', ''),
+            'team_abbr':   team.get('abbreviation', ''),
+            'team_id':     str(team.get('id', '')),
+            'type_desc':   tx.get('typeDesc', ''),
+            'description': tx.get('description', ''),
+        })
+
+    # Newest first
+    entries.sort(key=lambda e: e['date'], reverse=True)
+
+    transactions_data = {
+        'fetched_at':    _t.time(),
+        'lookback_days': lookback_days,
+        'transactions':  entries,
+    }
+    save_off_results(transactions_data, 'transactions')
+    return transactions_data
 
 
 def main():

--- a/tests/test_fetch_transactions.py
+++ b/tests/test_fetch_transactions.py
@@ -1,0 +1,147 @@
+"""Tests for standings.fetch_transactions.
+
+Mocks all network access (standings.requests.get) and file I/O
+(standings.save_off_results) following the pattern in test_fetch_playoff_bracket.py.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import standings
+from standings import fetch_transactions
+
+
+def _resp(status_code=200, json_data=None):
+    """Resp."""
+    m = MagicMock()
+    m.status_code = status_code
+    m.json.return_value = json_data if json_data is not None else {}
+    return m
+
+
+def _tx(date='2026-07-08', player='Aaron Judge', team_abbr='NYY', team_id=147,
+        type_desc='Status Change', description='Yankees placed Aaron Judge on 10-day IL',
+        to_team=True):
+    """Tx."""
+    team = {'id': team_id, 'abbreviation': team_abbr}
+    entry = {
+        'date': date,
+        'person': {'fullName': player},
+        'typeDesc': type_desc,
+        'description': description,
+    }
+    entry['toTeam' if to_team else 'fromTeam'] = team
+    return entry
+
+
+@pytest.fixture(autouse=True)
+def _reset_team_abbr_list():
+    """Reset team abbr list."""
+    standings.team_abbreviation_list.clear()
+    yield
+    standings.team_abbreviation_list.clear()
+
+
+class TestFetchTransactions:
+    def test_non_200_response_returns_none(self):
+        """Non 200 response returns none."""
+        with patch('standings.requests.get', return_value=_resp(status_code=503)), \
+             patch('standings.save_off_results') as mock_save:
+            result = fetch_transactions()
+        assert result is None
+        mock_save.assert_not_called()
+
+    def test_network_exception_returns_none(self):
+        """Network exception returns none."""
+        with patch('standings.requests.get', side_effect=OSError('timeout')), \
+             patch('standings.save_off_results') as mock_save:
+            result = fetch_transactions()
+        assert result is None
+        mock_save.assert_not_called()
+
+    def test_empty_transactions_returns_empty_list(self):
+        """Empty transactions returns empty list."""
+        payload = {'transactions': []}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)), \
+             patch('standings.save_off_results') as mock_save:
+            result = fetch_transactions()
+        assert result is not None
+        assert result['transactions'] == []
+        mock_save.assert_called_once()
+
+    def test_entry_fields_extracted(self):
+        """Entry fields extracted."""
+        payload = {'transactions': [_tx()]}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)), \
+             patch('standings.save_off_results'):
+            result = fetch_transactions()
+        e = result['transactions'][0]
+        assert e['player_name'] == 'Aaron Judge'
+        assert e['team_abbr'] == 'NYY'
+        assert e['team_id'] == '147'
+        assert e['type_desc'] == 'Status Change'
+        assert e['date'] == '2026-07-08'
+
+    def test_from_team_used_when_no_to_team(self):
+        """From team used when no to team."""
+        payload = {'transactions': [_tx(team_abbr='BOS', team_id=111, to_team=False)]}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)), \
+             patch('standings.save_off_results'):
+            result = fetch_transactions()
+        assert result['transactions'][0]['team_abbr'] == 'BOS'
+
+    def test_entries_sorted_newest_first(self):
+        """Entries sorted newest first."""
+        payload = {'transactions': [
+            _tx(date='2026-07-06', player='Older Move'),
+            _tx(date='2026-07-08', player='Newer Move'),
+            _tx(date='2026-07-07', player='Middle Move'),
+        ]}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)), \
+             patch('standings.save_off_results'):
+            result = fetch_transactions()
+        names = [e['player_name'] for e in result['transactions']]
+        assert names == ['Newer Move', 'Middle Move', 'Older Move']
+
+    def test_result_includes_fetched_at_and_lookback_days(self):
+        """Result includes fetched at and lookback days."""
+        payload = {'transactions': []}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)), \
+             patch('standings.save_off_results'):
+            result = fetch_transactions(lookback_days=5)
+        assert 'fetched_at' in result
+        assert isinstance(result['fetched_at'], float)
+        assert result['lookback_days'] == 5
+
+    def test_save_off_results_called_with_transactions_name(self):
+        """Save off results called with transactions name."""
+        payload = {'transactions': []}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)), \
+             patch('standings.save_off_results') as mock_save:
+            fetch_transactions()
+        mock_save.assert_called_once()
+        call_args = mock_save.call_args
+        assert call_args[0][1] == 'transactions'
+
+    def test_lookback_days_embedded_in_request_url(self):
+        """Lookback days embedded in request url reflects the date window."""
+        from datetime import datetime, timedelta
+        payload = {'transactions': []}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)) as mock_get, \
+             patch('standings.save_off_results'):
+            fetch_transactions(lookback_days=3)
+        url = mock_get.call_args[0][0]
+        expected_start = (datetime.now() - timedelta(days=3)).strftime('%Y-%m-%d')
+        assert expected_start in url
+        assert 'sportId=1' in url
+
+    def test_missing_person_or_team_falls_back_to_empty_strings(self):
+        """Missing person or team falls back to empty strings."""
+        payload = {'transactions': [{'date': '2026-07-08', 'typeDesc': 'Trade'}]}
+        with patch('standings.requests.get', return_value=_resp(json_data=payload)), \
+             patch('standings.save_off_results'):
+            result = fetch_transactions()
+        e = result['transactions'][0]
+        assert e['player_name'] == ''
+        assert e['team_abbr'] == ''
+        assert e['team_id'] == ''

--- a/tests/test_transactions_cell.py
+++ b/tests/test_transactions_cell.py
@@ -1,0 +1,111 @@
+"""Tests for image_transactions.draw_transactions_cell."""
+from unittest.mock import patch
+from PIL import Image
+
+from image_transactions import draw_transactions_cell
+
+
+SAMPLE_TRANSACTIONS = [
+    {'date': '2026-07-08', 'player_name': 'Aaron Judge', 'team_abbr': 'NYY',
+     'team_id': '147', 'type_desc': 'Status Change', 'description': 'placed on IL'},
+    {'date': '2026-07-08', 'player_name': 'Jasson Dominguez', 'team_abbr': 'NYY',
+     'team_id': '147', 'type_desc': 'Recalled', 'description': 'recalled from AAA'},
+    {'date': '2026-07-07', 'player_name': 'Some Pitcher', 'team_abbr': 'BOS',
+     'team_id': '111', 'type_desc': 'Optioned', 'description': 'optioned to AAA'},
+]
+
+SAMPLE_TEAM_DATA = {
+    'team_abbreviation': {'147': 'NYY', '111': 'BOS'},
+}
+
+
+def _make_image():
+    """Make image."""
+    return Image.new('1', (800, 480), 255)
+
+
+def test_draw_transactions_cell_renders_without_error():
+    """Draw transactions cell renders without error."""
+    img = _make_image()
+    result = draw_transactions_cell(img, 32, 30, SAMPLE_TRANSACTIONS, SAMPLE_TEAM_DATA)
+    assert result is not None
+
+
+def test_draw_transactions_cell_empty_list_shows_fallback():
+    """Draw transactions cell empty list shows fallback."""
+    img = _make_image()
+    result = draw_transactions_cell(img, 32, 30, [], SAMPLE_TEAM_DATA)
+    assert result is not None
+
+
+def test_draw_transactions_cell_none_data_shows_fallback():
+    """Draw transactions cell none data shows fallback."""
+    img = _make_image()
+    result = draw_transactions_cell(img, 32, 30, None, SAMPLE_TEAM_DATA)
+    assert result is not None
+
+
+def test_draw_transactions_cell_none_team_data():
+    """Draw transactions cell none team data."""
+    img = _make_image()
+    result = draw_transactions_cell(img, 32, 30, SAMPLE_TRANSACTIONS, None)
+    assert result is not None
+
+
+def test_draw_transactions_cell_very_long_name_truncated():
+    """Draw transactions cell very long name truncated."""
+    img = _make_image()
+    long_name = [{
+        'date': '2026-07-08', 'player_name': 'Bartholomew Humperdink-Smithson',
+        'team_abbr': 'NYY', 'team_id': '147', 'type_desc': 'Status Change', 'description': '',
+    }]
+    result = draw_transactions_cell(img, 32, 30, long_name, SAMPLE_TEAM_DATA)
+    assert result is not None
+
+
+def test_draw_transactions_cell_unknown_type_desc_passthrough():
+    """Unknown type_desc values (not in _TYPE_ABBR) are shown as-is, not dropped."""
+    img = _make_image()
+    entries = [{
+        'date': '2026-07-08', 'player_name': 'Some Player',
+        'team_abbr': 'NYY', 'team_id': '147', 'type_desc': 'Something New', 'description': '',
+    }]
+    result = draw_transactions_cell(img, 32, 30, entries, SAMPLE_TEAM_DATA)
+    assert result is not None
+
+
+def test_draw_transactions_cell_with_logos_pastes_logo():
+    """Draw transactions cell with logos pastes logo."""
+    img = _make_image()
+    fake_logo = Image.new('1', (18, 18), 0)
+    with patch('image_transactions._logo_small', return_value=fake_logo) as mock_logo:
+        result = draw_transactions_cell(img, 32, 30, SAMPLE_TRANSACTIONS, SAMPLE_TEAM_DATA, use_logos=True)
+    assert result is not None
+    assert mock_logo.called
+
+
+def test_draw_transactions_cell_logo_lookup_failure_falls_back():
+    """Logo lookup failure must not crash the cell."""
+    img = _make_image()
+    with patch('image_transactions._logo_small', side_effect=OSError('missing')):
+        result = draw_transactions_cell(img, 32, 30, SAMPLE_TRANSACTIONS, SAMPLE_TEAM_DATA, use_logos=True)
+    assert result is not None
+
+
+def test_draw_transactions_cell_more_entries_than_rows_is_capped():
+    """More entries than fit in the cell must not crash — extras are dropped, not overflowed."""
+    img = _make_image()
+    many = [
+        {'date': '2026-07-08', 'player_name': f'Player {i}', 'team_abbr': 'NYY',
+         'team_id': '147', 'type_desc': 'Status Change', 'description': ''}
+        for i in range(20)
+    ]
+    result = draw_transactions_cell(img, 32, 30, many, SAMPLE_TEAM_DATA)
+    assert result is not None
+
+
+def test_draw_transactions_cell_respects_max_rows():
+    """max_rows further limits how many entries are drawn."""
+    img = _make_image()
+    result = draw_transactions_cell(img, 32, 30, SAMPLE_TRANSACTIONS, SAMPLE_TEAM_DATA, max_rows=1)
+    assert result is not None

--- a/tests/test_transactions_grid_placement.py
+++ b/tests/test_transactions_grid_placement.py
@@ -1,0 +1,132 @@
+"""Tests for transactions-ticker placement in draw_out_of_town_score_board.
+
+Covers: ticker shown in the first free cell when there are fewer than 15
+games, disabled via config, and taking priority over the leaders panel for
+that first slot (mirrors tests/test_image_grid_qr.py's placement pattern).
+"""
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from PIL import Image
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+needs_pil = pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not installed")
+
+FIXED_CONFIG = {
+    'timezone': 'America/Chicago',
+    'use_team_logos': False,
+    'show_transactions_ticker': True,
+    'show_leaders_panel': False,
+}
+
+TEAM_DATA = {'team_abbreviation': {'119': 'LAD', '137': 'SF'}}
+
+SAMPLE_TRANSACTIONS = [
+    {'date': '2026-07-08', 'player_name': 'Aaron Judge', 'team_abbr': 'NYY',
+     'team_id': '147', 'type_desc': 'Status Change', 'description': ''},
+]
+
+
+def _game(pk, state='Scheduled'):
+    """Game."""
+    return {
+        'game_pk': pk, 'away_team_id': 119, 'home_team_id': 137,
+        'detailed_state': state, 'game_start': '7:05 PM',
+        'game_datetime': '2026-06-20T23:05:00Z',
+        'away_runs': 0, 'home_runs': 0, 'away_hits': 0, 'home_hits': 0,
+        'away_errors': 0, 'home_errors': 0,
+        'away_team_record_wins': 1, 'away_team_record_losses': 1,
+        'home_team_record_wins': 1, 'home_team_record_losses': 1,
+        'away_probable': 'X', 'home_probable': 'Y',
+    }
+
+
+def _has_black_pixels(region):
+    """In mode '1', white=255 (non-zero) is background, black=0 is content —
+    Image.getbbox() treats any non-zero pixel as content, so an all-white
+    region still returns a bbox. Count actual black pixels instead."""
+    return any(px == 0 for px in region.getdata())
+
+
+def _render(games, config=None, transactions=None):
+    """Render."""
+    import image_box
+    white = Image.new('1', (800, 480), 255)
+    cfg = config if config is not None else FIXED_CONFIG
+    tx = transactions if transactions is not None else SAMPLE_TRANSACTIONS
+    with patch('image_grid.load_yaml_file', return_value=cfg), \
+         patch('image_box.load_yaml_file', return_value=cfg), \
+         patch('image_grid.load_json_file', side_effect=lambda name: (
+             {'transactions': tx} if name == 'transactions.json' else {}
+         )):
+        from image_grid import draw_out_of_town_score_board
+        image_box.set_historical_mode(True)
+        try:
+            return draw_out_of_town_score_board(white, games, TEAM_DATA)
+        finally:
+            image_box.set_historical_mode(False)
+
+
+@needs_pil
+def test_ticker_appears_in_first_free_slot():
+    """Ticker appears in first free slot."""
+    result = _render([_game(i) for i in range(3)])
+    region = result.crop((3 * 150 + 32, 30, 3 * 150 + 32 + 150, 30 + 150))
+    assert _has_black_pixels(region)
+
+
+@needs_pil
+def test_no_ticker_at_15_games():
+    """No ticker at 15 games — no room left, rendering all 15 must not raise."""
+    result = _render([_game(i) for i in range(15)])
+    region = result.crop((4 * 150 + 32, 2 * 150 + 30, 4 * 150 + 32 + 150, 2 * 150 + 30 + 150))
+    assert _has_black_pixels(region)
+
+
+@needs_pil
+def test_ticker_disabled_via_config():
+    """Ticker disabled via config."""
+    config = dict(FIXED_CONFIG, show_transactions_ticker=False)
+    result = _render([_game(i) for i in range(3)], config=config)
+    region = result.crop((3 * 150 + 32, 30, 3 * 150 + 32 + 150, 30 + 150))
+    assert not _has_black_pixels(region)
+
+
+@needs_pil
+def test_ticker_takes_priority_over_leaders_panel_for_first_slot():
+    """When both are enabled, the ticker claims the first free slot and the
+    leaders panel fills whatever's left over, not the other way around."""
+    config = dict(FIXED_CONFIG, show_leaders_panel=True)
+    leaders_data = {'leaders': {'homeRuns': [
+        {'rank': 1, 'value': '28', 'name': 'Someone', 'team_id': '147'},
+    ]}}
+    with patch('image_grid.load_yaml_file', return_value=config), \
+         patch('image_box.load_yaml_file', return_value=config), \
+         patch('image_grid.load_json_file', side_effect=lambda name: (
+             {'transactions': SAMPLE_TRANSACTIONS} if name == 'transactions.json'
+             else leaders_data if name == 'leaders.json' else {}
+         )), \
+         patch('image_grid.draw_leaders_cell') as mock_leaders_cell, \
+         patch('image_grid.draw_transactions_cell', wraps=None) as mock_tx_cell:
+        import image_box
+        from image_grid import draw_out_of_town_score_board
+        white = Image.new('1', (800, 480), 255)
+        image_box.set_historical_mode(True)
+        try:
+            mock_tx_cell.return_value = white
+            draw_out_of_town_score_board(white, [_game(i) for i in range(3)], TEAM_DATA)
+        finally:
+            image_box.set_historical_mode(False)
+
+    assert mock_tx_cell.called
+    _tx_call_slot = (mock_tx_cell.call_args[0][1], mock_tx_cell.call_args[0][2])
+    assert _tx_call_slot == (3 * 150 + 32, 30)  # first free slot (col 3, row 0)
+
+    assert mock_leaders_cell.called
+    for _call in mock_leaders_cell.call_args_list:
+        _slot = (_call[0][1], _call[0][2])
+        assert _slot != _tx_call_slot  # leaders never reuses the ticker's slot


### PR DESCRIPTION
## Summary
- New optional grid card: recent MLB transactions (IL moves, call-ups/demotions, signings, trades) shown in an empty grid slot when there are fewer than 15 games that day.
- Config: `show_transactions_ticker` (default `false`), `transactions_lookback_days` (default `2`). Exposed in the phone config server next to the leaders-panel toggle.
- Placement: claims the **first** free grid slot, ahead of the leaders panel (per request — leaders panel still fills whatever's left over). Neither card appears at 15/15 games.
- Data: `fetch_transactions()` in `src/standings.py` hits the MLB Stats API transactions endpoint, cached to `data/transactions.json`, refreshed on a 3h-stale throttle (mirrors the leaders/standings refresh pattern) — not on every poll, since transactions don't change mid-game.
- Rendering: `src/image_transactions.py` — new module mirroring `image_leaders.py`'s cell layout exactly (same 150x150 footprint, header style, row truncation) so it drops into a grid slot identically.

Also confirmed while scoping this: `show_playoff_bracket` (a separate existing config flag) is *not* a stub — it's fully implemented end-to-end (fetch → cache → header-strip render), just off by default and meant to be toggled on in October.

## Test plan
- [x] `poetry run pytest -q` — 1599 passed
- [x] `poetry run ruff check` — clean
- [x] `poetry run mypy` — clean
- New tests: `test_fetch_transactions.py` (fetch/parsing/sorting), `test_transactions_cell.py` (render edge cases: empty, None, long names, logo failure, row cap), `test_transactions_grid_placement.py` (slot placement, disabled-via-config, priority over leaders panel — mirrors `test_image_grid_qr.py`'s pattern)