### PR TITLE
Auto-toggle playoff bracket header during postseason

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -86,8 +86,11 @@ show_wildcard_standings: true
 
 # Show postseason bracket in the top header strip instead of wildcard standings.
 # Fetches series win totals via the MLB schedule API (gameType F/D/L/W).
-# Set to true during October; mutually exclusive with show_wildcard_standings.
-show_playoff_bracket: false
+# Auto-toggles on during the postseason calendar window (mid-Sept to mid-Nov)
+# once real bracket data exists — no manual flip needed each October. Falls
+# back to wildcard standings the rest of the year. Set to false to disable
+# the bracket entirely (always shows wildcard standings instead, if enabled).
+show_playoff_bracket: true
 
 # Small logo X offset: pixels from the left edge of each score box where the small logo is placed.
 # Set to 2 to align with the box edge. Increase to shift the logo right.

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from fetch_leaders import fetch_leaders
 from render_scoreboard import render
 from display import send_to_display
 from util import load_json_file
-from standings import get_standings, fetch_playoff_bracket, fetch_transactions
+from standings import get_standings, fetch_playoff_bracket, fetch_transactions, is_postseason_window
 from image_box import set_historical_mode
 
 
@@ -168,6 +168,7 @@ def _maybe_generate_video(date_str, config):
 _STANDINGS_MAX_AGE_HOURS = 20  # refresh if standings.json is older than this
 _LEADERS_MAX_AGE_HOURS = 24    # refresh if leaders.json is older than this
 _TRANSACTIONS_MAX_AGE_HOURS = 3  # refresh if transactions.json is older than this
+_PLAYOFF_BRACKET_MAX_AGE_HOURS = 1  # refresh cadence during an active postseason
 
 
 def _should_refresh_leaders(sched):
@@ -214,6 +215,24 @@ def _should_refresh_transactions():
     age_hours = (_t.time() - os.path.getmtime(transactions_path)) / 3600
     if age_hours >= _TRANSACTIONS_MAX_AGE_HOURS:
         print(f"Transactions stale ({age_hours:.1f}h old) — refreshing")
+        return True
+    return False
+
+
+def _should_refresh_playoff_bracket():
+    """Return True if playoff_bracket.json needs a refresh.
+
+    Simple age check — series win counts only change once per completed
+    game, so hourly is frequent enough even during an active series.
+    """
+    bracket_path = _data_path('playoff_bracket.json')
+    if not os.path.exists(bracket_path):
+        return True
+
+    import time as _t
+    age_hours = (_t.time() - os.path.getmtime(bracket_path)) / 3600
+    if age_hours >= _PLAYOFF_BRACKET_MAX_AGE_HOURS:
+        print(f"Playoff bracket stale ({age_hours:.1f}h old) — refreshing")
         return True
     return False
 
@@ -528,7 +547,8 @@ Examples:
                                       date=_sl_prev.strftime('%m/%d/%Y'), save_as='standings_prev')
                     except Exception as _sl_e:
                         print(f"Warning: standings refresh on poll-skip: {_sl_e}")
-                if config.get('show_playoff_bracket', False) and league_mode != 'aaa':
+                if config.get('show_playoff_bracket', True) and league_mode != 'aaa' \
+                        and is_postseason_window() and _should_refresh_playoff_bracket():
                     try:
                         fetch_playoff_bracket()
                     except Exception as _bp_e:
@@ -614,8 +634,12 @@ Examples:
             except Exception as e:
                 print(f"Warning: standings refresh failed: {e}")
 
-    # 7c. Playoff bracket refresh (postseason only)
-    if config.get('show_playoff_bracket', False) and league_mode != 'aaa':
+    # 7c. Playoff bracket refresh — auto-detects postseason via the calendar
+    # window (mid-Sept to mid-Nov) rather than requiring a manual config
+    # toggle each year; show_playoff_bracket now just lets a user force it
+    # off entirely if they never want the header taken over.
+    if config.get('show_playoff_bracket', True) and league_mode != 'aaa' \
+            and is_postseason_window() and _should_refresh_playoff_bracket():
         try:
             fetch_playoff_bracket()
         except Exception as e:

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -376,10 +376,19 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
     if config.get('show_wildcard_standings', False) or config.get('show_standings_sidebar', False):
         standings_data = load_json_file('standings.json')
 
-    if config.get('show_playoff_bracket', False) and league_mode != 'aaa':
-        _bracket = load_json_file('playoff_bracket.json')
-        if _bracket and _bracket.get('series'):
-            Himage = draw_playoff_bracket_header(Himage, _bracket)
+    # Playoff bracket auto-toggles on: it takes over the header strip only
+    # when there's an actual current-season bracket to show (fetched by
+    # main.py during the postseason calendar window), not just because the
+    # config flag defaults to True — otherwise wildcard standings would
+    # never render for the ~10 months a year there's no bracket data yet.
+    _bracket = None
+    if config.get('show_playoff_bracket', True) and league_mode != 'aaa':
+        _candidate = load_json_file('playoff_bracket.json')
+        if _candidate and _candidate.get('series') and _candidate.get('season') == datetime.now().year:
+            _bracket = _candidate
+
+    if _bracket:
+        Himage = draw_playoff_bracket_header(Himage, _bracket)
     elif config.get('show_wildcard_standings', False) and league_mode != 'aaa':
         if standings_data and 'standings' in standings_data:
             wildcard_data = derive_wildcard_from_standings(standings_data)

--- a/src/image_featured.py
+++ b/src/image_featured.py
@@ -777,10 +777,16 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
 
     # Overlay wildcard/bracket header and standings sidebars (skipped for live games)
     if not _is_live:
-        if config.get('show_playoff_bracket', False) and league_mode != 'aaa':
-            _bracket = load_json_file('playoff_bracket.json')
-            if _bracket and _bracket.get('series'):
-                canvas = draw_playoff_bracket_header(canvas, _bracket)
+        # See generate_image.py for why this checks actual bracket content
+        # rather than just the (now default-True) config flag.
+        _bracket = None
+        if config.get('show_playoff_bracket', True) and league_mode != 'aaa':
+            _candidate = load_json_file('playoff_bracket.json')
+            if _candidate and _candidate.get('series') and _candidate.get('season') == datetime.now().year:
+                _bracket = _candidate
+
+        if _bracket:
+            canvas = draw_playoff_bracket_header(canvas, _bracket)
         elif standings_data and 'standings' in standings_data and \
                 config.get('show_wildcard_standings', False) and league_mode != 'aaa':
             wildcard_data = derive_wildcard_from_standings(standings_data)

--- a/src/standings.py
+++ b/src/standings.py
@@ -215,6 +215,26 @@ def fetch_wildcard_standings(season=None, date=None):
     return result
 
 
+def is_postseason_window(now=None):
+    """True during the rough calendar window postseason games can occur in
+    (mid-September through mid-November), so callers can skip the schedule
+    API entirely outside that window instead of fetching/checking a
+    guaranteed-empty bracket every poll for ~10 months of the year.
+
+    This is deliberately coarse — the actual "is the bracket non-empty"
+    decision is made from real schedule data by the caller, this just
+    avoids the wasted network call the rest of the year.
+    """
+    now = now or datetime.now()
+    if now.month == 10:
+        return True
+    if now.month == 9:
+        return now.day >= 15
+    if now.month == 11:
+        return now.day <= 10
+    return False
+
+
 def fetch_playoff_bracket(season=None):
     """Fetch current postseason series data and save to data/playoff_bracket.json.
 

--- a/tests/test_generate_image_orchestrate.py
+++ b/tests/test_generate_image_orchestrate.py
@@ -44,6 +44,7 @@ FIXED_CONFIG = {
     'final_linescore_minutes': 60,
     'show_wildcard_standings': False,
     'show_standings_sidebar': False,
+    'show_playoff_bracket': False,
     'primary': '',
     'league_mode': 'mlb',
     'dark_mode': False,
@@ -923,10 +924,12 @@ def test_playoff_bracket_header_drawn_when_bracket_data_present():
     draw_playoff_bracket_header (generate_image.py lines 261-264)."""
     import generate_image
 
+    from datetime import datetime
     bracket_cfg = dict(FIXED_CONFIG, show_playoff_bracket=True, league_mode='mlb')
     stub_img = MagicMock()
     stub_img.size = (800, 480)
-    bracket_data = {'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'LAD',
+    bracket_data = {'season': datetime.now().year,
+                     'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'LAD',
                                 'away_wins': 2, 'home_wins': 3, 'complete': False}]}
 
     def fake_load(filename, *a, **kw):

--- a/tests/test_image_featured.py
+++ b/tests/test_image_featured.py
@@ -775,8 +775,10 @@ def test_featured_fullscreen_winner_ghost_logo_away_winner():
 def test_featured_fullscreen_playoff_bracket_header_branch():
     """show_playoff_bracket=True exercises the playoff-bracket header path."""
     from image_featured import draw_featured_game_fullscreen
+    from datetime import datetime
     bracket_cfg = dict(CONFIG, show_playoff_bracket=True, league_mode='mlb')
-    bracket_data = {'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'BOS',
+    bracket_data = {'season': datetime.now().year,
+                     'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'BOS',
                                 'away_wins': 2, 'home_wins': 1, 'complete': False}]}
     with patch('image_featured.load_json_file', return_value=bracket_data), \
          patch('image_featured.draw_playoff_bracket_header',

--- a/tests/test_postseason_window.py
+++ b/tests/test_postseason_window.py
@@ -1,0 +1,52 @@
+"""Tests for standings.is_postseason_window — the coarse date gate that lets
+main.py auto-toggle the playoff bracket on without a manual config flip,
+while skipping the schedule API entirely outside the postseason months."""
+from datetime import datetime
+
+from standings import is_postseason_window
+
+
+class TestIsPostseasonWindow:
+    def test_early_october_is_in_window(self):
+        """Early october is in window."""
+        assert is_postseason_window(datetime(2026, 10, 3)) is True
+
+    def test_late_october_is_in_window(self):
+        """Late october is in window."""
+        assert is_postseason_window(datetime(2026, 10, 31)) is True
+
+    def test_mid_september_boundary_included(self):
+        """Mid september boundary included."""
+        assert is_postseason_window(datetime(2026, 9, 15)) is True
+
+    def test_before_mid_september_excluded(self):
+        """Before mid september excluded."""
+        assert is_postseason_window(datetime(2026, 9, 14)) is False
+
+    def test_early_september_excluded(self):
+        """Early september excluded."""
+        assert is_postseason_window(datetime(2026, 9, 1)) is False
+
+    def test_mid_november_boundary_included(self):
+        """Mid november boundary included."""
+        assert is_postseason_window(datetime(2026, 11, 10)) is True
+
+    def test_after_mid_november_excluded(self):
+        """After mid november excluded."""
+        assert is_postseason_window(datetime(2026, 11, 11)) is False
+
+    def test_regular_season_month_excluded(self):
+        """Regular season month excluded."""
+        assert is_postseason_window(datetime(2026, 6, 15)) is False
+
+    def test_offseason_month_excluded(self):
+        """Offseason month excluded."""
+        assert is_postseason_window(datetime(2026, 1, 15)) is False
+
+    def test_december_excluded(self):
+        """December excluded."""
+        assert is_postseason_window(datetime(2026, 12, 25)) is False
+
+    def test_defaults_to_now_when_no_arg_given(self):
+        """No crash and returns a bool when called with no argument."""
+        assert isinstance(is_postseason_window(), bool)


### PR DESCRIPTION
## Summary
- `show_playoff_bracket` now defaults to `true` and self-detects the postseason instead of requiring a manual flip every October.
- `standings.is_postseason_window()` (mid-Sept through mid-Nov) gates the schedule-API fetch in `main.py`, so it's skipped entirely the other ~10 months of the year — no wasted calls during the regular season.
- The header only actually switches to the bracket once real current-season series data exists (`generate_image.py` / `image_featured.py` now check `_bracket.get('season') == current year` in addition to non-empty `series`, so a stale prior-season cache file can't linger and show); otherwise it falls through to wildcard standings exactly as before.
- Added an hourly staleness throttle (`_should_refresh_playoff_bracket`, mirroring the leaders/standings refresh pattern) since the previous code fetched on every single poll whenever the flag was on.
- A user can still force it off entirely by setting `show_playoff_bracket: false`.

## Test plan
- [x] `poetry run pytest -q` — 1586 passed
- [x] `poetry run ruff check` / `poetry run mypy` — clean
- New: `tests/test_postseason_window.py` (date-boundary coverage for the auto-detect window)
- Fixed 3 pre-existing tests whose synthetic bracket fixtures lacked a `season` field (now required to guard against stale-season display), and gave `test_generate_image_orchestrate.py`'s baseline `FIXED_CONFIG` an explicit `show_playoff_bracket: False` since it wasn't testing that feature and the new default broke an unrelated `load_json_file` call-count assertion.

Built on top of #208 (transactions ticker) but branched independently from `main` — no dependency between them, can merge in either order.