### PR TITLE
Fix dark mode never triggering on the display

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -62,9 +62,14 @@ morning_end: 9          # weekday cutoff (Mon–Fri)
 morning_end_weekend: 11 # weekend cutoff (Sat–Sun)
 
 
-# Auto dark/light mode: display is dark (inverted) during the night window
-# (night_start → night_end) and light during the day. No manual dark_mode toggle needed.
+# Auto dark/light mode: display is dark (inverted) between dark_start and dark_end,
+# light the rest of the day. No manual dark_mode toggle needed.
+# Kept separate from night_start/night_end (the refresh-skip window above) — if they
+# were the same, dark mode would only ever be true while refreshes are being skipped,
+# so the display would never actually be seen in dark mode.
 # A full e-ink refresh is forced on the day↔night transition to prevent ghosting.
+dark_start: 20  # 8pm
+dark_end: 7     # 7am
 
 # Team logos: display PNG logos instead of 3-letter abbreviations
 # Requires logo files in pic/logos/{ABBR}.png — run src/download_logos.py to fetch them


### PR DESCRIPTION
## Summary
- `dark_start`/`dark_end` were never set in `config/config.yaml`, so `_in_dark_window()` fell back to `night_start`/`night_end` (2am–7am) — the exact same window `night_mode` uses to skip refreshes entirely.
- Result: dark mode could only ever evaluate to `True` while the display refresh was being skipped, so the screen never actually rendered/showed dark mode — it just sat frozen in light mode.
- Fix: explicitly set `dark_start: 20` / `dark_end: 7` so the dark window (evening→morning) is decoupled from the narrow overnight refresh-skip window, matching the intent from #202.

## Test plan
- [ ] Deploy to Pi and confirm display flips to dark (inverted) shortly after 8pm and back to light around 7am
- [ ] Confirm a full refresh is forced on the transition (no ghosting)