### PR TITLE
Auto-refresh stale team logos every 30 days

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from display import send_to_display
 from util import load_json_file
 from standings import get_standings, fetch_playoff_bracket, fetch_transactions, is_postseason_window
 from image_box import set_historical_mode
+from image_assets import refresh_stale_logos
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +437,9 @@ Examples:
     print(f"Throttle bypass: {_no_throttle} (local={args.local}, platform={system_platform}, env_test={_is_test})")
 
     config = load_config(args.config)
+
+    if config.get('use_team_logos', False):
+        refresh_stale_logos()
 
     # 3. Night mode gate
     if config.get('night_mode', False) and not _no_throttle:

--- a/src/image_assets.py
+++ b/src/image_assets.py
@@ -53,6 +53,31 @@ def _get_logo_invert_config():
     return _logo_invert_config
 
 
+def refresh_stale_logos(max_age_days=30):
+    """Delete any cached logo PNG older than max_age_days.
+
+    Lazy re-download in _load_logo_gray only fires when a file is missing, so
+    a corrupted or outdated cached logo never gets refreshed on its own. This
+    forces periodic re-download (e.g. to pick up CDN artwork updates) without
+    needing an external cron job — safe to call every run since a freshly
+    re-downloaded logo's mtime won't clear the cutoff again for another
+    max_age_days.
+    """
+    import time
+    if not os.path.isdir(logodir):
+        return
+    cutoff = time.time() - max_age_days * 86400
+    for fname in os.listdir(logodir):
+        if not fname.endswith('.png'):
+            continue
+        fpath = os.path.join(logodir, fname)
+        try:
+            if os.path.getmtime(fpath) < cutoff:
+                os.remove(fpath)
+        except OSError:
+            pass
+
+
 def _try_download_logo(abbr, team_id=None):
     """Download a missing team logo from ESPN CDN using stdlib only (no pip needed).
 


### PR DESCRIPTION
## Summary
- Cached logo PNGs are only re-downloaded when missing, so a corrupted/outdated file (like today's DET logo issue) never self-heals on its own.
- Adds `refresh_stale_logos()` in `image_assets.py`, deleting any cached logo PNG older than 30 days; the existing lazy-download path in `_load_logo_gray` then re-fetches it automatically.
- Wired into `main.py` right after config load (gated on `use_team_logos`), so it runs on the existing cron cadence with no separate cron job needed, and self-heals even if the Pi was powered off past the 30-day mark (mtime-based, not a fixed calendar date).

## Test plan
- [x] Unit-verified `refresh_stale_logos` deletes files older than 30 days and leaves recent ones alone
- [x] `pytest tests/ -k "logo or main"` — 66 passed
- [x] Pre-commit syntax check + wide-cell smoke tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJ3aeVZUxT7bK8Ww6UKLJE