### PR TITLE
Fix DET logo (wrong CDN variant) and morning stale-data false alarm

### DIFF
--- a/pic/logo_render_config.json
+++ b/pic/logo_render_config.json
@@ -1,6 +1,6 @@
 {
   "_comment_non_dark": "non_dark: use mlb/500/ URL instead of mlb/500-dark/ — dark variant has white elements that disappear on white e-ink",
-  "non_dark": ["ATH", "BAL", "BOS", "CLE", "COL", "MIL", "MIN", "NYM"],
+  "non_dark": ["ATH", "BAL", "BOS", "CLE", "COL", "DET", "MIL", "MIN", "NYM"],
   "_comment_darken_white": "darken_white: turn near-white visible pixels black before compositing — logos with white outlines or text on colored backgrounds that vanish on white",
   "darken_white": ["LAA", "CIN", "ATH", "TEX", "STL", "NYM"],
   "ATH": false,

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -70,9 +70,13 @@ _DEBUG_STALE_HOURS = 2  # fetch age threshold before overlay turns inverted/alar
 def _fetch_skip_is_expected(config, sched):
     """Return True when a long gap since the last fetch is normal and expected.
 
-    Two cases suppress the stale alarm:
+    Three cases suppress the stale alarm:
     - Night mode is enabled and we are currently inside the night window, so
       fetching is intentionally paused.
+    - We're in the morning alternating window (night_end - morning_end):
+      main.py intentionally re-shows yesterday's already-final results on
+      alternating cycles here, so a fetch gap inherited from the overnight
+      quiet period is expected, not a sign anything is broken.
     - Smart polling determined there are no games until a future date, so
       the display is legitimately sitting out until then.
     """
@@ -92,6 +96,19 @@ def _fetch_skip_is_expected(config, sched):
                 return True
         except Exception:
             pass
+
+    # Morning alternating window check (mirrors main.py's date-selection logic)
+    try:
+        tz = pytz.timezone(config.get('timezone', 'America/Chicago'))
+        now = datetime.now(tz)
+        is_weekend = now.weekday() >= 5
+        morning_end = (config.get('morning_end_weekend', 11) if is_weekend
+                       else config.get('morning_end', 9))
+        morning_start = config.get('night_end', 7)
+        if morning_start <= now.hour < morning_end:
+            return True
+    except Exception:
+        pass
 
     # Off-day / between-season skip
     next_game_date = sched.get('next_game_date')

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -165,6 +165,15 @@ def test_skip_expected_during_weekend_morning_window_extended_end():
         assert _fetch_skip_is_expected(cfg, sched) is True
 
 
+def test_skip_morning_window_check_handles_exception_gracefully():
+    """Skip morning window check handles exception gracefully."""
+    sched = _make_sched()
+    cfg = dict(BASE_CONFIG, night_mode=False, morning_end=9)
+    with patch('generate_image.pytz.timezone', side_effect=Exception('boom')):
+        result = _fetch_skip_is_expected(cfg, sched)
+    assert result is False
+
+
 def test_skip_not_expected_after_morning_window_ends():
     """Skip not expected after morning window ends."""
     sched = _make_sched()

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -134,6 +134,52 @@ def test_skip_not_expected_when_next_game_date_is_today():
     assert result is False
 
 
+def test_skip_expected_during_morning_alternating_window():
+    """Skip expected during morning alternating window."""
+    sched = _make_sched()
+    cfg = dict(BASE_CONFIG, night_mode=False, morning_end=9)
+    import pytz
+    tz = pytz.timezone('America/Chicago')
+    # Wednesday 8am — inside the 7am-9am morning-alternating window
+    fake_now = datetime(2026, 7, 8, 8, 0, 0, tzinfo=tz)
+    with patch('generate_image.datetime') as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.now.side_effect = lambda *a, **kw: fake_now
+        mock_dt.fromisoformat = datetime.fromisoformat
+        assert _fetch_skip_is_expected(cfg, sched) is True
+
+
+def test_skip_expected_during_weekend_morning_window_extended_end():
+    """Skip expected during weekend morning window extended end."""
+    sched = _make_sched()
+    cfg = dict(BASE_CONFIG, night_mode=False, morning_end=9, morning_end_weekend=11)
+    import pytz
+    tz = pytz.timezone('America/Chicago')
+    # Saturday 10am — past weekday morning_end (9) but still within the
+    # weekend-extended morning_end_weekend (11) window
+    fake_now = datetime(2026, 7, 11, 10, 0, 0, tzinfo=tz)
+    with patch('generate_image.datetime') as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.now.side_effect = lambda *a, **kw: fake_now
+        mock_dt.fromisoformat = datetime.fromisoformat
+        assert _fetch_skip_is_expected(cfg, sched) is True
+
+
+def test_skip_not_expected_after_morning_window_ends():
+    """Skip not expected after morning window ends."""
+    sched = _make_sched()
+    cfg = dict(BASE_CONFIG, night_mode=False, morning_end=9)
+    import pytz
+    tz = pytz.timezone('America/Chicago')
+    # Wednesday 9am — at the morning_end boundary, window has closed
+    fake_now = datetime(2026, 7, 8, 9, 0, 0, tzinfo=tz)
+    with patch('generate_image.datetime') as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.now.side_effect = lambda *a, **kw: fake_now
+        mock_dt.fromisoformat = datetime.fromisoformat
+        assert _fetch_skip_is_expected(cfg, sched) is False
+
+
 def test_skip_not_expected_when_night_mode_disabled():
     """Skip not expected when night mode disabled."""
     cfg = dict(BASE_CONFIG, night_mode=False)


### PR DESCRIPTION
## Summary
- **DET logo missing**: root cause found — ESPN's `mlb/500-dark/det.png` variant is a solid white silhouette (confirmed via pixel dump: 100% white/transparent), meant for dark UI backgrounds, and invisible on white e-ink no matter the invert setting. PR #206 only adjusted `invert`, which couldn't fix an all-white source image. Adds `DET` to the `non_dark` list in `pic/logo_render_config.json` so it downloads the correctly-colored normal variant instead (same pattern already used for ATH/BAL/BOS/CLE/COL/MIL/MIN/NYM).
- **Stale-data alarm firing every morning**: `main.py` intentionally alternates between showing yesterday's final scores and today's schedule between `night_end` (7am) and `morning_end` (9am) — a quiet period by design. `_fetch_skip_is_expected()` in `generate_image.py` didn't know about this window, so the inherited overnight fetch gap tripped the 2-hour stale threshold as soon as night mode ended. Added the same window check used by `main.py`'s date-selection logic to suppress the alarm during this period.

## Test plan
- [x] Verified `_load_logo_gray('DET', 116)` downloads the corrected (colored, 34KB) logo and produces real black/white contrast, not a blank image
- [x] `pytest tests/` — 1610 passed, 15 skipped
- [x] Pre-commit syntax check + wide-cell smoke tests passed

Note: the Pi's cached `pic/logos/DET.png` is the old broken white-silhouette file — delete it after pulling this (`rm pic/logos/DET.png`) so it re-downloads with the corrected `non_dark` setting immediately, rather than waiting for the 30-day auto-refresh from #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJ3aeVZUxT7bK8Ww6UKLJE