### PR TITLE
Remove 30-day stale-logo refresh; download only when missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,6 @@ from display import send_to_display
 from util import load_json_file
 from standings import get_standings, fetch_playoff_bracket, fetch_transactions, is_postseason_window
 from image_box import set_historical_mode
-from image_assets import refresh_stale_logos
 
 
 # ---------------------------------------------------------------------------
@@ -437,9 +436,6 @@ Examples:
     print(f"Throttle bypass: {_no_throttle} (local={args.local}, platform={system_platform}, env_test={_is_test})")
 
     config = load_config(args.config)
-
-    if config.get('use_team_logos', False):
-        refresh_stale_logos()
 
     # 3. Night mode gate
     if config.get('night_mode', False) and not _no_throttle:

--- a/src/image_assets.py
+++ b/src/image_assets.py
@@ -53,31 +53,6 @@ def _get_logo_invert_config():
     return _logo_invert_config
 
 
-def refresh_stale_logos(max_age_days=30):
-    """Delete any cached logo PNG older than max_age_days.
-
-    Lazy re-download in _load_logo_gray only fires when a file is missing, so
-    a corrupted or outdated cached logo never gets refreshed on its own. This
-    forces periodic re-download (e.g. to pick up CDN artwork updates) without
-    needing an external cron job — safe to call every run since a freshly
-    re-downloaded logo's mtime won't clear the cutoff again for another
-    max_age_days.
-    """
-    import time
-    if not os.path.isdir(logodir):
-        return
-    cutoff = time.time() - max_age_days * 86400
-    for fname in os.listdir(logodir):
-        if not fname.endswith('.png'):
-            continue
-        fpath = os.path.join(logodir, fname)
-        try:
-            if os.path.getmtime(fpath) < cutoff:
-                os.remove(fpath)
-        except OSError:
-            pass
-
-
 def _try_download_logo(abbr, team_id=None):
     """Download a missing team logo from ESPN CDN using stdlib only (no pip needed).
 


### PR DESCRIPTION
## Summary
- Removes `refresh_stale_logos()` and its call in `main.py`
- Logos are now only downloaded when the file is missing (no periodic re-download/deletion based on age)

Follow-up to the DET logo CDN-variant bug: the 30-day refresh masked the real problem (bad cached files should just be removed, not waited out) and added complexity for no real benefit.

## Test plan
- [x] `poetry run pytest -q` — 1619 passed, 15 skipped