### PR TITLE
Add Home Run Derby bracket display mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ data/*.json
 !data/mlbam_walls.json
 # Exception: static stadium weather coordinates (lat/lon + roof type)
 !data/stadium_weather.json
+# Exception: hand-maintained Home Run Derby bracket (no API source; edited by hand)
+!data/derby_bracket.json
 
 # Environment
 .env

--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ FEATURED_TEAM_FULLSCREEN=true poetry run python main.py
 */14 * * * * cd /home/pi/mlb_display && poetry run python main.py >> logs/display.log 2>&1
 ```
 
+On the Home Run Derby's actual date, if there are no games to show, main.py automatically
+switches to the Derby bracket (see `auto_derby_mode` in config.yaml) instead of exiting quietly.
+Once the event goes live, that run blocks and polls MLB every 60 seconds until the derby ends
+(capped at 3 hours) rather than waiting for the next 14-minute cron tick — so a concurrent cron
+invocation firing mid-derby is expected and harmless (it just re-fetches/re-renders the same data).
+
 **systemd** — recommended for auto-start on boot:
 
 ```ini

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,11 +2,14 @@
 # scoreboard: true = 15 game grid, false = 2 detailed linescores + standings
 scoreboard: true
 
-# Display mode: "scoreboard" | "linescore" | "field" | "scorecard" | "pitch"
+# Display mode: "scoreboard" | "linescore" | "field" | "scorecard" | "pitch" | "derby"
 # If set, overrides the scoreboard: true/false flag above.
 # "field"     = single-game field diagram with runners, hit location, strike zone overlay
 # "scorecard" = official scorer-style per-batter at-bat grid for both teams
 # "pitch"     = full strike zone with pitch locations for current at-bat
+# "derby"     = Home Run Derby single-elimination bracket, read from data/derby_bracket.json.
+#               There's no MLB API for derby brackets, so edit that file by hand with the
+#               real 8 participants before the event and flip winner/hr/complete as rounds finish.
 display_mode: "scoreboard"
 
 primary: NYY

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,9 +7,9 @@ scoreboard: true
 # "field"     = single-game field diagram with runners, hit location, strike zone overlay
 # "scorecard" = official scorer-style per-batter at-bat grid for both teams
 # "pitch"     = full strike zone with pitch locations for current at-bat
-# "derby"     = Home Run Derby single-elimination bracket, read from data/derby_bracket.json.
-#               There's no MLB API for derby brackets, so edit that file by hand with the
-#               real 8 participants before the event and flip winner/hr/complete as rounds finish.
+# "derby"     = Home Run Derby single-elimination bracket. Auto-fetched from MLB's Stats API
+#               (src/fetch_derby.py) each run and cached to data/derby_bracket.json; falls back
+#               to the last cached file if the event hasn't started yet or the fetch fails.
 display_mode: "scoreboard"
 
 primary: NYY

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,14 @@ scoreboard: true
 # "derby"     = Home Run Derby single-elimination bracket. Auto-fetched from MLB's Stats API
 #               (src/fetch_derby.py) each run and cached to data/derby_bracket.json; falls back
 #               to the last cached file if the event hasn't started yet or the fetch fails.
+#               Setting display_mode to "derby" here forces it on unconditionally. You normally
+#               don't need to — see auto_derby_mode below.
 display_mode: "scoreboard"
+
+# Automatically switch to the Home Run Derby bracket (see "derby" above) on the actual Derby
+# date, but only on days with no games to show (e.g. the All-Star break) — days with real games
+# always take priority. Set to false to disable and rely solely on display_mode above.
+auto_derby_mode: true
 
 primary: NYY
 primary_backup: BOS

--- a/data/derby_bracket.json
+++ b/data/derby_bracket.json
@@ -1,0 +1,39 @@
+{
+  "event_date": "2026-07-13",
+  "round_status": "Round 1 - In Progress",
+  "matchups": {
+    "qf": [
+      {"complete": true,  "players": [
+        {"name": "J. Judge",    "abbr": "NYY", "hr": 23, "winner": true},
+        {"name": "P. Alonso",   "abbr": "NYM", "hr": 17, "winner": false}
+      ]},
+      {"complete": false, "players": [
+        {"name": "S. Ohtani",   "abbr": "LAD", "hr": 14, "winner": false},
+        {"name": "K. Schwarber","abbr": "PHI", "hr": 11, "winner": false}
+      ]},
+      {"complete": false, "players": [
+        {"name": "TBD", "abbr": "", "hr": null, "winner": false},
+        {"name": "TBD", "abbr": "", "hr": null, "winner": false}
+      ]},
+      {"complete": false, "players": [
+        {"name": "TBD", "abbr": "", "hr": null, "winner": false},
+        {"name": "TBD", "abbr": "", "hr": null, "winner": false}
+      ]}
+    ],
+    "sf": [
+      {"complete": false, "players": [
+        {"name": "J. Judge", "abbr": "NYY", "hr": null, "winner": false},
+        {"name": "TBD",      "abbr": "",    "hr": null, "winner": false}
+      ]},
+      {"complete": false, "players": [
+        {"name": "TBD", "abbr": "", "hr": null, "winner": false},
+        {"name": "TBD", "abbr": "", "hr": null, "winner": false}
+      ]}
+    ],
+    "final": {"complete": false, "players": [
+      {"name": "TBD", "abbr": "", "hr": null, "winner": false},
+      {"name": "TBD", "abbr": "", "hr": null, "winner": false}
+    ]}
+  },
+  "champion": null
+}

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import os
 import json
 import platform
 import argparse
+import time
 from datetime import datetime, timedelta, timezone
 
 import pytz
@@ -19,7 +20,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 from config_loader import load_config, add_config_arg
 from fetch_games import fetch_scoreboard_for_date, fetch_all_team_abbreviations, find_next_game_date, fetch_tomorrow_games, SPORT_NAMES
 from fetch_leaders import fetch_leaders
-from fetch_derby import fetch_and_save_derby_bracket
+from fetch_derby import fetch_and_save_derby_bracket, get_derby_date
 from render_scoreboard import render
 from display import send_to_display
 from util import load_json_file
@@ -353,6 +354,74 @@ def _should_skip_poll(date_str, config, sched):
     return False, ""
 
 
+_DERBY_LIVE_POLL_SECONDS = 60          # re-check every minute while the derby is actually in progress
+_DERBY_LIVE_POLL_MAX_SECONDS = 3 * 60 * 60  # safety cap in case the API never reports "Final"
+
+
+def _run_derby_mode(config, event_id=None, no_throttle=False, auto_open=False):
+    """Fetch the live Derby bracket and render/display it, overriding display_mode.
+
+    The rest of the day this runs once per invocation like every other mode
+    (paced by cron, e.g. every 14 min — see README). But once the event's
+    status flips to "In Progress" it blocks in a minute-by-minute poll loop
+    right here so the display tracks the live bracket without waiting for
+    the next cron tick, exiting once the derby is no longer in progress (or
+    after a safety cap in case the API never reports "Final").
+    """
+    start = time.monotonic()
+    while True:
+        try:
+            bracket = fetch_and_save_derby_bracket(event_id=event_id)
+        except Exception as _derby_e:
+            print(f"Warning: derby bracket fetch failed: {_derby_e}")
+            bracket = None
+
+        derby_config = dict(config, display_mode='derby')
+        output_path = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
+        result = render(derby_config, output_path=output_path, bypass_cache=no_throttle)
+        if result:
+            image, changed_regions = result
+            refresh_mode = send_to_display(output_path, changed_regions, force_full=no_throttle)
+            print(f"Derby: {refresh_mode} refresh ({len(changed_regions)} region(s))")
+            if auto_open:
+                import subprocess
+                subprocess.run(['open', output_path], check=False)
+        else:
+            print("No display update needed - image unchanged")
+
+        if not bracket or bracket.get('state') != 'In Progress':
+            break
+        if time.monotonic() - start > _DERBY_LIVE_POLL_MAX_SECONDS:
+            print("Derby live-poll safety cap reached — stopping (next cron tick will resume)")
+            break
+        print(f"Derby in progress — checking again in {_DERBY_LIVE_POLL_SECONDS}s")
+        time.sleep(_DERBY_LIVE_POLL_SECONDS)
+
+
+def _maybe_show_derby_bracket(config, no_throttle=False, auto_open=False):
+    """When there are no games, check whether today is actually Derby day and show it.
+
+    Returns True if today is Derby day (bracket fetched/rendered/displayed, or
+    already up to date) so the caller can skip its normal "no games" handling.
+    Returns False otherwise (auto_derby_mode disabled, lookup failed, or it's
+    just not Derby day) so the caller falls back to normal no-game behavior.
+    """
+    if not config.get('auto_derby_mode', True):
+        return False
+    try:
+        tz = config.get('timezone', 'America/Chicago')
+        today_str = datetime.now(pytz.timezone(tz)).strftime('%Y-%m-%d')
+        derby_date, derby_event_id = get_derby_date()
+    except Exception as _derby_lookup_e:
+        print(f"Warning: derby day auto-detection failed: {_derby_lookup_e}")
+        return False
+    if derby_date != today_str:
+        return False
+    print(f"No games today, but it's Derby day ({today_str}) — showing Home Run Derby bracket")
+    _run_derby_mode(config, event_id=derby_event_id, no_throttle=no_throttle, auto_open=auto_open)
+    return True
+
+
 def _update_schedule_state(game_state_data, date_str, config, sched):
     """Update schedule state."""
     sched['last_game_fetch'] = datetime.now(timezone.utc).isoformat(timespec='seconds')
@@ -446,24 +515,11 @@ Examples:
             print(f"Night mode: skipping refresh ({now_str})")
             return
 
-    # Home Run Derby bracket mode bypasses the normal game-schedule pipeline
-    # entirely (there's no "game" to fetch/poll for — it's a standalone event).
+    # Home Run Derby bracket mode: explicit manual override. Bypasses the normal
+    # game-schedule pipeline entirely (there's no "game" to fetch/poll for).
     if config.get('display_mode') == 'derby':
-        try:
-            fetch_and_save_derby_bracket()
-        except Exception as _derby_e:
-            print(f"Warning: derby bracket fetch failed: {_derby_e}")
-        output_path = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
-        result = render(config, output_path=output_path, bypass_cache=_no_throttle)
-        if not result:
-            print("No display update needed - image unchanged")
-            return
-        image, changed_regions = result
-        refresh_mode = send_to_display(output_path, changed_regions, force_full=_no_throttle)
-        print(f"Derby: {refresh_mode} refresh ({len(changed_regions)} region(s))")
-        if args.local and system_platform == 'Darwin':
-            import subprocess
-            subprocess.run(['open', output_path], check=False)
+        _run_derby_mode(config, event_id=None, no_throttle=_no_throttle,
+                        auto_open=args.local and system_platform == 'Darwin')
         return
 
     league_mode = (os.environ.get('LEAGUE_MODE', '').lower().strip()
@@ -551,6 +607,9 @@ Examples:
             skip, reason = _should_skip_poll(date_str, config, sched)
             if skip:
                 print(reason)
+                if reason.startswith("No games until") and _maybe_show_derby_bracket(
+                        config, no_throttle=_no_throttle, auto_open=args.local and system_platform == 'Darwin'):
+                    return
                 # Still refresh standings if needed — sidebar/fullscreen must stay current
                 # even when the game-data poll is throttled.
                 _sl_needs = (
@@ -615,6 +674,8 @@ Examples:
             game_state_data = load_json_file('games.json').get('games', [])
             no_games = _update_schedule_state(game_state_data, date_str, config, sched)
             if no_games:
+                _maybe_show_derby_bracket(config, no_throttle=_no_throttle,
+                                          auto_open=args.local and system_platform == 'Darwin')
                 return
 
     # 7b. Standings refresh

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 from config_loader import load_config, add_config_arg
 from fetch_games import fetch_scoreboard_for_date, fetch_all_team_abbreviations, find_next_game_date, fetch_tomorrow_games, SPORT_NAMES
 from fetch_leaders import fetch_leaders
+from fetch_derby import fetch_and_save_derby_bracket
 from render_scoreboard import render
 from display import send_to_display
 from util import load_json_file
@@ -444,6 +445,26 @@ Examples:
             now_str = datetime.now(pytz.timezone(tz)).strftime('%H:%M')
             print(f"Night mode: skipping refresh ({now_str})")
             return
+
+    # Home Run Derby bracket mode bypasses the normal game-schedule pipeline
+    # entirely (there's no "game" to fetch/poll for — it's a standalone event).
+    if config.get('display_mode') == 'derby':
+        try:
+            fetch_and_save_derby_bracket()
+        except Exception as _derby_e:
+            print(f"Warning: derby bracket fetch failed: {_derby_e}")
+        output_path = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
+        result = render(config, output_path=output_path, bypass_cache=_no_throttle)
+        if not result:
+            print("No display update needed - image unchanged")
+            return
+        image, changed_regions = result
+        refresh_mode = send_to_display(output_path, changed_regions, force_full=_no_throttle)
+        print(f"Derby: {refresh_mode} refresh ({len(changed_regions)} region(s))")
+        if args.local and system_platform == 'Darwin':
+            import subprocess
+            subprocess.run(['open', output_path], check=False)
+        return
 
     league_mode = (os.environ.get('LEAGUE_MODE', '').lower().strip()
                    or config.get('league_mode', 'mlb'))

--- a/src/config_server.py
+++ b/src/config_server.py
@@ -35,7 +35,7 @@ FIELD_SPECS = [
     {'key': 'primary', 'source': 'yaml', 'type': 'text',
      'label': 'Primary Team', 'help': 'Abbreviation shown first / highlighted, e.g. NYY'},
     {'key': 'display_mode', 'source': 'yaml', 'type': 'select',
-     'label': 'Display Mode', 'options': ['scoreboard', 'linescore', 'field', 'scorecard', 'pitch']},
+     'label': 'Display Mode', 'options': ['scoreboard', 'linescore', 'field', 'scorecard', 'pitch', 'derby']},
     {'key': 'league_mode', 'source': 'yaml', 'type': 'select',
      'label': 'League Mode', 'options': ['mlb', 'aaa']},
     {'key': 'show_leaders_panel', 'source': 'yaml', 'type': 'bool', 'label': 'Season Leaders Panel'},

--- a/src/fetch_derby.py
+++ b/src/fetch_derby.py
@@ -227,7 +227,7 @@ def fetch_and_save_derby_bracket(season=None, event_id=None):
     return result
 
 
-def main():
+def main():  # pragma: no cover
     parser = argparse.ArgumentParser(description='Fetch live Home Run Derby bracket data')
     parser.add_argument('--season', type=int, default=None, help='Season year (default: current year)')
     parser.add_argument('--event-id', type=int, default=None, help='Derby event id override (skip lookup)')

--- a/src/fetch_derby.py
+++ b/src/fetch_derby.py
@@ -14,15 +14,17 @@ import argparse
 import re
 import sys
 import os
+import time
 from datetime import datetime, timedelta
 
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from util import save_off_results
+from util import save_off_results, load_json_file
 from config_loader import load_config, add_config_arg
 
 _STATS_API = 'https://statsapi.mlb.com/api/v1'
+_EVENT_CACHE_TTL = 86400  # re-resolve the event id/date at most once a day
 _DERBY_NAME_RE = re.compile(r'All-Star Workout Day: Home Run Derby', re.IGNORECASE)
 
 
@@ -62,6 +64,34 @@ def find_derby_event_id(season):
                 if _DERBY_NAME_RE.search(event.get('name', '')):
                     return event.get('id'), candidate
     return None, None
+
+
+def get_derby_date(season=None, force_refresh=False):
+    """Return (event_date, event_id) for this season's Derby, cached for a day.
+
+    Cheap enough to call on every main.py run to check "is today Derby day?"
+    without hitting the schedule API each time — the event date/id can't
+    change once MLB publishes the schedule, so a daily refresh is plenty.
+    """
+    current_season = season or datetime.now().year
+    cache = load_json_file('derby_event_cache.json') or {}
+    fresh = (
+        not force_refresh
+        and cache.get('season') == current_season
+        and cache.get('event_date')
+        and time.time() - cache.get('fetched_at', 0) < _EVENT_CACHE_TTL
+    )
+    if fresh:
+        return cache['event_date'], cache.get('event_id')
+
+    event_id, event_date = find_derby_event_id(current_season)
+    save_off_results({
+        'season': current_season,
+        'event_id': event_id,
+        'event_date': event_date,
+        'fetched_at': time.time(),
+    }, 'derby_event_cache')
+    return event_date, event_id
 
 
 def fetch_derby_bracket_raw(event_id):
@@ -165,6 +195,7 @@ def transform_bracket(raw, event_date):
     return {
         'event_date': event_date,
         'round_status': round_status,
+        'state': state,  # raw MLB status.state: 'Preview' | 'In Progress' | 'Final' — used to pace polling
         'matchups': {'qf': qf, 'sf': sf, 'final': final},
         'champion': champion,
     }

--- a/src/fetch_derby.py
+++ b/src/fetch_derby.py
@@ -1,0 +1,213 @@
+"""
+Fetch live Home Run Derby bracket data from the MLB Stats API and write
+data/derby_bracket.json in the shape image_derby.render_derby_bracket() expects.
+
+There's no dedicated "derby" entry in the regular schedule/gameType endpoints —
+the event lives in the non-game "events" calendar (scheduleTypes=events) under
+a name like "<year> MLB All-Star Workout Day: Home Run Derby", and its bracket
+is served by GET /api/v1/homeRunDerby/{event_id}/bracket once the event starts.
+
+Standalone CLI:
+    python src/fetch_derby.py [--season 2026] [--event-id 838655]
+"""
+import argparse
+import re
+import sys
+import os
+from datetime import datetime, timedelta
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from util import save_off_results
+from config_loader import load_config, add_config_arg
+
+_STATS_API = 'https://statsapi.mlb.com/api/v1'
+_DERBY_NAME_RE = re.compile(r'All-Star Workout Day: Home Run Derby', re.IGNORECASE)
+
+
+def _find_asg_date(season):
+    """Return the All-Star Game's officialDate string for a season, or None."""
+    resp = requests.get(f'{_STATS_API}/schedule', params={
+        'sportId': 1, 'gameType': 'A', 'season': season,
+    }, timeout=10)
+    resp.raise_for_status()
+    for day in resp.json().get('dates', []):
+        for game in day.get('games', []):
+            if game.get('gameType') == 'A':
+                return game.get('officialDate')
+    return None
+
+
+def find_derby_event_id(season):
+    """Locate this season's Home Run Derby non-game event id.
+
+    Searches the events calendar on and around the day before the All-Star
+    Game (where the Derby is traditionally held) for an event named
+    "<year> MLB All-Star Workout Day: Home Run Derby".
+    """
+    asg_date_str = _find_asg_date(season)
+    if not asg_date_str:
+        return None, None
+
+    asg_date = datetime.strptime(asg_date_str, '%Y-%m-%d')
+    for offset in (1, 2, 3):  # derby is usually 1 day before ASG; scan a small window
+        candidate = (asg_date - timedelta(days=offset)).strftime('%Y-%m-%d')
+        resp = requests.get(f'{_STATS_API}/schedule', params={
+            'sportId': 1, 'date': candidate, 'scheduleTypes': 'events',
+        }, timeout=10)
+        resp.raise_for_status()
+        for day in resp.json().get('dates', []):
+            for event in day.get('events', []):
+                if _DERBY_NAME_RE.search(event.get('name', '')):
+                    return event.get('id'), candidate
+    return None, None
+
+
+def fetch_derby_bracket_raw(event_id):
+    """GET the raw homeRunDerby bracket payload for an event id, or None."""
+    resp = requests.get(f'{_STATS_API}/homeRunDerby/{event_id}/bracket', timeout=10)
+    if resp.status_code != 200:
+        return None
+    data = resp.json()
+    if 'rounds' not in data:
+        return None
+    return data
+
+
+def _team_abbr_by_player_id(raw):
+    return {
+        p['id']: p.get('currentTeam', {}).get('abbreviation', '')
+        for p in raw.get('players', [])
+    }
+
+
+def _short_name(full_name):
+    """'Cal Raleigh' -> 'C. Raleigh'."""
+    parts = full_name.split(' ', 1)
+    if len(parts) != 2:
+        return full_name
+    first, last = parts
+    return f'{first[0]}. {last}'
+
+
+def _seed_to_player(seed, team_abbr):
+    if not seed or not seed.get('player'):
+        return {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False}
+    player = seed['player']
+    return {
+        'name': _short_name(player.get('fullName', 'TBD')),
+        'abbr': team_abbr.get(player.get('id'), ''),
+        'hr': seed.get('numHomeRuns') if seed.get('started') else None,
+        'winner': bool(seed.get('winner')),
+    }
+
+
+def _matchup_complete(matchup):
+    top, bottom = matchup.get('topSeed'), matchup.get('bottomSeed')
+    return bool(top and top.get('complete') and bottom and bottom.get('complete'))
+
+
+def transform_bracket(raw, event_date):
+    """Convert the raw MLB Stats API bracket payload into our derby_bracket.json shape."""
+    team_abbr = _team_abbr_by_player_id(raw)
+    rounds = sorted(raw.get('rounds', []), key=lambda r: r['round'])
+
+    def _round_matchups(round_data):
+        if not round_data:
+            return []
+        return [
+            {
+                'complete': _matchup_complete(m),
+                'players': [
+                    _seed_to_player(m.get('topSeed'), team_abbr),
+                    _seed_to_player(m.get('bottomSeed'), team_abbr),
+                ],
+            }
+            for m in round_data.get('matchups', [])
+        ]
+
+    qf = _round_matchups(rounds[0] if len(rounds) > 0 else None)
+    sf = _round_matchups(rounds[1] if len(rounds) > 1 else None)
+    final_list = _round_matchups(rounds[2] if len(rounds) > 2 else None)
+    final = final_list[0] if final_list else {
+        'complete': False,
+        'players': [
+            {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False},
+            {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False},
+        ],
+    }
+
+    # Pad qf/sf out to the expected slot counts with TBD placeholders so
+    # render_derby_bracket always has 4 qf / 2 sf entries to lay out.
+    _tbd_matchup = {
+        'complete': False,
+        'players': [
+            {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False},
+            {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False},
+        ],
+    }
+    while len(qf) < 4:
+        qf.append(dict(_tbd_matchup))
+    while len(sf) < 2:
+        sf.append(dict(_tbd_matchup))
+
+    status = raw.get('status', {})
+    state = status.get('state', '')
+    current_round = status.get('currentRound')
+    round_status = f'Round {current_round} - {state}' if current_round else state
+
+    champion = None
+    for p in final.get('players', []):
+        if p.get('winner'):
+            champion = p.get('name')
+
+    return {
+        'event_date': event_date,
+        'round_status': round_status,
+        'matchups': {'qf': qf, 'sf': sf, 'final': final},
+        'champion': champion,
+    }
+
+
+def fetch_and_save_derby_bracket(season=None, event_id=None):
+    """Fetch the live derby bracket and write data/derby_bracket.json. Returns the saved dict or None."""
+    if season is None:
+        season = datetime.now().year
+
+    event_date = None
+    if event_id is None:
+        event_id, event_date = find_derby_event_id(season)
+        if event_id is None:
+            print(f'No Home Run Derby event found for season {season}')
+            return None
+
+    raw = fetch_derby_bracket_raw(event_id)
+    if raw is None:
+        print(f'No derby bracket data yet for event {event_id} (event may not have started)')
+        return None
+
+    if event_date is None:
+        event_date = raw.get('info', {}).get('eventDate', '')[:10]
+
+    result = transform_bracket(raw, event_date)
+    save_off_results(result, 'derby_bracket')
+    print(f'Derby bracket saved: {result["round_status"]}')
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Fetch live Home Run Derby bracket data')
+    parser.add_argument('--season', type=int, default=None, help='Season year (default: current year)')
+    parser.add_argument('--event-id', type=int, default=None, help='Derby event id override (skip lookup)')
+    add_config_arg(parser)
+    args = parser.parse_args()
+
+    load_config(args.config)  # validated for CLI consistency with other fetch_* scripts
+    result = fetch_and_save_derby_bracket(season=args.season, event_id=args.event_id)
+    if not result:
+        sys.exit(1)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/src/image_derby.py
+++ b/src/image_derby.py
@@ -1,0 +1,165 @@
+"""Home Run Derby bracket rendering (single elimination, 8 batters).
+
+Data source: data/derby_bracket.json — there is no MLB Stats API endpoint for
+Derby bracket progress, so this file is maintained by hand (or a small manual
+update script) during the event: fill in real names/seeds ahead of time, then
+flip "complete"/"winner"/"hr" as each round finishes.
+"""
+from image_assets import Image, ImageDraw, _get_font
+
+EPD_WIDTH = 800
+EPD_HEIGHT = 480
+
+_HEADER_H = 46
+_AREA_TOP = _HEADER_H
+_AREA_H = EPD_HEIGHT - _AREA_TOP - 10
+
+_QF_X = 15
+_SF_X = 260
+_FINAL_X = 500
+_CHAMP_X = 715
+
+_BOX_W_QF = 175
+_BOX_W_SF = 175
+_BOX_W_FINAL = 175
+_BOX_H = 40  # two player rows @ ~20px each
+
+_COL_LABEL_Y = _AREA_TOP - 14
+
+
+def _slot_centers(n):
+    """Evenly spaced vertical centers for n boxes across the bracket area."""
+    slot_h = _AREA_H / n
+    return [_AREA_TOP + slot_h * (i + 0.5) for i in range(n)]
+
+
+def _player_row_text(player):
+    """'J. Judge (NYY)' left side; 'TBD' when not yet determined."""
+    name = player.get('name') or 'TBD'
+    abbr = player.get('abbr') or ''
+    label = f"{name} ({abbr})" if abbr else name
+    hr = player.get('hr')
+    score = '' if hr is None else str(hr)
+    return label, score
+
+
+def _draw_matchup_box(draw, x, y_center, w, matchup, font):
+    """Draw a two-player matchup card centered at y_center. Returns box (x0,y0,x1,y1)."""
+    h = _BOX_H
+    y0 = int(y_center - h / 2)
+    y1 = y0 + h
+    draw.rectangle([x, y0, x + w, y1], outline=0, width=1)
+    draw.line([x, y0 + h // 2, x + w, y0 + h // 2], fill=0, width=1)
+
+    players = matchup.get('players', [{}, {}])
+    for i, player in enumerate(players[:2]):
+        row_y = y0 + (i * h // 2)
+        label, score = _player_row_text(player)
+        text_y = row_y + (h // 2 - 11) // 2 + 1
+        draw.text((x + 4, text_y), label, font=font, fill=0)
+        if score:
+            sw = draw.textlength(score, font=font)
+            draw.text((x + w - sw - 6, text_y), score, font=font, fill=0)
+        if player.get('winner'):
+            # bold the winning row by double-drawing offset by 1px
+            draw.text((x + 5, text_y), label, font=font, fill=0)
+
+    return (x, y0, x + w, y1)
+
+
+def _connect(draw, box_a, box_b, target_x, target_y_center):
+    """Elbow connector from the right-mid of two feeder boxes into a target box's left-mid."""
+    for box in (box_a, box_b):
+        x1, y0, x1r, y1 = box
+        mid_y = (y0 + y1) // 2
+        mid_x = (x1r + target_x) // 2
+        draw.line([x1r, mid_y, mid_x, mid_y], fill=0, width=1)
+        draw.line([mid_x, mid_y, mid_x, target_y_center], fill=0, width=1)
+        draw.line([mid_x, target_y_center, target_x, target_y_center], fill=0, width=1)
+
+
+def render_derby_bracket(derby_data, dark_mode=False):
+    """Render the 8-man Home Run Derby single-elimination bracket as an 800x480 image."""
+    canvas = Image.new('1', (EPD_WIDTH, EPD_HEIGHT), 255)
+    draw = ImageDraw.Draw(canvas)
+
+    f28 = _get_font(28)
+    f14 = _get_font(14)
+    f11 = _get_font(11)
+    f9 = _get_font(9)
+
+    title = "HOME RUN DERBY"
+    tw = draw.textlength(title, font=f28)
+    draw.text(((EPD_WIDTH - tw) / 2, 4), title, font=f28, fill=0)
+
+    status = derby_data.get('round_status', '')
+    date_str = derby_data.get('event_date', '')
+    sub = f"{date_str}   {status}".strip()
+    sw = draw.textlength(sub, font=f9)
+    draw.text(((EPD_WIDTH - sw) / 2, 34), sub, font=f9, fill=0)
+
+    matchups = derby_data.get('matchups', {})
+    qf_list = matchups.get('qf', [])
+    sf_list = matchups.get('sf', [])
+    final_m = matchups.get('final', {})
+
+    for label, x in (("QUARTERFINALS", _QF_X), ("SEMIFINALS", _SF_X),
+                      ("FINAL", _FINAL_X), ("CHAMPION", _CHAMP_X)):
+        draw.text((x, _COL_LABEL_Y), label, font=f9, fill=0)
+
+    qf_centers = _slot_centers(4)
+    qf_boxes = []
+    for center, matchup in zip(qf_centers, qf_list):
+        box = _draw_matchup_box(draw, _QF_X, center, _BOX_W_QF, matchup, f11)
+        qf_boxes.append(box)
+
+    sf_centers = [
+        (qf_centers[0] + qf_centers[1]) / 2,
+        (qf_centers[2] + qf_centers[3]) / 2,
+    ]
+    sf_boxes = []
+    for i, (center, matchup) in enumerate(zip(sf_centers, sf_list)):
+        box = _draw_matchup_box(draw, _SF_X, center, _BOX_W_SF, matchup, f11)
+        sf_boxes.append(box)
+        _connect(draw, qf_boxes[i * 2], qf_boxes[i * 2 + 1], _SF_X, center)
+
+    final_center = (sf_centers[0] + sf_centers[1]) / 2
+    final_box = _draw_matchup_box(draw, _FINAL_X, final_center, _BOX_W_FINAL, final_m, f14)
+    _connect(draw, sf_boxes[0], sf_boxes[1], _FINAL_X, final_center)
+
+    champion = derby_data.get('champion')
+    champ_players = final_m.get('players', [])
+    if not champion:
+        for p in champ_players:
+            if p.get('winner'):
+                champion = p.get('name')
+                break
+
+    cx = _CHAMP_X
+    cy = final_center
+    draw.rectangle([cx, cy - 30, EPD_WIDTH - 10, cy + 30], outline=0, width=2)
+    star = "★"
+    if champion:
+        try:
+            sw = draw.textlength(star, font=f14)
+        except Exception:
+            sw = 0
+        draw.text((cx + (EPD_WIDTH - 10 - cx - sw) / 2, cy - 24), star, font=f14, fill=0)
+        cw = draw.textlength(champion, font=f14)
+        draw.text((cx + (EPD_WIDTH - 10 - cx - cw) / 2, cy + 2), champion, font=f14, fill=0)
+    else:
+        tbd = "TBD"
+        tw = draw.textlength(tbd, font=f14)
+        draw.text((cx + (EPD_WIDTH - 10 - cx - tw) / 2, cy - 7), tbd, font=f14, fill=0)
+    # Final -> champion connector (single feeder, not the two-box elbow helper)
+    x1r = final_box[2]
+    mid_x = (x1r + cx) // 2
+    draw.line([x1r, final_center, mid_x, final_center], fill=0, width=1)
+    draw.line([mid_x, final_center, mid_x, cy], fill=0, width=1)
+    draw.line([mid_x, cy, cx, cy], fill=0, width=1)
+
+    if dark_mode:
+        from PIL import ImageOps
+        canvas = ImageOps.invert(canvas.convert('L')).convert('1')
+
+    return canvas

--- a/src/image_derby.py
+++ b/src/image_derby.py
@@ -140,10 +140,7 @@ def render_derby_bracket(derby_data, dark_mode=False):
     draw.rectangle([cx, cy - 30, EPD_WIDTH - 10, cy + 30], outline=0, width=2)
     star = "★"
     if champion:
-        try:
-            sw = draw.textlength(star, font=f14)
-        except Exception:
-            sw = 0
+        sw = draw.textlength(star, font=f14)
         draw.text((cx + (EPD_WIDTH - 10 - cx - sw) / 2, cy - 24), star, font=f14, fill=0)
         cw = draw.textlength(champion, font=f14)
         draw.text((cx + (EPD_WIDTH - 10 - cx - cw) / 2, cy + 2), champion, font=f14, fill=0)

--- a/src/render_scoreboard.py
+++ b/src/render_scoreboard.py
@@ -21,6 +21,7 @@ from game_detail_fetch import select_game, fetch_field_view_data, fetch_scorecar
 from field_view import render_field_view
 from scorecard_view import render_scorecard_view
 from pitch_view import render_pitch_view
+from image_derby import render_derby_bracket
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _DEFAULT_OUTPUT = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
@@ -29,7 +30,7 @@ _DEFAULT_OUTPUT = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
 def _get_display_mode(config):
     """Determine display mode from config."""
     mode = config.get('display_mode')
-    if mode and mode in ('scoreboard', 'linescore', 'field', 'scorecard', 'pitch'):
+    if mode and mode in ('scoreboard', 'linescore', 'field', 'scorecard', 'pitch', 'derby'):
         return mode
     if config.get('scoreboard', True):
         return 'scoreboard'
@@ -176,6 +177,18 @@ def render(config, date_str=None, output_path=None, bypass_cache=False):
             return (image, [(0, 0, image.width, image.height)])
         return None
 
+    if mode == 'derby':
+        derby_data = load_json_file('derby_bracket.json')
+        if not derby_data:
+            print("No derby_bracket.json data found")
+            return None
+        dark_mode = config.get('dark_mode', False)
+        image = render_derby_bracket(derby_data, dark_mode=dark_mode)
+        if output_path:
+            image.save(output_path)
+            print(f"Image saved to {output_path}")
+        return (image, [(0, 0, image.width, image.height)])
+
     # Snapshot the current saved image before overwriting so we can pixel-diff it.
     # Only used for the fullscreen single-game display where partial updates are
     # most valuable; the multi-game scoreboard already uses per-cell regions.
@@ -224,7 +237,7 @@ Examples:
     )
     parser.add_argument('--date', type=str, help='Date string for scoreboard header')
     parser.add_argument('--mode', type=str,
-                        choices=['scoreboard', 'linescore', 'field', 'scorecard', 'pitch'],
+                        choices=['scoreboard', 'linescore', 'field', 'scorecard', 'pitch', 'derby'],
                         help='Display mode override')
     parser.add_argument('--output', type=str, default=None,
                         help=f'Output image path (default: {_DEFAULT_OUTPUT})')

--- a/tests/test_fetch_derby.py
+++ b/tests/test_fetch_derby.py
@@ -1,0 +1,167 @@
+"""Tests for fetch_derby.py — Home Run Derby bracket fetch/transform.
+
+Mocks all network access (fetch_derby.requests.get) and file I/O
+(fetch_derby.save_off_results) following the pattern in test_fetch_playoff_bracket.py.
+"""
+from unittest.mock import patch, MagicMock
+
+import fetch_derby
+from fetch_derby import (
+    _find_asg_date, find_derby_event_id, fetch_derby_bracket_raw,
+    transform_bracket, fetch_and_save_derby_bracket, _short_name,
+)
+
+
+def _resp(status_code=200, json_data=None):
+    m = MagicMock()
+    m.status_code = status_code
+    m.json.return_value = json_data if json_data is not None else {}
+    m.raise_for_status = MagicMock()
+    return m
+
+
+def _seed(name, team_id, hr, winner, complete=True, started=True):
+    return {
+        'started': started,
+        'complete': complete,
+        'winner': winner,
+        'player': {'id': team_id * 1000, 'fullName': name},
+        'numHomeRuns': hr,
+    }
+
+
+class TestShortName:
+    def test_two_part_name(self):
+        assert _short_name('Cal Raleigh') == 'C. Raleigh'
+
+    def test_single_word_name_unchanged(self):
+        assert _short_name('Ohtani') == 'Ohtani'
+
+
+class TestFindAsgDate:
+    def test_returns_official_date_of_all_star_game(self):
+        payload = {'dates': [{'games': [{'gameType': 'A', 'officialDate': '2026-07-14'}]}]}
+        with patch('fetch_derby.requests.get', return_value=_resp(json_data=payload)):
+            assert _find_asg_date(2026) == '2026-07-14'
+
+    def test_no_asg_found_returns_none(self):
+        with patch('fetch_derby.requests.get', return_value=_resp(json_data={'dates': []})):
+            assert _find_asg_date(2026) is None
+
+
+class TestFindDerbyEventId:
+    def test_finds_event_one_day_before_asg(self):
+        asg_resp = _resp(json_data={'dates': [{'games': [{'gameType': 'A', 'officialDate': '2026-07-14'}]}]})
+        events_resp = _resp(json_data={'dates': [{'events': [
+            {'id': 838655, 'name': '2026 MLB All-Star Workout Day: Home Run Derby'},
+            {'id': 1, 'name': 'Ballpark Tour'},
+        ]}]})
+        with patch('fetch_derby.requests.get', side_effect=[asg_resp, events_resp]):
+            event_id, event_date = find_derby_event_id(2026)
+        assert event_id == 838655
+        assert event_date == '2026-07-13'
+
+    def test_no_asg_date_returns_none_none(self):
+        with patch('fetch_derby.requests.get', return_value=_resp(json_data={'dates': []})):
+            event_id, event_date = find_derby_event_id(2026)
+        assert (event_id, event_date) == (None, None)
+
+    def test_no_matching_event_scans_wider_window_then_gives_up(self):
+        asg_resp = _resp(json_data={'dates': [{'games': [{'gameType': 'A', 'officialDate': '2026-07-14'}]}]})
+        empty_events = _resp(json_data={'dates': [{'events': []}]})
+        with patch('fetch_derby.requests.get', side_effect=[asg_resp, empty_events, empty_events, empty_events]):
+            event_id, event_date = find_derby_event_id(2026)
+        assert (event_id, event_date) == (None, None)
+
+
+class TestFetchDerbyBracketRaw:
+    def test_non_200_returns_none(self):
+        with patch('fetch_derby.requests.get', return_value=_resp(status_code=404)):
+            assert fetch_derby_bracket_raw(838655) is None
+
+    def test_missing_rounds_key_returns_none(self):
+        with patch('fetch_derby.requests.get', return_value=_resp(json_data={'info': {}})):
+            assert fetch_derby_bracket_raw(838655) is None
+
+    def test_valid_payload_returned(self):
+        payload = {'info': {}, 'rounds': [], 'players': []}
+        with patch('fetch_derby.requests.get', return_value=_resp(json_data=payload)):
+            assert fetch_derby_bracket_raw(838655) == payload
+
+
+class TestTransformBracket:
+    def _raw(self):
+        return {
+            'info': {},
+            'status': {'state': 'Final', 'currentRound': 3},
+            'players': [
+                {'id': 1000, 'fullName': 'Cal Raleigh', 'currentTeam': {'abbreviation': 'SEA'}},
+                {'id': 2000, 'fullName': 'Oneil Cruz', 'currentTeam': {'abbreviation': 'PIT'}},
+            ],
+            'rounds': [
+                {'round': 1, 'matchups': [
+                    {'topSeed': _seed('Cal Raleigh', 1, 17, True), 'bottomSeed': _seed('Oneil Cruz', 2, 21, True)},
+                ]},
+                {'round': 2, 'matchups': [
+                    {'topSeed': _seed('Cal Raleigh', 1, 19, True), 'bottomSeed': _seed('Oneil Cruz', 2, 13, False)},
+                ]},
+                {'round': 3, 'matchups': [
+                    {'topSeed': _seed('Cal Raleigh', 1, 18, True), 'bottomSeed': _seed('Oneil Cruz', 2, 15, False)},
+                ]},
+            ],
+        }
+
+    def test_full_bracket_transform_and_champion(self):
+        result = transform_bracket(self._raw(), '2025-07-14')
+        assert result['event_date'] == '2025-07-14'
+        assert result['round_status'] == 'Round 3 - Final'
+        assert result['champion'] == 'C. Raleigh'
+        assert len(result['matchups']['qf']) == 4  # padded to 4 slots
+        assert len(result['matchups']['sf']) == 2  # padded to 2 slots
+        qf0 = result['matchups']['qf'][0]
+        assert qf0['complete'] is True
+        assert qf0['players'][0] == {'name': 'C. Raleigh', 'abbr': 'SEA', 'hr': 17, 'winner': True}
+        assert qf0['players'][1] == {'name': 'O. Cruz', 'abbr': 'PIT', 'hr': 21, 'winner': True}
+        # unfilled qf/sf slots are TBD placeholders
+        assert result['matchups']['qf'][1]['players'][0]['name'] == 'TBD'
+
+    def test_missing_final_round_defaults_to_tbd(self):
+        raw = self._raw()
+        raw['rounds'] = raw['rounds'][:2]  # only qf + sf rounds present
+        result = transform_bracket(raw, '2025-07-14')
+        assert result['matchups']['final']['players'][0]['name'] == 'TBD'
+        assert result['champion'] is None
+
+
+class TestFetchAndSaveDerbyBracket:
+    def test_no_event_found_returns_none(self):
+        with patch('fetch_derby.find_derby_event_id', return_value=(None, None)), \
+             patch('fetch_derby.save_off_results') as mock_save:
+            result = fetch_and_save_derby_bracket(season=2026)
+        assert result is None
+        mock_save.assert_not_called()
+
+    def test_no_bracket_data_yet_returns_none(self):
+        with patch('fetch_derby.find_derby_event_id', return_value=(838655, '2026-07-13')), \
+             patch('fetch_derby.fetch_derby_bracket_raw', return_value=None), \
+             patch('fetch_derby.save_off_results') as mock_save:
+            result = fetch_and_save_derby_bracket(season=2026)
+        assert result is None
+        mock_save.assert_not_called()
+
+    def test_successful_fetch_saves_and_returns_result(self):
+        raw = TestTransformBracket()._raw()
+        with patch('fetch_derby.find_derby_event_id', return_value=(838655, '2026-07-13')), \
+             patch('fetch_derby.fetch_derby_bracket_raw', return_value=raw), \
+             patch('fetch_derby.save_off_results') as mock_save:
+            result = fetch_and_save_derby_bracket(season=2026)
+        assert result['champion'] == 'C. Raleigh'
+        mock_save.assert_called_once_with(result, 'derby_bracket')
+
+    def test_explicit_event_id_skips_lookup(self):
+        raw = TestTransformBracket()._raw()
+        with patch('fetch_derby.find_derby_event_id') as mock_find, \
+             patch('fetch_derby.fetch_derby_bracket_raw', return_value=raw), \
+             patch('fetch_derby.save_off_results'):
+            fetch_and_save_derby_bracket(season=2026, event_id=838655)
+        mock_find.assert_not_called()

--- a/tests/test_fetch_derby.py
+++ b/tests/test_fetch_derby.py
@@ -3,12 +3,15 @@
 Mocks all network access (fetch_derby.requests.get) and file I/O
 (fetch_derby.save_off_results) following the pattern in test_fetch_playoff_bracket.py.
 """
+import time as time_mod
+from datetime import datetime
 from unittest.mock import patch, MagicMock
 
 import fetch_derby
 from fetch_derby import (
     _find_asg_date, find_derby_event_id, fetch_derby_bracket_raw,
     transform_bracket, fetch_and_save_derby_bracket, _short_name,
+    get_derby_date, _seed_to_player,
 )
 
 
@@ -133,7 +136,69 @@ class TestTransformBracket:
         assert result['champion'] is None
 
 
+class TestSeedToPlayer:
+    def test_missing_seed_returns_tbd(self):
+        assert _seed_to_player(None, {}) == {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False}
+
+    def test_seed_without_player_returns_tbd(self):
+        assert _seed_to_player({'started': True}, {}) == {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False}
+
+
+class TestGetDerbyDate:
+    def test_cache_miss_calls_lookup_and_saves(self):
+        with patch('fetch_derby.load_json_file', return_value={}), \
+             patch('fetch_derby.find_derby_event_id', return_value=(838655, '2026-07-13')) as mock_find, \
+             patch('fetch_derby.save_off_results') as mock_save:
+            event_date, event_id = get_derby_date(season=2026)
+        assert (event_date, event_id) == ('2026-07-13', 838655)
+        mock_find.assert_called_once_with(2026)
+        mock_save.assert_called_once()
+        assert mock_save.call_args.args[1] == 'derby_event_cache'
+
+    def test_fresh_cache_skips_lookup(self):
+        cache = {'season': 2026, 'event_id': 838655, 'event_date': '2026-07-13', 'fetched_at': time_mod.time()}
+        with patch('fetch_derby.load_json_file', return_value=cache), \
+             patch('fetch_derby.find_derby_event_id') as mock_find:
+            event_date, event_id = get_derby_date(season=2026)
+        assert (event_date, event_id) == ('2026-07-13', 838655)
+        mock_find.assert_not_called()
+
+    def test_stale_cache_triggers_refresh(self):
+        cache = {'season': 2026, 'event_id': 1, 'event_date': 'old', 'fetched_at': 0}
+        with patch('fetch_derby.load_json_file', return_value=cache), \
+             patch('fetch_derby.find_derby_event_id', return_value=(838655, '2026-07-13')) as mock_find, \
+             patch('fetch_derby.save_off_results'):
+            event_date, event_id = get_derby_date(season=2026)
+        assert (event_date, event_id) == ('2026-07-13', 838655)
+        mock_find.assert_called_once()
+
+    def test_force_refresh_bypasses_fresh_cache(self):
+        cache = {'season': 2026, 'event_id': 1, 'event_date': 'old', 'fetched_at': time_mod.time()}
+        with patch('fetch_derby.load_json_file', return_value=cache), \
+             patch('fetch_derby.find_derby_event_id', return_value=(838655, '2026-07-13')) as mock_find, \
+             patch('fetch_derby.save_off_results'):
+            event_date, event_id = get_derby_date(season=2026, force_refresh=True)
+        assert (event_date, event_id) == ('2026-07-13', 838655)
+        mock_find.assert_called_once()
+
+    def test_default_season_uses_current_year(self):
+        with patch('fetch_derby.load_json_file', return_value={}), \
+             patch('fetch_derby.find_derby_event_id', return_value=(None, None)) as mock_find, \
+             patch('fetch_derby.save_off_results'):
+            get_derby_date()
+        mock_find.assert_called_once_with(datetime.now().year)
+
+
 class TestFetchAndSaveDerbyBracket:
+    def test_default_season_uses_current_year(self):
+        with patch('fetch_derby.find_derby_event_id', return_value=(None, None)) as mock_find, \
+             patch('fetch_derby.save_off_results') as mock_save:
+            result = fetch_and_save_derby_bracket()
+        assert result is None
+        mock_find.assert_called_once_with(datetime.now().year)
+        mock_save.assert_not_called()
+
+
     def test_no_event_found_returns_none(self):
         with patch('fetch_derby.find_derby_event_id', return_value=(None, None)), \
              patch('fetch_derby.save_off_results') as mock_save:

--- a/tests/test_image_derby.py
+++ b/tests/test_image_derby.py
@@ -66,6 +66,13 @@ class TestRenderDerbyBracket:
         assert isinstance(img, Image.Image)
         assert img.size == (800, 480)
 
+    def test_champion_derived_from_final_winner_when_not_set_explicitly(self):
+        data = _completed_bracket()
+        data['champion'] = None  # not pre-computed; renderer must derive it from final['players']
+        img = render_derby_bracket(data)
+        assert isinstance(img, Image.Image)
+        assert img.size == (800, 480)
+
     def test_dark_mode_inverts_without_error(self):
         img = render_derby_bracket(_completed_bracket(), dark_mode=True)
         assert isinstance(img, Image.Image)

--- a/tests/test_image_derby.py
+++ b/tests/test_image_derby.py
@@ -1,0 +1,76 @@
+"""Smoke tests for src/image_derby.py — the Home Run Derby bracket renderer."""
+try:
+    from PIL import Image
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+import pytest
+
+from image_derby import render_derby_bracket
+
+
+def _tbd_matchup():
+    return {
+        'complete': False,
+        'players': [
+            {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False},
+            {'name': 'TBD', 'abbr': '', 'hr': None, 'winner': False},
+        ],
+    }
+
+
+def _empty_bracket():
+    return {
+        'event_date': '2026-07-13',
+        'round_status': 'Round 1 - In Progress',
+        'matchups': {
+            'qf': [_tbd_matchup() for _ in range(4)],
+            'sf': [_tbd_matchup() for _ in range(2)],
+            'final': _tbd_matchup(),
+        },
+        'champion': None,
+    }
+
+
+def _completed_bracket():
+    data = _empty_bracket()
+    data['round_status'] = 'Round 3 - Final'
+    data['matchups']['qf'][0] = {
+        'complete': True,
+        'players': [
+            {'name': 'C. Raleigh', 'abbr': 'SEA', 'hr': 17, 'winner': True},
+            {'name': 'O. Cruz', 'abbr': 'PIT', 'hr': 21, 'winner': False},
+        ],
+    }
+    data['matchups']['final'] = {
+        'complete': True,
+        'players': [
+            {'name': 'C. Raleigh', 'abbr': 'SEA', 'hr': 18, 'winner': True},
+            {'name': 'J. Caminero', 'abbr': 'TB', 'hr': 15, 'winner': False},
+        ],
+    }
+    data['champion'] = 'C. Raleigh'
+    return data
+
+
+@pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not installed")
+class TestRenderDerbyBracket:
+    def test_empty_bracket_renders_800x480(self):
+        img = render_derby_bracket(_empty_bracket())
+        assert isinstance(img, Image.Image)
+        assert img.size == (800, 480)
+
+    def test_completed_bracket_with_champion_renders(self):
+        img = render_derby_bracket(_completed_bracket())
+        assert isinstance(img, Image.Image)
+        assert img.size == (800, 480)
+
+    def test_dark_mode_inverts_without_error(self):
+        img = render_derby_bracket(_completed_bracket(), dark_mode=True)
+        assert isinstance(img, Image.Image)
+        assert img.size == (800, 480)
+
+    def test_missing_champion_shows_tbd(self):
+        img = render_derby_bracket(_empty_bracket())
+        assert isinstance(img, Image.Image)

--- a/tests/test_main_derby.py
+++ b/tests/test_main_derby.py
@@ -1,0 +1,118 @@
+"""Tests for main.py's Home Run Derby auto-detection helpers.
+
+Mocks all network/render/display access so these run offline, following the
+pattern in test_fetch_derby.py.
+"""
+from unittest.mock import patch, MagicMock
+
+import main
+
+
+def _base_config(**overrides):
+    config = {'timezone': 'America/Chicago', 'auto_derby_mode': True}
+    config.update(overrides)
+    return config
+
+
+class TestMaybeShowDerbyBracket:
+    def test_disabled_returns_false_without_lookup(self):
+        config = _base_config(auto_derby_mode=False)
+        with patch('main.get_derby_date') as mock_get_date:
+            result = main._maybe_show_derby_bracket(config)
+        assert result is False
+        mock_get_date.assert_not_called()
+
+    def test_not_derby_day_returns_false(self):
+        config = _base_config()
+        with patch('main.get_derby_date', return_value=('2026-01-01', 999)), \
+             patch('main._run_derby_mode') as mock_run:
+            result = main._maybe_show_derby_bracket(config)
+        assert result is False
+        mock_run.assert_not_called()
+
+    def test_lookup_failure_returns_false(self):
+        config = _base_config()
+        with patch('main.get_derby_date', side_effect=OSError('timeout')), \
+             patch('main._run_derby_mode') as mock_run:
+            result = main._maybe_show_derby_bracket(config)
+        assert result is False
+        mock_run.assert_not_called()
+
+    def test_derby_day_runs_derby_mode_and_returns_true(self):
+        config = _base_config()
+        import pytz
+        from datetime import datetime
+        today_str = datetime.now(pytz.timezone(config['timezone'])).strftime('%Y-%m-%d')
+        with patch('main.get_derby_date', return_value=(today_str, 838655)), \
+             patch('main._run_derby_mode') as mock_run:
+            result = main._maybe_show_derby_bracket(config, no_throttle=True, auto_open=False)
+        assert result is True
+        mock_run.assert_called_once_with(config, event_id=838655, no_throttle=True, auto_open=False)
+
+
+class TestRunDerbyMode:
+    def test_fetch_failure_still_renders(self):
+        config = _base_config()
+        with patch('main.fetch_and_save_derby_bracket', side_effect=OSError('boom')), \
+             patch('main.render', return_value=None) as mock_render:
+            main._run_derby_mode(config, event_id=1, no_throttle=True)
+        mock_render.assert_called_once()
+        assert mock_render.call_args.args[0]['display_mode'] == 'derby'
+
+    def test_no_result_skips_display(self):
+        config = _base_config()
+        with patch('main.fetch_and_save_derby_bracket', return_value={'state': 'Final'}), \
+             patch('main.render', return_value=None), \
+             patch('main.send_to_display') as mock_display:
+            main._run_derby_mode(config)
+        mock_display.assert_not_called()
+
+    def test_successful_render_sends_to_display(self):
+        config = _base_config()
+        fake_image = MagicMock()
+        with patch('main.fetch_and_save_derby_bracket', return_value={'state': 'Final'}), \
+             patch('main.render', return_value=(fake_image, [(0, 0, 800, 480)])), \
+             patch('main.send_to_display', return_value='full') as mock_display:
+            main._run_derby_mode(config, no_throttle=True)
+        mock_display.assert_called_once()
+
+    def test_preview_state_runs_only_once_no_sleep(self):
+        config = _base_config()
+        with patch('main.fetch_and_save_derby_bracket', return_value={'state': 'Preview'}), \
+             patch('main.render', return_value=None) as mock_render, \
+             patch('main.time.sleep') as mock_sleep:
+            main._run_derby_mode(config)
+        assert mock_render.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_none_bracket_runs_only_once_no_sleep(self):
+        config = _base_config()
+        with patch('main.fetch_and_save_derby_bracket', return_value=None), \
+             patch('main.render', return_value=None) as mock_render, \
+             patch('main.time.sleep') as mock_sleep:
+            main._run_derby_mode(config)
+        assert mock_render.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_in_progress_state_polls_every_minute_until_final(self):
+        config = _base_config()
+        states = iter([{'state': 'In Progress'}, {'state': 'In Progress'}, {'state': 'Final'}])
+        with patch('main.fetch_and_save_derby_bracket', side_effect=lambda **kw: next(states)), \
+             patch('main.render', return_value=None) as mock_render, \
+             patch('main.time.sleep') as mock_sleep:
+            main._run_derby_mode(config)
+        assert mock_render.call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(main._DERBY_LIVE_POLL_SECONDS)
+
+    def test_in_progress_state_stops_at_safety_cap(self):
+        config = _base_config()
+        # monotonic() is read once for start, then once per loop iteration to check elapsed time.
+        # Return a start time, then a time already past the cap so the loop stops after one fetch.
+        with patch('main.fetch_and_save_derby_bracket', return_value={'state': 'In Progress'}), \
+             patch('main.render', return_value=None) as mock_render, \
+             patch('main.time.sleep') as mock_sleep, \
+             patch('main.time.monotonic', side_effect=[0, main._DERBY_LIVE_POLL_MAX_SECONDS + 1]):
+            main._run_derby_mode(config)
+        assert mock_render.call_count == 1
+        mock_sleep.assert_not_called()

--- a/tests/test_render_scoreboard.py
+++ b/tests/test_render_scoreboard.py
@@ -147,10 +147,11 @@ def test_render_single_game_mode_handles_exception():
 # 3. render() — dispatch + save-to-disk logic
 # ---------------------------------------------------------------------------
 
-def _loader(games_payload=None, teams_payload=None):
+def _loader(games_payload=None, teams_payload=None, derby_payload=None):
     """Build a load_json_file side_effect that never touches real data/ files."""
     games_payload = games_payload if games_payload is not None else {'games': []}
     teams_payload = teams_payload if teams_payload is not None else {'team_abbreviation': {}}
+    derby_payload = derby_payload if derby_payload is not None else {}
 
     def _fn(filename, file_path=None):
         """Fn."""
@@ -158,6 +159,8 @@ def _loader(games_payload=None, teams_payload=None):
             return games_payload
         if filename == 'teams.json':
             return teams_payload
+        if filename == 'derby_bracket.json':
+            return derby_payload
         return {}
     return _fn
 
@@ -173,6 +176,31 @@ def test_render_dispatches_single_game_mode(tmp_path):
         result = render_scoreboard.render(config, output_path=str(tmp_path / 'out.bmp'))
     assert result == (fake_image, [(0, 0, 800, 480)])
     m_single.assert_called_once()
+
+
+def test_render_derby_mode_no_data_returns_none():
+    """render() in derby mode with no cached derby_bracket.json data returns None."""
+    config = {'display_mode': 'derby'}
+    with patch('render_scoreboard.load_json_file', side_effect=_loader(derby_payload={})):
+        result = render_scoreboard.render(config, output_path='/nonexistent/should/not/write.bmp')
+    assert result is None
+
+
+@needs_pil
+def test_render_derby_mode_dispatches_and_saves(tmp_path):
+    """render() in derby mode renders the bracket via render_derby_bracket and saves it."""
+    derby_data = {
+        'event_date': '2026-07-13', 'round_status': 'Round 1 - In Progress', 'state': 'In Progress',
+        'matchups': {'qf': [], 'sf': [], 'final': {'complete': False, 'players': []}}, 'champion': None,
+    }
+    fake_image = Image.new('1', (800, 480), 255)
+    out_path = tmp_path / 'derby.bmp'
+    with patch('render_scoreboard.load_json_file', side_effect=_loader(derby_payload=derby_data)), \
+         patch('render_scoreboard.render_derby_bracket', return_value=fake_image) as m_derby:
+        result = render_scoreboard.render(config={'display_mode': 'derby'}, output_path=str(out_path))
+    assert result == (fake_image, [(0, 0, 800, 480)])
+    m_derby.assert_called_once_with(derby_data, dark_mode=False)
+    assert out_path.exists()
 
 
 def test_render_single_game_mode_returns_none_propagates():


### PR DESCRIPTION
## Summary
- New `display_mode: "derby"` renders an 8-man single-elimination Home Run Derby bracket (quarterfinals → semifinals → final → champion) as an 800x480 e-ink image.
- **Real live data, no manual editing required.** MLB's regular schedule/gameType endpoints don't cover the Derby, but it's a non-game "event" (`scheduleTypes=events`) named `"<year> MLB All-Star Workout Day: Home Run Derby"`, whose live bracket is served at `GET /api/v1/homeRunDerby/{event_id}/bracket` once the event starts. `src/fetch_derby.py` locates that event id and transforms the payload into `data/derby_bracket.json`.
- **Fully automatic — nothing to toggle by hand.** Whenever the normal game pipeline finds no games to show, `main.py` checks (via a daily-cached lookup) whether today is actually Derby day and shows the bracket instead of just exiting. This piggybacks on the existing 14-minute cron cadence for "check throughout the day." `auto_derby_mode: true` in config.yaml controls this; `display_mode: "derby"` still forces it on unconditionally if you want that instead.
- **Live polling while the event is happening.** Once the bracket's status flips to "In Progress", that run blocks and re-fetches/re-renders/re-displays every 60 seconds (capped at 3h) instead of waiting for the next cron tick — so the display tracks the live event closely. A concurrent cron invocation firing mid-derby is expected and harmless (idempotent re-fetch/re-render).
- Wired into `render_scoreboard.py` (`--mode derby` CLI flag / `python src/fetch_derby.py` standalone) and `config_server.py`'s mode selector.

## Test plan
- [x] `poetry run pytest -q` — 1650 passed, 15 skipped (unrelated)
- [x] Verified the real endpoint against the completed 2025 Derby (event id 788030) — transform correctly reproduces Cal Raleigh's actual win path
- [x] Verified event lookup finds the real 2026 Derby (event id 838655, 2026-07-13) and gracefully reports "no bracket data yet" pre-event
- [x] Unit tests for the auto-detection helper, the live-poll loop (including the safety cap), and the transform/renderer
- [x] `main.py --local` end-to-end dry run for both explicit `display_mode: "derby"` and the auto-detected no-games path
- [ ] Watch it pick up live data and start polling every minute once the derby actually starts tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyh2jrhC1x6Do6SR1xEcJA