### PR TITLE
Guarantee logos always show at least some black pixels

### DIFF
--- a/src/image_assets.py
+++ b/src/image_assets.py
@@ -196,6 +196,26 @@ def _paste_logo(image, logo, pos):
     image.paste(logo, pos, mask=ImageOps.invert(logo.convert('L')))
 
 
+def _ensure_visible_1bit(gray):
+    """Convert an L-mode image to '1', guaranteeing at least some black pixels survive.
+
+    A logo that's very light overall (e.g. a pale color that a team's config doesn't
+    flag for inversion) can dither down to an all-white '1'-mode image — invisible on
+    the white e-ink background, since only dark pixels get pasted. When that happens,
+    fall back to an adaptive threshold keyed off the image's own darkest pixels so its
+    outline stays visible instead of silently vanishing. Returns None only when the
+    source has no variance at all (a single flat color — nothing to show either way).
+    """
+    result = gray.convert('1')
+    if result.getextrema() != (255, 255):
+        return result
+    lo, hi = gray.getextrema()
+    if lo >= hi:
+        return None
+    threshold = lo + max(1, (hi - lo) // 4)  # darkest quartile becomes visible
+    return gray.point(lambda p: 0 if p <= threshold else 255).convert('1')
+
+
 def _logo_small(abbr, team_id, size=28):
     """Small 1-bit logo for the team name row. Returns a '1'-mode image or None."""
     gray = _load_logo_gray(abbr, team_id)
@@ -207,7 +227,7 @@ def _logo_small(abbr, team_id, size=28):
     # to a visible range before dithering, preserving internal detail.
     gray = ImageOps.autocontrast(gray, cutoff=2)
     gray = ImageEnhance.Contrast(gray).enhance(3.0)
-    return gray.convert('1')
+    return _ensure_visible_1bit(gray)
 
 
 def _logo_ghost(abbr, team_id, size=110, lightness=140):
@@ -224,7 +244,7 @@ def _logo_ghost(abbr, team_id, size=110, lightness=140):
     gray = gray.copy()
     gray.thumbnail((size, size), Image.LANCZOS)
     gray = gray.point(lambda p: 255 if p > 180 else min(255, int(p * 0.3 + lightness)))
-    return gray.convert('1')
+    return _ensure_visible_1bit(gray)
 
 
 _emoji_cache: dict = {}       # abbr -> grayscale PIL Image or None

--- a/tests/test_image_assets.py
+++ b/tests/test_image_assets.py
@@ -247,6 +247,47 @@ def test_logo_small_returns_1bit_image(monkeypatch):
     assert result.mode == '1'
 
 
+@needs_pil
+def test_logo_small_never_disappears_for_very_light_logo(monkeypatch):
+    """A pale logo that would otherwise dither to an all-white (invisible) '1'-mode
+    image must still show at least some black pixels instead of vanishing on e-ink."""
+    fake = Image.new('L', (60, 60), 250)  # near-white, no internal variance
+    monkeypatch.setattr(image_assets, '_load_logo_gray', lambda abbr, team_id: fake)
+    result = image_assets._logo_small('ZZ', 1, size=28)
+    assert result is not None
+    assert result.mode == '1'
+    assert result.getextrema()[0] == 0, "logo has no black pixels — would be invisible on the display"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_visible_1bit
+# ---------------------------------------------------------------------------
+
+@needs_pil
+def test_ensure_visible_1bit_passes_through_when_already_visible():
+    """Normal contrast image already has black pixels after dithering — unchanged."""
+    img = Image.new('L', (28, 28), 90)
+    result = image_assets._ensure_visible_1bit(img)
+    assert result.getextrema()[0] == 0
+
+
+@needs_pil
+def test_ensure_visible_1bit_forces_black_pixels_for_near_white_image():
+    """An image that dithers to all-white gets an adaptive threshold instead."""
+    img = Image.new('L', (28, 28))
+    img.putdata([250 if i % 2 == 0 else 255 for i in range(28 * 28)])
+    assert img.convert('1').getextrema() == (255, 255)  # sanity check: would vanish untreated
+    result = image_assets._ensure_visible_1bit(img)
+    assert result.getextrema()[0] == 0
+
+
+@needs_pil
+def test_ensure_visible_1bit_returns_none_for_perfectly_flat_image():
+    """A genuinely uniform image (no variance at all) has nothing to threshold — None."""
+    img = Image.new('L', (10, 10), 255)
+    assert image_assets._ensure_visible_1bit(img) is None
+
+
 # ---------------------------------------------------------------------------
 # _paste_logo
 # ---------------------------------------------------------------------------
@@ -284,6 +325,20 @@ def test_logo_ghost_returns_1bit_watermark(monkeypatch):
     result = image_assets._logo_ghost('ZZ', 1, size=50)
     assert result is not None
     assert result.mode == '1'
+
+
+@needs_pil
+def test_logo_ghost_routes_through_visibility_guard(monkeypatch):
+    """_logo_ghost must run its output through the same all-white-dither guard as
+    _logo_small — verified by checking it's actually called, since LANCZOS thumbnail
+    smoothing makes reliably engineering an end-to-end near-white fixture brittle."""
+    fake = Image.new('L', (200, 200), 100)
+    monkeypatch.setattr(image_assets, '_load_logo_gray', lambda abbr, team_id: fake)
+    sentinel = Image.new('1', (50, 50), 255)
+    with patch.object(image_assets, '_ensure_visible_1bit', return_value=sentinel) as mock_guard:
+        result = image_assets._logo_ghost('ZZ', 1, size=50)
+    mock_guard.assert_called_once()
+    assert result is sentinel
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Team logo processing (`_logo_small`, `_logo_ghost` in `src/image_assets.py`) could occasionally produce an all-white `'1'`-mode image for very pale/light logos — since only dark pixels get pasted onto the white e-ink background (`_paste_logo`), that logo would silently vanish instead of just looking low-contrast.
- New `_ensure_visible_1bit()` helper: converts to `'1'` mode as before, but if the result has zero black pixels, falls back to an adaptive threshold based on the image's own darkest pixels (its darkest quartile becomes visible) so the logo's outline still shows.
- Only returns `None` for a genuinely flat single-color source with zero variance at all — real downloaded logo PNGs always have some anti-aliased edge variance from alpha compositing onto the white background, so this only matters for degenerate/synthetic cases.

## Test plan
- [x] `poetry run pytest -q --cov` — 1666 passed, 15 skipped, coverage 99.07% (≥99% gate), `image_assets.py` at 100%
- [x] New unit tests directly exercising `_ensure_visible_1bit`'s pass-through / fallback / flat-image-None paths, plus `_logo_small`/`_logo_ghost` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyh2jrhC1x6Do6SR1xEcJA