### PR TITLE
Fix missing AL/NL abbreviation for All-Star Game

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -528,6 +528,15 @@ def parse_games(data, sport_id=None, config=None):
         away_abbreviation = away_team_info.get('abbreviation')
         home_abbreviation = home_team_info.get('abbreviation')
 
+        # The schedule endpoint omits 'abbreviation' for some teams (e.g. the
+        # All-Star Game's "American/National League All-Stars", team ids 159/160).
+        # Fall back to a per-team lookup rather than caching nothing, which would
+        # otherwise leave the renderer displaying "T159"/"T160" with no logo.
+        if away_team_id and not away_abbreviation:
+            away_abbreviation = team_abbreviations.get(str(away_team_id)) or get_team_abbreviation(away_team_id)
+        if home_team_id and not home_abbreviation:
+            home_abbreviation = team_abbreviations.get(str(home_team_id)) or get_team_abbreviation(home_team_id)
+
         if sport_id == 8:
             away_abbreviation = _WBC_ABBR_OVERRIDES.get(away_abbreviation, away_abbreviation)
             home_abbreviation = _WBC_ABBR_OVERRIDES.get(home_abbreviation, home_abbreviation)


### PR DESCRIPTION
## Summary
- The MLB schedule API doesn't return an `abbreviation` field for the All-Star Game's team entries (team ids 159/160, "American/National League All-Stars") — confirmed against the live endpoint for 2026-07-14's game.
- Without a fallback, `team_abbreviations` never got an entry for these ids, so the renderer displayed "T159"/"T160" placeholder text instead of "AL"/"NL", and logos never downloaded (the auto-download path explicitly skips `T{digits}`-shaped abbreviations).
- Added a fallback to the existing (previously unused) `get_team_abbreviation()` per-team lookup when the schedule response omits the field.

## Test plan
- [x] `poetry run pytest -q` — 1666 passed, 15 skipped
- [x] Manually parsed the real 2026-07-14 schedule response and confirmed `teams.json` now maps `159 -> AL`, `160 -> NL`
- [x] Confirmed AL/NL logos successfully auto-download from ESPN CDN (`mlb/500/al.png`, `mlb/500/nl.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyh2jrhC1x6Do6SR1xEcJA