### PR TITLE
Fix league leaders showing wrong stats by filtering on statGroup

### DIFF
--- a/src/fetch_leaders.py
+++ b/src/fetch_leaders.py
@@ -35,6 +35,22 @@ _HIGHER_IS_BETTER = {
     'stolenBases':       True,
 }
 
+# The API returns duplicate leaderCategory groups across statGroups (e.g.
+# "homeRuns" exists for both hitting and pitching, "hits"/"stolenBases" for
+# hitting and catching), so without a statGroup filter it's ambiguous which
+# group's numbers land in the response for a given category. Pin each
+# category to the group we actually want (all hitting except the two
+# pitching-only categories).
+_STAT_GROUP = {
+    'homeRuns':         'hitting',
+    'battingAverage':   'hitting',
+    'earnedRunAverage': 'pitching',
+    'saves':            'pitching',
+    'hits':              'hitting',
+    'runsBattedIn':      'hitting',
+    'stolenBases':       'hitting',
+}
+
 
 def _sort_and_rank(entries, higher_is_better):
     """Sort leader entries by value (best first) and re-derive rank, so a
@@ -93,6 +109,8 @@ def fetch_leaders(season=None, sport_id=1):
         for group in data.get('leagueLeaders', []):
             cat = group.get('leaderCategory')
             if cat not in _CATEGORIES:
+                continue
+            if group.get('statGroup') != _STAT_GROUP.get(cat):
                 continue
             entries = []
             for leader in group.get('leaders', [])[:_TOP_N]:

--- a/tests/test_leaders.py
+++ b/tests/test_leaders.py
@@ -285,6 +285,7 @@ def test_fetch_leaders_refetches_when_stale(tmp_path, monkeypatch):
         'leagueLeaders': [
             {
                 'leaderCategory': 'homeRuns',
+                'statGroup': 'hitting',
                 'leaders': [
                     {'rank': 1, 'value': '30', 'person': {'fullName': 'Aaron Judge'},
                      'team': {'id': 147}}


### PR DESCRIPTION
## Problem
League leader stats (especially home runs, but affecting most categories) were often wrong — e.g. pitchers or catchers showing up as home run leaders instead of actual sluggers.

## Root cause
The MLB stats API's `/stats/leaders` endpoint, when called without a `statGroup` filter, returns **duplicate** `leaderCategory` groups across different stat groups. For example `homeRuns` exists as both a hitting stat and a pitching stat (home runs allowed), and even a catching-group entry. `hits`/`stolenBases`/etc. have similar overlaps.

The fetch loop in `fetch_leaders()` iterated over every returned group and did `leaders[cat] = ...`, unconditionally overwriting. Since the API doesn't guarantee any particular group ordering, whichever group happened to land last for a given category won — sometimes the correct hitting leaders, sometimes nonsense from an unrelated group.

## Fix
Added a `_STAT_GROUP` mapping (hitting vs pitching) per category, and filter each response group by its `statGroup` field before using it — same approach the API itself uses to disambiguate.

## Test plan
- [x] Verified `python3 src/fetch_leaders.py` now returns real hitters for HR/AVG/hits/RBI/SB and real pitchers for ERA/saves
- [x] Existing smoke tests pass