### PR TITLE
Fix stale HR leaders during no-games gaps

### DIFF
--- a/main.py
+++ b/main.py
@@ -674,6 +674,17 @@ Examples:
             game_state_data = load_json_file('games.json').get('games', [])
             no_games = _update_schedule_state(game_state_data, date_str, config, sched)
             if no_games:
+                # Leaders/standings only otherwise refresh once games resume and
+                # go Final, so a multi-day gap (All-Star break, rainouts) would
+                # leave them frozen indefinitely without this age-based check.
+                if config.get('show_leaders_panel', False) and league_mode != 'aaa' \
+                        and _should_refresh_leaders(sched):
+                    print("Refreshing leaders during no-games gap (stale cache)...")
+                    try:
+                        _leaders_sport = sport_id if sport_id else (config.get('sport_id_priority', [1])[0])
+                        fetch_leaders(sport_id=_leaders_sport)
+                    except Exception as e:
+                        print(f"Warning: leaders fetch failed: {e}")
                 _maybe_show_derby_bracket(config, no_throttle=_no_throttle,
                                           auto_open=args.local and system_platform == 'Darwin')
                 return


### PR DESCRIPTION
## Summary
- Leaders/standings only refreshed on the normal per-game fetch path, which returns early when there are no games scheduled today
- A multi-day gap (All-Star break, rainouts) meant the 24h staleness fallback in `_should_refresh_leaders` never got a chance to run, so `leaders.json` stayed frozen at whatever it was before the gap started
- Once games resumed, the leaders panel showed home run counts (and other stats) that had drifted from reality, since real players kept hitting HRs during the gap while the cache didn't update

## Fix
Run the leaders staleness check in the no-games early-return path too, so a stale cache gets refreshed even without new Finals to trigger it.

## Test plan
- [x] `poetry run pytest tests/test_leaders.py tests/test_main_derby.py` — 40 passed
- [x] Verified `fetch_leaders.py` + rendered leaders cell match live MLB.com/statsapi HR leaders (Schwarber 32, Alvarez 31, Rice 29...) confirming the data source itself is accurate — the bug was purely a stale-cache-during-gap issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyh2jrhC1x6Do6SR1xEcJA