### PR TITLE
Fix smart polling skipping today's All-Star Game

### DIFF
--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -462,9 +462,8 @@ def find_next_game_date(sport_id_priority, from_date_str):
                             games = regular
                     if games:
                         found = date_entry['date']
-                        if found != from_date_str:
-                            print(f"Next game date: {found} (sport_id={sid})")
-                            return found
+                        print(f"Next game date: {found} (sport_id={sid})")
+                        return found
         except Exception as e:
             print(f"Error searching for next game date: {e}")
     return None

--- a/tests/test_fetch_games_more.py
+++ b/tests/test_fetch_games_more.py
@@ -776,15 +776,20 @@ class TestFindNextGameDate:
         assert result == '2026-07-03'
         assert mock_get.call_count == 1
 
-    def test_games_on_from_date_itself_are_skipped(self):
-        """Games on from date itself are skipped."""
+    def test_games_on_from_date_itself_are_found(self):
+        """Games on from_date itself count as the next game date.
+
+        The caller always passes "tomorrow" relative to a confirmed no-games
+        day, so from_date_str is never itself already-known-empty — skipping
+        it caused real games that day (e.g. the All-Star Game) to be missed.
+        """
         payload = {'dates': [
             {'date': '2026-07-01', 'games': [{'gameType': 'R'}]},
             {'date': '2026-07-02', 'games': []},
         ]}
         with patch('fetch_games.requests.get', return_value=_resp(json_data=payload)):
             result = find_next_game_date([1], '2026-07-01')
-        assert result is None
+        assert result == '2026-07-01'
 
     def test_falls_through_sport_priority_list(self):
         """Falls through sport priority list."""


### PR DESCRIPTION
## Summary
- `find_next_game_date()` discarded a match whenever it landed on `from_date_str` itself (`if found != from_date_str: return found`)
- The only caller passes "tomorrow" relative to a day already confirmed to have no games — that date is *unconfirmed*, not known-empty, so skipping a match on it is wrong
- Live bug: today (2026-07-14) is the All-Star Game (`gameType: "A"`), which isn't filtered out by the `S`/`E` spring-training/exhibition exclusion — but the same-day skip caused the search to keep looking and land on July 16 instead, so `main.py` printed "No games until 2026-07-16 — skipping API call" and never fetched today's ASG

## Fix
Removed the `found != from_date_str` guard — the first date in the search range with games is always the correct answer, whether or not it happens to equal the search's starting date.

Also updated `tests/test_fetch_games_more.py::TestFindNextGameDate` — the old test asserted the buggy skip-same-day behavior; renamed/inverted it to assert the correct find.

## Test plan
- [x] `poetry run pytest` — 1667 passed, 15 skipped
- [x] Confirmed live via statsapi that 2026-07-14 has `gameType: "A"` (All-Star Game), currently in progress, which should have been picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyh2jrhC1x6Do6SR1xEcJA