### PR TITLE
Add --full-refresh flag; force data refresh on dark-mode transitions

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,14 +173,19 @@ _TRANSACTIONS_MAX_AGE_HOURS = 3  # refresh if transactions.json is older than th
 _PLAYOFF_BRACKET_MAX_AGE_HOURS = 1  # refresh cadence during an active postseason
 
 
-def _should_refresh_leaders(sched):
+def _should_refresh_leaders(sched, force=False):
     """Return True if leaders.json needs a refresh.
 
     Mirrors _should_refresh_standings: season stat leaders barely move
     mid-game, so we only refetch when the cache is missing/stale (catches
     the once-a-day / offline-for-a-day cases) or a game that is now Final
     wasn't Final during the last leaders refresh — i.e. once games wrap up.
+
+    force=True (--full-refresh) always refreshes regardless of cache state.
     """
+    if force:
+        return True
+
     leaders_path = _data_path('leaders.json')
     if not os.path.exists(leaders_path):
         return True
@@ -203,12 +208,17 @@ def _should_refresh_leaders(sched):
     return bool(current_finals - known_finals)
 
 
-def _should_refresh_transactions():
+def _should_refresh_transactions(force=False):
     """Return True if transactions.json needs a refresh.
 
     Unlike standings/leaders, transactions aren't tied to games going Final —
     just a simple age check (missing or older than _TRANSACTIONS_MAX_AGE_HOURS).
+
+    force=True (--full-refresh) always refreshes regardless of cache state.
     """
+    if force:
+        return True
+
     transactions_path = _data_path('transactions.json')
     if not os.path.exists(transactions_path):
         return True
@@ -221,12 +231,17 @@ def _should_refresh_transactions():
     return False
 
 
-def _should_refresh_playoff_bracket():
+def _should_refresh_playoff_bracket(force=False):
     """Return True if playoff_bracket.json needs a refresh.
 
     Simple age check — series win counts only change once per completed
     game, so hourly is frequent enough even during an active series.
+
+    force=True (--full-refresh) always refreshes regardless of cache state.
     """
+    if force:
+        return True
+
     bracket_path = _data_path('playoff_bracket.json')
     if not os.path.exists(bracket_path):
         return True
@@ -239,13 +254,18 @@ def _should_refresh_playoff_bracket():
     return False
 
 
-def _should_refresh_standings(sched):
+def _should_refresh_standings(sched, force=False):
     """Return True if standings.json needs a refresh.
 
     Triggers when: the file is missing, the file is older than 20 hours
     (catches the case where the program was offline for a day or more),
     or a game that is now Final was not Final during the last standings refresh.
+
+    force=True (--full-refresh) always refreshes regardless of cache state.
     """
+    if force:
+        return True
+
     standings_path = _data_path('standings.json')
     if not os.path.exists(standings_path):
         return True
@@ -471,6 +491,7 @@ Examples:
   python main.py --date 2025-04-01
   python main.py --sport-id 8 --date 2023-03-21
   python main.py --local
+  python main.py --full-refresh
         ''',
     )
     parser.add_argument('--date', type=str, help='Date (YYYY-MM-DD). Default: today')
@@ -479,6 +500,9 @@ Examples:
                         help='Fetch and cache all team abbreviations, then exit')
     parser.add_argument('--local', action='store_true',
                         help='Local dev mode: bypass night mode and smart polling, auto-open output')
+    parser.add_argument('--full-refresh', action='store_true',
+                        help='Bypass all throttling/staleness caches and force a fresh fetch of '
+                             'games, standings, leaders, transactions, and the playoff bracket')
     add_config_arg(parser)
     args = parser.parse_args()
 
@@ -502,7 +526,7 @@ Examples:
         return False
 
     _is_test = _env_is_test()
-    _no_throttle = args.local or system_platform == 'Darwin' or _is_test
+    _no_throttle = args.local or args.full_refresh or system_platform == 'Darwin' or _is_test
     print(f"Throttle bypass: {_no_throttle} (local={args.local}, platform={system_platform}, env_test={_is_test})")
 
     config = load_config(args.config)
@@ -655,7 +679,7 @@ Examples:
         _tmrw_target = _today_str if _pre9am else _tmrw_str
         _for_date_arg = _today_str if _pre9am else None   # None → fetch_tomorrow_games uses tomorrow
         _tmrw_age = _tm_mod.time() - _tmrw_cache.get('fetched_at', 0)
-        if _tmrw_cache.get('date') != _tmrw_target or _tmrw_age > 3600:
+        if _tmrw_cache.get('date') != _tmrw_target or _tmrw_age > 3600 or args.full_refresh:
             try:
                 fetch_tomorrow_games(config, for_date=_for_date_arg)
             except Exception as _e:
@@ -678,6 +702,29 @@ Examples:
                                           auto_open=args.local and system_platform == 'Darwin')
                 return
 
+    # 7a. Auto dark/light mode: day = light, night = dark.
+    # Uses dark_start / dark_end config keys (defaults: 20 → 7) so the display
+    # dark window is independent of the refresh-suppression night window.
+    # Detect day↔night transitions and force a full refresh — of the render/
+    # display (below) *and* of standings/leaders/transactions/bracket data
+    # (7b-7d) — since a mode flip is exactly the kind of moment stale data
+    # would be most visible (e.g. a fresh light-mode morning screen showing
+    # last night's leaders).
+    _is_dark = _in_dark_window(config) if config.get('night_mode', True) else False
+    config['dark_mode'] = _is_dark
+    _dark_transitioned = False
+    if not _no_throttle and not args.date:
+        _last_dark = sched.get('last_dark_mode')
+        if _last_dark is None or _last_dark != _is_dark:
+            # None = first run after Pi boot/state reset — force a full refresh so the
+            # display is guaranteed to start in the correct mode without ghosting.
+            label = 'first-run' if _last_dark is None else ('light→dark' if _is_dark else 'dark→light')
+            print(f"Dark mode transition: {label} — forcing full refresh")
+            _dark_transitioned = True
+        sched['last_dark_mode'] = _is_dark
+        _save_schedule_state(sched)
+    _force_data_refresh = args.full_refresh or _dark_transitioned
+
     # 7b. Standings refresh
     _needs_standings = (
         config.get('show_standings_sidebar', False) or
@@ -699,7 +746,7 @@ Examples:
                               date=_prev.strftime('%m/%d/%Y'), save_as='standings_prev')
             except Exception as e:
                 print(f"Warning: historical standings fetch failed: {e}")
-        elif _should_refresh_standings(sched):
+        elif _should_refresh_standings(sched, force=_force_data_refresh):
             print("Refreshing standings (new Finals detected or no cache)...")
             try:
                 today = datetime.now()
@@ -721,7 +768,7 @@ Examples:
     # toggle each year; show_playoff_bracket now just lets a user force it
     # off entirely if they never want the header taken over.
     if config.get('show_playoff_bracket', True) and league_mode != 'aaa' \
-            and is_postseason_window() and _should_refresh_playoff_bracket():
+            and is_postseason_window() and _should_refresh_playoff_bracket(force=_force_data_refresh):
         try:
             fetch_playoff_bracket()
         except Exception as e:
@@ -730,7 +777,7 @@ Examples:
     # 7c2. Transactions ticker refresh — recent IL moves/call-ups/signings,
     # only when the panel is enabled, and only when the cache is stale
     # (transactions don't change fast enough to warrant fetching every poll).
-    if config.get('show_transactions_ticker', False) and _should_refresh_transactions():
+    if config.get('show_transactions_ticker', False) and _should_refresh_transactions(force=_force_data_refresh):
         try:
             fetch_transactions(config.get('transactions_lookback_days', 2))
         except Exception as e:
@@ -739,11 +786,12 @@ Examples:
     # 7d. Season leaders refresh (HR/AVG/ERA/Saves/Hits) — only when panel is
     # enabled, and only once games have gone Final (or cache is stale/missing),
     # not on every poll — leaders barely move mid-game.
-    if config.get('show_leaders_panel', False) and league_mode != 'aaa' and _should_refresh_leaders(sched):
+    if config.get('show_leaders_panel', False) and league_mode != 'aaa' \
+            and _should_refresh_leaders(sched, force=_force_data_refresh):
         print("Refreshing leaders (new Finals detected or no cache)...")
         try:
             _leaders_sport = sport_id if sport_id else (config.get('sport_id_priority', [1])[0])
-            fetch_leaders(sport_id=_leaders_sport)
+            fetch_leaders(sport_id=_leaders_sport, force=_force_data_refresh)
             games = load_json_file('games.json').get('games', [])
             sched['leaders_final_pks'] = [
                 str(g['game_pk']) for g in games
@@ -752,25 +800,6 @@ Examples:
             _save_schedule_state(sched)
         except Exception as e:
             print(f"Warning: leaders fetch failed: {e}")
-
-    # 8. Auto dark/light mode: day = light, night = dark.
-    # Uses dark_start / dark_end config keys (defaults: 20 → 7) so the display
-    # dark window is independent of the refresh-suppression night window.
-    # Detect day↔night transitions and force a full e-ink refresh to prevent
-    # ghosting when the polarity of the entire image flips.
-    _is_dark = _in_dark_window(config) if config.get('night_mode', True) else False
-    config['dark_mode'] = _is_dark
-    _dark_transitioned = False
-    if not _no_throttle and not args.date:
-        _last_dark = sched.get('last_dark_mode')
-        if _last_dark is None or _last_dark != _is_dark:
-            # None = first run after Pi boot/state reset — force a full refresh so the
-            # display is guaranteed to start in the correct mode without ghosting.
-            label = 'first-run' if _last_dark is None else ('light→dark' if _is_dark else 'dark→light')
-            print(f"Dark mode transition: {label} — forcing full refresh")
-            _dark_transitioned = True
-        sched['last_dark_mode'] = _is_dark
-        _save_schedule_state(sched)
 
     # 9. Render
     # On a dark-mode transition the rendered image inverts even when the game

--- a/src/fetch_leaders.py
+++ b/src/fetch_leaders.py
@@ -78,8 +78,12 @@ def _sort_and_rank(entries, higher_is_better):
     return ranked
 
 
-def fetch_leaders(season=None, sport_id=1):
+def fetch_leaders(season=None, sport_id=1, force=False):
     """Fetch HR/AVG/ERA leaders and cache to data/leaders.json.
+
+    force=True bypasses this function's own TTL cache — needed because the
+    caller (main.py) makes its own refresh-worthiness decision upstream, and
+    that decision would otherwise be silently overridden by this cache check.
 
     Returns the cached dict (possibly stale) or {} on total failure.
     """
@@ -87,7 +91,7 @@ def fetch_leaders(season=None, sport_id=1):
         season = datetime.now().year
 
     cached = load_json_file('leaders.json')
-    if cached:
+    if cached and not force:
         age_h = (time.time() - cached.get('fetched_at', 0)) / 3600
         if age_h < _CACHE_TTL_HOURS and cached.get('season') == season:
             print(f"Leaders cache fresh ({age_h:.1f}h old) — skipping fetch")

--- a/tests/test_dark_transition_refresh.py
+++ b/tests/test_dark_transition_refresh.py
@@ -31,7 +31,7 @@ BASE_CONFIG = {
 }
 
 
-def _run_main(monkeypatch, tmp_path, sched, render_mock):
+def _run_main(monkeypatch, tmp_path, sched, render_mock, config=None):
     """Drive main.main() down the on-Pi path (throttling active) with all
     network/display side effects stubbed out."""
     # Point _REPO_ROOT away from the repo so the real .env (ENV=test) doesn't
@@ -41,7 +41,7 @@ def _run_main(monkeypatch, tmp_path, sched, render_mock):
     monkeypatch.setattr(main_mod.platform, 'system', lambda: 'Linux')
     monkeypatch.setattr(sys, 'argv', ['main.py'])
 
-    monkeypatch.setattr(main_mod, 'load_config', lambda *a, **k: dict(BASE_CONFIG))
+    monkeypatch.setattr(main_mod, 'load_config', lambda *a, **k: dict(config or BASE_CONFIG))
     monkeypatch.setattr(main_mod, '_load_schedule_state', lambda: sched)
     monkeypatch.setattr(main_mod, '_save_schedule_state', lambda s: None)
     monkeypatch.setattr(main_mod, '_should_skip_poll', lambda *a, **k: (False, ''))
@@ -82,3 +82,34 @@ def test_no_transition_keeps_render_cache(monkeypatch, tmp_path):
 
     render_mock.assert_called_once()
     assert render_mock.call_args.kwargs['bypass_cache'] is False
+
+
+def test_dark_transition_forces_leaders_refresh(monkeypatch, tmp_path):
+    """A polarity flip must also force stale data (e.g. leaders) to refresh,
+    not just bypass the render cache — a mode flip is exactly the moment a
+    frozen leaders panel from hours ago would be most visible."""
+    render_mock = MagicMock(return_value=None)
+    config = dict(BASE_CONFIG, show_leaders_panel=True)
+    fetch_leaders_mock = MagicMock(return_value={})
+    monkeypatch.setattr(main_mod, 'fetch_leaders', fetch_leaders_mock)
+    monkeypatch.setattr(main_mod, 'load_json_file', lambda *a, **k: {})
+
+    # last run was dark, config now evaluates light → transition detected
+    _run_main(monkeypatch, tmp_path, {'last_dark_mode': True}, render_mock, config=config)
+
+    fetch_leaders_mock.assert_called_once()
+    assert fetch_leaders_mock.call_args.kwargs['force'] is True
+
+
+def test_no_transition_does_not_force_leaders_refresh(monkeypatch, tmp_path):
+    """Steady state (no polarity change) must not force a leaders refetch —
+    the normal staleness/Finals-based check still gates it."""
+    render_mock = MagicMock(return_value=None)
+    config = dict(BASE_CONFIG, show_leaders_panel=True)
+    fetch_leaders_mock = MagicMock(return_value={})
+    monkeypatch.setattr(main_mod, 'fetch_leaders', fetch_leaders_mock)
+    monkeypatch.setattr(main_mod, '_should_refresh_leaders', lambda *a, **k: False)
+
+    _run_main(monkeypatch, tmp_path, {'last_dark_mode': False}, render_mock, config=config)
+
+    fetch_leaders_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- New `--full-refresh` CLI flag: bypasses every throttling/staleness cache (games/smart-polling, standings, leaders, transactions, playoff bracket) for one forced run — useful after manually clearing a bad cached state (like the recent all-star-game/next_game_date incident) or just wanting everything current right now
- Wired the existing night↔day transition detection (`_dark_transitioned`) into the same force path — a polarity flip already forced a full *display* repaint, but now it also forces standings/leaders/transactions/bracket **data** refreshes, since a mode flip is exactly the moment stale data (e.g. an unrefreshed leaders panel) is most visible
- Confirmed the transition check is a state comparison (`last_dark_mode` vs freshly computed `_is_dark`), not a clock check — it still fires correctly on the next poll even if that poll lands a few minutes after 7am/8pm rather than exactly on the boundary

## Bug found while testing
`fetch_leaders()` had its own internal 20h TTL cache that silently ignored the caller's force decision — `main.py` would decide a refresh was needed and call `fetch_leaders()`, but that function would print "Leaders cache fresh" and return the stale cache anyway. Added a `force` param that bypasses it. Without this fix, `--full-refresh` looked like it worked (it printed "Refreshing leaders...") but `leaders.json` was never actually updated.

## Test plan
- [x] `poetry run pytest` — 1669 passed, 15 skipped
- [x] Manually ran `python main.py --full-refresh` — confirmed "Fetching 2026 season leaders..." now appears instead of the cache-skip message
- [x] Added `test_dark_transition_forces_leaders_refresh` / `test_no_transition_does_not_force_leaders_refresh` to `tests/test_dark_transition_refresh.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyh2jrhC1x6Do6SR1xEcJA