### PR TITLE
Fix MiLB logo auto-download: PNG CDN + per-sport subdirectories

### DIFF
--- a/src/download_logos.py
+++ b/src/download_logos.py
@@ -74,7 +74,8 @@ def _load_render_config(root):
         return {}
 
 
-MLBSTATIC_SVG_URL = 'https://www.mlbstatic.com/team-logos/{team_id}.svg'
+MLBSTATIC_SVG_URL    = 'https://www.mlbstatic.com/team-logos/{team_id}.svg'
+MIDFIELD_PNG_URL     = 'https://midfield.mlbstatic.com/v1/team/{team_id}/spots/96'
 
 
 def _svg_to_png(svg_bytes, dest, size=500):
@@ -99,10 +100,17 @@ def download_logos(abbr_map, logodir, render_config=None, sport_id=1):
     is_wbc = sport_id == 8
     is_milb = sport_id not in (1, 8)  # MiLB sports: AAA=11, AA=12, etc.
 
+    milb_subdir = os.path.join(logodir, str(sport_id)) if is_milb else None
+    if milb_subdir:
+        os.makedirs(milb_subdir, exist_ok=True)
+
     for team_id, abbr in sorted(abbr_map.items(), key=lambda x: x[1]):
-        # MiLB logos saved as {team_id}.png to avoid abbr collisions with MLB teams
-        # (e.g. COL = Colorado Rockies AND Columbus Clippers).
-        dest = os.path.join(logodir, f'{team_id}.png' if is_milb else f'{abbr}.png')
+        # MiLB logos stored in pic/logos/{sport_id}/{team_id}.png to keep leagues
+        # separate and avoid ID collisions between sports.
+        if is_milb:
+            dest = os.path.join(milb_subdir, f'{team_id}.png')
+        else:
+            dest = os.path.join(logodir, f'{abbr}.png')
 
         if os.path.exists(dest):
             print(f'  {abbr:<4} already exists — skipping')
@@ -128,7 +136,23 @@ def download_logos(abbr_map, logodir, render_config=None, sport_id=1):
                 print(f'  {abbr:<4} try failed: {url} — {e}')
 
         if not saved and is_milb:
-            # MiLB/AAA: download SVG from mlbstatic and convert to PNG
+            # MiLB: try midfield PNG CDN first (no cairosvg needed)
+            png_url = MIDFIELD_PNG_URL.format(team_id=team_id)
+            try:
+                req = urllib.request.Request(png_url, headers={'User-Agent': 'Mozilla/5.0'})
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    data_bytes = resp.read()
+                with open(dest, 'wb') as f:
+                    f.write(data_bytes)
+                size_kb = len(data_bytes) // 1024
+                print(f'  {abbr:<4} saved  ({size_kb} KB)  [{png_url}]')
+                success += 1
+                saved = True
+            except Exception as e:
+                print(f'  {abbr:<4} midfield PNG failed: {e}')
+
+        if not saved and is_milb:
+            # MiLB fallback: SVG from mlbstatic (requires cairosvg + libcairo2)
             svg_url = MLBSTATIC_SVG_URL.format(team_id=team_id)
             try:
                 req = urllib.request.Request(svg_url, headers={'User-Agent': 'Mozilla/5.0'})
@@ -186,12 +210,17 @@ def main():
                         help='Shortcut for --sport-id 8 --fetch-teams (download WBC logos)')
     parser.add_argument('--aaa', action='store_true',
                         help='Shortcut for --sport-id 11 --fetch-teams (download Triple-A logos)')
+    parser.add_argument('--intl', action='store_true',
+                        help='Shortcut for --sport-id 51 --fetch-teams (download DSL/FCL/ACL logos)')
     args = parser.parse_args()
 
     if args.wbc:
         args.sport_id = 8
     if args.aaa:
         args.sport_id = 11
+        args.fetch_teams = True
+    if getattr(args, 'intl', False):
+        args.sport_id = 51
         args.fetch_teams = True
 
     root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/src/image_assets.py
+++ b/src/image_assets.py
@@ -58,12 +58,23 @@ def _get_logo_invert_config():
     return _logo_invert_config
 
 
-def _try_download_logo(abbr, team_id=None):
+def _milb_logo_dir(sport_id):
+    """Return the per-sport logo subdirectory for MiLB teams (created on demand)."""
+    d = os.path.join(logodir, str(sport_id))
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _try_download_logo(abbr, team_id=None, sport_id=None):
     """Download a missing team logo from ESPN CDN using stdlib only (no pip needed).
 
-    Tries MLB CDN first, then mlbstatic SVG (for MiLB/AAA teams, requires cairosvg),
+    Tries MLB CDN first, then midfield PNG CDN for MiLB (no cairosvg required),
+    then mlbstatic SVG fallback (requires cairosvg + libcairo2),
     then ESPN countries CDN only for known WBC abbreviations.
     Skips numeric or T{id} fallback abbreviations.
+
+    MiLB logos are stored in pic/logos/{sport_id}/{team_id}.png to keep leagues
+    separate and avoid ID collisions between sports.
     """
     if abbr.isdigit() or (abbr.startswith('T') and abbr[1:].isdigit()):
         return False
@@ -86,16 +97,38 @@ def _try_download_logo(abbr, team_id=None):
     except Exception:
         pass
 
-    # Try mlbstatic SVG CDN (covers MiLB/AAA teams not on ESPN) — requires cairosvg
-    # Save as {team_id}.png (not {abbr}.png) to avoid collisions with MLB team abbreviations
+    # MiLB teams: validate via mlbstatic SVG (404s for non-existent teams), then download
+    # PNG from midfield CDN (no cairosvg required).
+    # Stored in pic/logos/{sport_id}/{team_id}.png; sport_id defaults to 0 when unknown.
     if team_id and str(team_id).isdigit():
+        sid = sport_id if sport_id is not None else 0
+        id_path = os.path.join(_milb_logo_dir(sid), f'{team_id}.png')
+        try:
+            # HEAD the SVG first — mlbstatic returns 404 for invalid/non-existent teams
+            # while midfield CDN returns 200 with a generic placeholder for any ID.
+            svg_url = f'https://www.mlbstatic.com/team-logos/{team_id}.svg'
+            head_req = urllib.request.Request(svg_url, method='HEAD',
+                                              headers={'User-Agent': 'Mozilla/5.0'})
+            with urllib.request.urlopen(head_req, timeout=5):
+                pass  # 200 = team exists; 404 raises HTTPError → skip download
+
+            png_url = f'https://midfield.mlbstatic.com/v1/team/{team_id}/spots/96'
+            req = urllib.request.Request(png_url, headers={'User-Agent': 'Mozilla/5.0'})
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                data = resp.read()
+            with open(id_path, 'wb') as f:
+                f.write(data)
+            print(f'Auto-downloaded MiLB logo: {abbr}')
+            return True
+        except Exception:
+            pass
+
+        # Fallback: convert SVG to PNG via cairosvg (requires libcairo2 system lib)
         try:
             import cairosvg
-            svg_url = f'https://www.mlbstatic.com/team-logos/{team_id}.svg'
             svg_data = urllib.request.urlopen(svg_url, timeout=5).read()
-            id_path = os.path.join(logodir, f'{team_id}.png')
             cairosvg.svg2png(bytestring=svg_data, write_to=id_path, output_width=500)
-            print(f'Auto-downloaded MiLB logo: {abbr}')
+            print(f'Auto-downloaded MiLB logo (SVG): {abbr}')
             return True
         except Exception:
             pass
@@ -136,16 +169,30 @@ def _load_logo_gray(abbr, team_id):
     abbr_path = os.path.join(logodir, f'{abbr}.png')
     id_path   = os.path.join(logodir, f'{str(team_id)}.png')
 
-    # Auto-download once if neither file exists yet
-    if not os.path.exists(abbr_path) and not os.path.exists(id_path):
-        _try_download_logo(abbr, team_id=team_id)
+    # MiLB logos live in pic/logos/{sport_id}/{team_id}.png subdirs.
+    # Scan all numeric subdirs to find one that has this team_id.
+    subdir_id_path = None
+    if team_id and str(team_id).isdigit() and not os.path.exists(id_path):
+        import glob as _glob
+        matches = _glob.glob(os.path.join(logodir, '*', f'{team_id}.png'))
+        if matches:
+            subdir_id_path = matches[0]
 
-    # Prefer {team_id}.png — avoids collisions where a MiLB team shares an abbreviation
-    # with an MLB team (e.g. COL = Colorado Rockies AND Columbus Clippers).
-    # MLB logos are only saved as {abbr}.png, so they fall through naturally.
+    # Auto-download once if no logo file exists anywhere
+    if not os.path.exists(abbr_path) and not os.path.exists(id_path) and not subdir_id_path:
+        _try_download_logo(abbr, team_id=team_id)
+        # Re-check subdir after download
+        if team_id and str(team_id).isdigit():
+            import glob as _glob
+            matches = _glob.glob(os.path.join(logodir, '*', f'{team_id}.png'))
+            if matches:
+                subdir_id_path = matches[0]
+
+    # Prefer team_id path (subdir or flat) over abbr — avoids collisions where a MiLB
+    # team shares an abbreviation with an MLB team (e.g. COL = Rockies AND Clippers).
     result = None
-    for path in (id_path, abbr_path):
-        if os.path.exists(path):
+    for path in (subdir_id_path, id_path, abbr_path):
+        if path and os.path.exists(path):
             try:
                 img = Image.open(path).convert('RGBA')
                 _alpha_bbox = img.split()[3].getbbox()


### PR DESCRIPTION
## Summary
- **Root cause**: MiLB logos (FCL/DSL/ACL/AAA teams) weren't auto-downloading on the Pi because `cairosvg` requires `libcairo2` as a system library, which isn't always installed
- **Fix**: Switch to `midfield.mlbstatic.com/v1/team/{id}/spots/96` PNG CDN — no cairosvg needed, works everywhere
- **Validation**: Before downloading, HEAD the `mlbstatic.com/team-logos/{id}.svg` endpoint (404s for non-existent IDs) to prevent the midfield CDN's generic placeholder from being saved for bogus team IDs
- **Organization**: MiLB logos now stored in `pic/logos/{sport_id}/{team_id}.png` subdirectories (e.g. `pic/logos/51/467.png`) so each league's logos are visually distinct from MLB logos
- **`download_logos.py`**: Added `--intl` shortcut for sport_id 51 (DSL/FCL/ACL leagues); MiLB downloads also use the subdir scheme and PNG CDN first

## Test plan
- [ ] Logos auto-download during render when `pic/logos/0/` is empty
- [ ] No bogus files (ID 0, 999, etc.) downloaded — SVG HEAD validation works
- [ ] `download_logos.py --intl` stores to `pic/logos/51/`
- [ ] Existing flat `pic/logos/{team_id}.png` logos still load (backward-compat via `id_path` check)
- [ ] All 1709 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gyh2jrhC1x6Do6SR1xEcJA