### PR TITLE
Move leaderboard logos down 2px

### DIFF
--- a/src/image_leaders.py
+++ b/src/image_leaders.py
@@ -143,7 +143,7 @@ def draw_leaders_cell(Himage, sx, sy, leaders_data, team_data, category=None, ro
                 logo = _logo_small(abbr, team_id, size=logo_size)
                 if logo:
                     logo_x = logo_col_x + (logo_size - logo.width) // 2
-                    logo_y = ry + (row_h - logo.height) // 2
+                    logo_y = ry + (row_h - logo.height) // 2 + 2
                     Himage.paste(logo, (logo_x, logo_y))
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- Shifted team logos in the stat-leaders cells (Home Runs, Batting Avg, ERA, Saves, Hits, RBIs, Stolen Bases) down 2px within each row for better vertical alignment with the name/value text.

## Test plan
- [x] Rendered a real triple-cell frame before/after and visually confirmed the logo offset without breaking row layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)