### PR TITLE
Fix real MLB logos overridden by circular MiLB placeholder cache

### DIFF
--- a/src/image_assets.py
+++ b/src/image_assets.py
@@ -188,10 +188,14 @@ def _load_logo_gray(abbr, team_id):
             if matches:
                 subdir_id_path = matches[0]
 
-    # Prefer team_id path (subdir or flat) over abbr — avoids collisions where a MiLB
-    # team shares an abbreviation with an MLB team (e.g. COL = Rockies AND Clippers).
+    # Prefer team_id path over abbr — avoids collisions where a MiLB team shares an
+    # abbreviation with an MLB team (e.g. COL = Rockies AND Clippers). The MiLB subdir
+    # match comes last: it's keyed by sport_id (defaulting to 0 when unknown, since
+    # _try_download_logo is never called with an explicit sport_id), so a flat file
+    # here is always a deliberate, known-good logo — it must win over a generic
+    # subdir cache entry even when both exist for the same team_id.
     result = None
-    for path in (subdir_id_path, id_path, abbr_path):
+    for path in (id_path, abbr_path, subdir_id_path):
         if path and os.path.exists(path):
             try:
                 img = Image.open(path).convert('RGBA')


### PR DESCRIPTION
## Summary
- Team logos were rendering as circular badges instead of the correct flat logo (e.g. Angels 'A' logo replaced by a circular midfield spot badge) for any team that had ever hit the MiLB download fallback.
- Root cause: `_try_download_logo` is never called with an explicit `sport_id`, so it defaults to `0`. When the primary ESPN CDN fetch fails, it falls back to the midfield MiLB endpoint and caches a circular team-spot PNG under `pic/logos/0/{team_id}.png` — using the real MLB numeric team ID. `_load_logo_gray` checked that subdir cache *before* the correct flat file (`pic/logos/{ABBR}.png`), so the bogus circular badge permanently won once cached.
- Fix: reorder the lookup so `id_path`/`abbr_path` (known-good, deliberately maintained files) are checked before the generic MiLB subdir cache.
- Also cleared the local stale `pic/logos/0/` cache (gitignored, auto-downloaded — not tracked in git).

## Test plan
- [x] Existing wide-cell smoke tests pass (pre-commit hook)
- [ ] Regenerate a scoreboard render and confirm MLB team logos (e.g. LAA) show the correct flat logo, not a circle

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01QMvJe7Wg2TzE3fvW4x5Mkh