### PR TITLE
Fix timelapse video runner numbers/hits and field diagram accuracy

### DIFF
--- a/src/field_view.py
+++ b/src/field_view.py
@@ -188,7 +188,7 @@ def _transform_hit_coords(api_x, api_y):
 
 
 def _draw_all_hits(draw, data, fonts=None):
-    """Plot all batted balls accumulated this game.
+    """Plot the last 7 batted balls in play (older markers are dropped upstream).
 
     Current half-inning events → filled markers.
     Previous half-inning events → outline/ghost markers.

--- a/src/game_detail_fetch.py
+++ b/src/game_detail_fetch.py
@@ -858,7 +858,9 @@ def _extract_all_hit_coordinates(plays):
         hit_data = play.get('hitData', {})
         cx = hit_data.get('coordinates', {}).get('coordX')
         cy = hit_data.get('coordinates', {}).get('coordY')
-        abbr = _EVENT_ABBR.get(event, event[:2].upper() if event else '?')
+        # Use the same credits-based notation as the scorecard (e.g. 'F9', 'L4')
+        # so flyouts/lineouts on the field diagram show the fielder who made the play.
+        abbr = _build_scorecard_notation(play) or _EVENT_ABBR.get(event, event[:2].upper() if event else '?')
         if cx is not None and cy is not None:
             distance = hit_data.get('totalDistance')
             hits.append({'x': cx, 'y': cy, 'is_hr': is_hr, 'is_hit': is_hit, 'is_out': is_out,
@@ -932,7 +934,9 @@ def fetch_field_view_data(game_pk):
 
     # Pitch locations and hit coordinates
     pitches = _extract_pitches_detailed(plays)
-    all_hits = _extract_all_hit_coordinates(plays)
+    # Keep only the last 7 batted balls so old markers are removed from the
+    # field diagram instead of accumulating for the whole game.
+    all_hits = _extract_all_hit_coordinates(plays)[-7:]
     last_hit = all_hits[-1] if all_hits else None
     hit_coords = (last_hit['x'], last_hit['y']) if last_hit else None
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -3051,6 +3051,20 @@ def _draw_field_cell(draw, Himage, fx, fy, fw, fh, game_data, scale=1, y_offset=
                 'is_out': bool(game_data.get('last_hit_is_out')),
             }]
 
+    def _wall_dist_at_angle(theta):
+        """Fence distance (ft) at a given angle from home plate, interpolated
+        along wall_poly (same theta = atan2(x_ft, y_ft) convention as `thetas` above)."""
+        t = max(thetas[0], min(thetas[-1], theta))
+        for i in range(len(thetas) - 1):
+            if thetas[i] <= t <= thetas[i + 1]:
+                x0, y0 = wall_poly[i]
+                x1, y1 = wall_poly[i + 1]
+                d0, d1 = _math.hypot(x0, y0), _math.hypot(x1, y1)
+                span = thetas[i + 1] - thetas[i]
+                frac = (t - thetas[i]) / span if span else 0
+                return d0 + (d1 - d0) * frac
+        return _math.hypot(*wall_poly[-1])
+
     def _bezier_trajectory(p0x, p0y, p1x, p1y):
         mx_, my_ = (p0x + p1x) / 2, (p0y + p1y) / 2
         dx_, dy_ = p1x - p0x, p1y - p0y
@@ -3079,8 +3093,17 @@ def _draw_field_cell(draw, Himage, fx, fy, fw, fh, game_data, scale=1, y_offset=
             if dist_ft is not None:
                 abbr = f'HR {int(dist_ft)}'
 
-        # HR endpoint: _ray_end traces to the cell edge (visually over the fence).
-        land_pt = _ray_end(hx_ft, hy_ft) if is_hr else _fpt(hx_ft, hy_ft)
+        # Landing spot: real hit coordinates for every ball. A confirmed HR must
+        # clear the fence visually — if the API coordinates land short of the wall
+        # in that direction (coordinate imprecision), push it out to just past
+        # the fence rather than forcing every HR to the cell edge.
+        if is_hr:
+            _ang = _math.atan2(hx_ft, hy_ft)
+            _d_ball = _math.hypot(hx_ft, hy_ft)
+            _d_wall = _wall_dist_at_angle(_ang)
+            _d_final = max(_d_ball, _d_wall + 8)
+            hx_ft, hy_ft = _d_final * _math.sin(_ang), _d_final * _math.cos(_ang)
+        land_pt = _fpt(hx_ft, hy_ft)
 
         if idx == most_recent_idx:
             _bezier_trajectory(HX, HY, *land_pt)

--- a/src/timelapse.py
+++ b/src/timelapse.py
@@ -23,7 +23,7 @@ import requests
 
 from fetch_games import fetch_scoreboard_for_date, _lookup_stadium
 from util import load_json_file, load_yaml_file
-from game_detail_fetch import _PITCH_TYPE_ABBR
+from game_detail_fetch import _PITCH_TYPE_ABBR, _EVENT_ABBR, _build_scorecard_notation
 
 _INNING_ORDINALS = {
     1: '1st', 2: '2nd', 3: '3rd', 4: '4th', 5: '5th', 6: '6th',
@@ -122,8 +122,19 @@ def _fetch_game_timeline(game_pk):
     away_order = _build_order(bscore_teams.get('away', {}))  # [(pid, name), ...]
     home_order = _build_order(bscore_teams.get('home', {}))
 
+    # Jersey numbers by player id, for runner-on-base labels (mirrors
+    # game_detail_fetch._runner_jersey, which is only available for live games).
+    player_jersey = {}
+    for _side in ('away', 'home'):
+        for _pdata in bscore_teams.get(_side, {}).get('players', {}).values():
+            _pid = _pdata.get('person', {}).get('id')
+            _jn = _pdata.get('jerseyNumber')
+            if _pid is not None and _jn is not None:
+                player_jersey[_pid] = _jn
+
     all_plays = data.get('liveData', {}).get('plays', {}).get('allPlays', [])
     timeline = []
+    hit_events = []
     first_pitch = None
     pitch_events = []
     wp_events = []
@@ -151,6 +162,7 @@ def _fetch_game_timeline(game_pk):
     running_away = 0
     running_home = 0
     running_runners = {'first': None, 'second': None, 'third': None}
+    running_runner_ids = {'first': None, 'second': None, 'third': None}
     cumulative_last_play      = None  # last non-substitution event name seen so far
     cumulative_last_play_inn  = None  # inning of that event
     cumulative_last_play_top  = None  # True if top half, False if bottom
@@ -189,6 +201,7 @@ def _fetch_game_timeline(game_pk):
         at_bat_batter_id = matchup.get('batter',  {}).get('id')
         # Runners at START of this at-bat = running_runners before the play completes
         at_bat_runners = dict(running_runners)
+        at_bat_runner_ids = dict(running_runner_ids)
 
         # Per-at-bat pitch detail state (reset for each play/at-bat)
         ab_pitch_num       = 0
@@ -260,6 +273,9 @@ def _fetch_game_timeline(game_pk):
                 'runner_on_first':    at_bat_runners['first'],
                 'runner_on_second':   at_bat_runners['second'],
                 'runner_on_third':    at_bat_runners['third'],
+                'runner_first_number':  player_jersey.get(at_bat_runner_ids['first']),
+                'runner_second_number': player_jersey.get(at_bat_runner_ids['second']),
+                'runner_third_number':  player_jersey.get(at_bat_runner_ids['third']),
                 # Pitch detail fields — populated for pitch events; non-pitch
                 # events carry over the last pitch values so they're always fresh.
                 'is_pitch':           is_pitch,
@@ -296,7 +312,11 @@ def _fetch_game_timeline(game_pk):
         post_first  = (matchup.get('postOnFirst')  or {}).get('fullName') or None
         post_second = (matchup.get('postOnSecond') or {}).get('fullName') or None
         post_third  = (matchup.get('postOnThird')  or {}).get('fullName') or None
+        post_first_id  = (matchup.get('postOnFirst')  or {}).get('id')
+        post_second_id = (matchup.get('postOnSecond') or {}).get('id')
+        post_third_id  = (matchup.get('postOnThird')  or {}).get('id')
         running_runners = {'first': post_first, 'second': post_second, 'third': post_third}
+        running_runner_ids = {'first': post_first_id, 'second': post_second_id, 'third': post_third_id}
 
         # Track hits and perfect-game state for no-hitter reconstruction.
         play_event = result.get('event', '')
@@ -315,6 +335,32 @@ def _fetch_game_timeline(game_pk):
             if _batter_reached:
                 away_pg_intact = False  # away pitcher's PG is broken
 
+        # Batted-ball landing spot for the field diagram (mirrors
+        # game_detail_fetch._extract_all_hit_coordinates, unavailable for past games).
+        _hit_data = play.get('hitData', {})
+        _hx = _hit_data.get('coordinates', {}).get('coordX')
+        _hy = _hit_data.get('coordinates', {}).get('coordY')
+        if _hx is None or _hy is None:
+            for _pe in play.get('playEvents', []):
+                _pe_hit_data = _pe.get('hitData', {})
+                _hx = _pe_hit_data.get('coordinates', {}).get('coordX')
+                _hy = _pe_hit_data.get('coordinates', {}).get('coordY')
+                if _hx is not None and _hy is not None:
+                    break
+        if _hx is not None and _hy is not None:
+            hit_events.append({
+                'time':     end_time,
+                'x':        _hx,
+                'y':        _hy,
+                'is_hr':    play_event == 'Home Run',
+                'is_out':   not _is_hit,
+                # Credits-based notation (e.g. 'F9', 'L4') shows the fielder who
+                # made the catch/play, matching the live-game field diagram.
+                'abbr':     _build_scorecard_notation(play) or
+                            _EVENT_ABBR.get(play_event, play_event[:2].upper() if play_event else '?'),
+                'distance': _hit_data.get('totalDistance'),
+            })
+
         timeline.append({
             'end_time':           end_time,
             'away_score':         away_score,
@@ -329,6 +375,9 @@ def _fetch_game_timeline(game_pk):
             'runner_on_first':    post_first,
             'runner_on_second':   post_second,
             'runner_on_third':    post_third,
+            'runner_first_number':  player_jersey.get(post_first_id),
+            'runner_second_number': player_jersey.get(post_second_id),
+            'runner_third_number':  player_jersey.get(post_third_id),
             # Cumulative hit counts and PG state as of this play's completion.
             'away_hits_so_far':   running_away_hits,
             'home_hits_so_far':   running_home_hits,
@@ -386,6 +435,7 @@ def _fetch_game_timeline(game_pk):
     timeline.sort(key=lambda p: p['end_time'])
     pitch_events.sort(key=lambda e: e['time'])
     wp_events.sort(key=lambda e: e['time'])
+    hit_events.sort(key=lambda e: e['time'])
 
     # First pitch event where a ball or strike was actually registered
     first_actual_pitch = None
@@ -454,6 +504,7 @@ def _fetch_game_timeline(game_pk):
         'first_actual_pitch_utc': first_actual_pitch,
         'last_play_utc':         timeline[-1]['end_time'] if timeline else None,
         'plays':                 timeline,
+        'hit_events':            hit_events,
         'pitch_events':          pitch_events,
         'wp_events':             wp_events,
         'challenge_events':      challenge_events,
@@ -797,14 +848,28 @@ def _game_state_at_time(base_game, tl, target_utc):
         state['runner_on_first']  = last_event.get('runner_on_first')
         state['runner_on_second'] = last_event.get('runner_on_second')
         state['runner_on_third']  = last_event.get('runner_on_third')
+        state['runner_first_number']  = last_event.get('runner_first_number')
+        state['runner_second_number'] = last_event.get('runner_second_number')
+        state['runner_third_number']  = last_event.get('runner_third_number')
     elif between_plays and last_play and last_play.get('outs_after', 0) < 3:
         state['runner_on_first']  = last_play.get('runner_on_first')
         state['runner_on_second'] = last_play.get('runner_on_second')
         state['runner_on_third']  = last_play.get('runner_on_third')
+        state['runner_first_number']  = last_play.get('runner_first_number')
+        state['runner_second_number'] = last_play.get('runner_second_number')
+        state['runner_third_number']  = last_play.get('runner_third_number')
     else:
         state['runner_on_first']  = None
         state['runner_on_second'] = None
         state['runner_on_third']  = None
+        state['runner_first_number']  = None
+        state['runner_second_number'] = None
+        state['runner_third_number']  = None
+
+    # Batted-ball markers for the field diagram: last 7 balls in play up to target_utc.
+    state['recent_hits'] = [
+        h for h in tl.get('hit_events', []) if h['time'] <= target_utc
+    ][-7:]
 
     # ABS challenges: replay cumulative state up to target_utc.
     # Default to full allotment when no challenges have been used yet.


### PR DESCRIPTION
## Summary
- Video (timelapse) reconstruction never populated runner jersey numbers or recent batted-ball coordinates, so generated videos showed empty bases and no field markers.
- Flyouts/lineouts on the field diagram showed a generic letter (F/L) instead of the fielder who made the play; now reuse the credits-based scorecard notation (F9, L4, 5-3, ...) in both the live path and the video reconstruction.
- Home run landing points either always jumped to the tile edge or could land short of the fence depending on raw hit coordinates; now use real coordinates but clamp to just past the actual fence distance so a HR always visually clears the wall.
- The standalone field view accumulated every batted ball for the whole game with no cap; capped to the last 7 like the other field diagrams so old markers are removed.

## Test plan
- [x] Syntax/pre-commit checks + wide-cell smoke tests pass (56 passed)
- [x] Manually verified against real completed game data (gamePk 777505): jersey numbers resolve correctly, flyouts/lineouts/groundouts show fielder credits (F7, F9, 5-3, etc.), HR landing points clamp past the fence
- [ ] Visual check of a generated timelapse video and the 3-cell/field-view displays on actual hardware or a rendered frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMvJe7Wg2TzE3fvW4x5Mkh