### PR TITLE
Reconstruct header play-by-play strip for timelapse video

### DIFF
--- a/src/timelapse.py
+++ b/src/timelapse.py
@@ -45,6 +45,31 @@ _NOT_AB_EVENTS = frozenset({
 # Inning threshold before displaying no-hitter / perfect game banner
 _NO_HITTER_INNING_THRESHOLD = 5
 
+# Header event ("half_inning_plays") reconstruction — mirrors
+# game_detail_fetch.fetch_scoreboard_live_extras, which is only available for
+# live games and can't be replayed for a historical timelapse.
+_HEADER_ACTION_CODES = {
+    'stolen_base':      'SB',
+    'caught_stealing':  'CS',
+    'pickoff':          'PK',
+    'wild_pitch':       'WP',
+    'passed_ball':      'PB',
+    'balk':             'BLK',
+    'pitching_substitution': 'PC',
+}
+_HEADER_SUBST_EVENT_TYPES = frozenset({
+    'pitching_substitution', 'defensive_substitution', 'offensive_substitution',
+    'runner_substitution', 'game_advisory', 'ejection', 'defensive_switch',
+})
+
+
+def _header_action_code(et):
+    """Map a lowercased playEvent eventType to its header abbreviation, if any."""
+    for kw, code in _HEADER_ACTION_CODES.items():
+        if et.startswith(kw):
+            return code
+    return None
+
 
 def _ordinal(n):
     """Ordinal."""
@@ -176,6 +201,11 @@ def _fetch_game_timeline(game_pk):
     home_pg_intact      = True   # home pitcher's PG (away team has no baserunners)
     away_pg_intact      = True   # away pitcher's PG (home team has no baserunners)
 
+    # Header event stream: (time, token) pairs feeding half_inning_plays
+    # reconstruction, mirroring game_detail_fetch's game_plays list.
+    header_events = []
+    _last_header_half = None   # (inning, isTopInning) of the last appended token
+
     for i, play in enumerate(all_plays):
         about  = play.get('about', {})
         result = play.get('result', {})
@@ -210,8 +240,38 @@ def _fetch_game_timeline(game_pk):
         ab_last_pitch_type = None
         ab_last_strike     = ''
         ab_last_call_code  = ''
+        _review_added_this_play = False
 
         for ev in play.get('playEvents', []):
+            # Header events: in-play actions (steals, pickoffs, wild pitches, ...)
+            # and challenge/replay reviews, timestamped by the event itself so
+            # they can be filtered to "as of target_utc" later.
+            if ev.get('type') == 'action':
+                _hcode = _header_action_code((ev.get('details', {}).get('eventType') or '').lower())
+                if _hcode and (not header_events or header_events[-1][1] != _hcode):
+                    _hev_time_str = ev.get('startTime', '')
+                    try:
+                        _hev_time = _parse_mlb_time(_hev_time_str) if _hev_time_str else None
+                    except ValueError:
+                        _hev_time = None
+                    if _hev_time:
+                        _this_half = (inning, half_inning == 'top')
+                        if _last_header_half and _this_half != _last_header_half:
+                            header_events.append((_hev_time, '^' if _this_half[1] else 'v'))
+                        header_events.append((_hev_time, _hcode))
+                        _last_header_half = _this_half
+            _hrd = ev.get('reviewDetails')
+            if _hrd and not _hrd.get('inProgress') and not _review_added_this_play:
+                _hev_time_str2 = ev.get('startTime', '')
+                try:
+                    _hev_time2 = _parse_mlb_time(_hev_time_str2) if _hev_time_str2 else None
+                except ValueError:
+                    _hev_time2 = None
+                if _hev_time2:
+                    header_events.append(
+                        (_hev_time2, 'CHAL W' if _hrd.get('isOverturned') else 'CHAL L')
+                    )
+                    _review_added_this_play = True
             # ABS challenge tracking
             rd = ev.get('reviewDetails')
             if rd and ev.get('type') == 'pitch':
@@ -335,6 +395,35 @@ def _fetch_game_timeline(game_pk):
             if _batter_reached:
                 away_pg_intact = False  # away pitcher's PG is broken
 
+        # Finalized play notation for the header (e.g. '6-3', 'K', 'F9', '3R HR'),
+        # mirroring game_detail_fetch's game_plays construction.
+        _et_h = (result.get('eventType') or '').lower().replace(' ', '_')
+        _this_header_half = (inning, half_inning == 'top')
+        if _et_h == 'pitching_substitution':
+            if not header_events or header_events[-1][1] != 'PC':
+                if _last_header_half and _this_header_half != _last_header_half:
+                    header_events.append((end_time, '^' if _this_header_half[1] else 'v'))
+                header_events.append((end_time, 'PC'))
+                _last_header_half = _this_header_half
+        elif _et_h not in _HEADER_SUBST_EVENT_TYPES and play_event.strip():
+            _note = _build_scorecard_notation(play)
+            _rbi = int(result.get('rbi') or 0)
+            _is_err = _note.startswith('E') or ' E' in _note
+            if _rbi > 0 and not _is_err:
+                if _note == 'HR':
+                    if _rbi == 4:
+                        _note = 'Grand Slam'
+                    elif _rbi >= 2:
+                        _note = f'{_rbi}R HR'
+                elif _rbi == 1:
+                    _note = f'RBI {_note}'
+                else:
+                    _note = f'{_rbi}RBI {_note}'
+            if _last_header_half and _this_header_half != _last_header_half:
+                header_events.append((end_time, '^' if _this_header_half[1] else 'v'))
+            header_events.append((end_time, _note))
+            _last_header_half = _this_header_half
+
         # Batted-ball landing spot for the field diagram (mirrors
         # game_detail_fetch._extract_all_hit_coordinates, unavailable for past games).
         _hit_data = play.get('hitData', {})
@@ -436,6 +525,7 @@ def _fetch_game_timeline(game_pk):
     pitch_events.sort(key=lambda e: e['time'])
     wp_events.sort(key=lambda e: e['time'])
     hit_events.sort(key=lambda e: e['time'])
+    header_events.sort(key=lambda t: t[0])
 
     # First pitch event where a ball or strike was actually registered
     first_actual_pitch = None
@@ -505,6 +595,7 @@ def _fetch_game_timeline(game_pk):
         'last_play_utc':         timeline[-1]['end_time'] if timeline else None,
         'plays':                 timeline,
         'hit_events':            hit_events,
+        'header_events':         header_events,
         'pitch_events':          pitch_events,
         'wp_events':             wp_events,
         'challenge_events':      challenge_events,
@@ -870,6 +961,20 @@ def _game_state_at_time(base_game, tl, target_utc):
     state['recent_hits'] = [
         h for h in tl.get('hit_events', []) if h['time'] <= target_utc
     ][-7:]
+
+    # Header play-by-play strip (same "half_inning_plays" field the live 2-cell/
+    # 3-cell header reads): last 7 events, plus interleaved inning-break markers,
+    # as of target_utc.
+    _header_tokens = [tok for (t, tok) in tl.get('header_events', []) if t <= target_utc]
+    _kept_tokens = []
+    _header_event_count = 0
+    for _tok in reversed(_header_tokens):
+        _kept_tokens.append(_tok)
+        if _tok not in ('^', 'v'):
+            _header_event_count += 1
+            if _header_event_count >= 7:
+                break
+    state['half_inning_plays'] = list(reversed(_kept_tokens))
 
     # ABS challenges: replay cumulative state up to target_utc.
     # Default to full allotment when no challenges have been used yet.

--- a/src/timelapse.py
+++ b/src/timelapse.py
@@ -206,6 +206,11 @@ def _fetch_game_timeline(game_pk):
     header_events = []
     _last_header_half = None   # (inning, isTopInning) of the last appended token
 
+    # Strikeout-tally stream for the cell-2 footer ("home_pitcher_ks"/
+    # "away_pitcher_ks"): (time, side, 'K'|'L') per strikeout, mirroring
+    # game_detail_fetch's home_pitcher_ks/away_pitcher_ks construction.
+    pitcher_k_events = []
+
     for i, play in enumerate(all_plays):
         about  = play.get('about', {})
         result = play.get('result', {})
@@ -395,6 +400,19 @@ def _fetch_game_timeline(game_pk):
             if _batter_reached:
                 away_pg_intact = False  # away pitcher's PG is broken
 
+        # Strikeout tally for the cell-2 footer: home_pitcher_ks tracks Ks by
+        # home-team pitchers (recorded when isTopInning, i.e. away batters are
+        # struck out); away_pitcher_ks is the mirror image.
+        if (result.get('eventType') or '').lower() == 'strikeout':
+            _k_last_code = ''
+            for _kpe in reversed(play.get('playEvents', [])):
+                if _kpe.get('isPitch'):
+                    _k_last_code = _kpe.get('details', {}).get('code', '')
+                    break
+            _k_type = 'L' if _k_last_code == 'C' else 'K'
+            _k_side = 'home' if half_inning == 'top' else 'away'
+            pitcher_k_events.append((end_time, _k_side, _k_type))
+
         # Finalized play notation for the header (e.g. '6-3', 'K', 'F9', '3R HR'),
         # mirroring game_detail_fetch's game_plays construction.
         _et_h = (result.get('eventType') or '').lower().replace(' ', '_')
@@ -526,6 +544,7 @@ def _fetch_game_timeline(game_pk):
     wp_events.sort(key=lambda e: e['time'])
     hit_events.sort(key=lambda e: e['time'])
     header_events.sort(key=lambda t: t[0])
+    pitcher_k_events.sort(key=lambda t: t[0])
 
     # First pitch event where a ball or strike was actually registered
     first_actual_pitch = None
@@ -596,6 +615,7 @@ def _fetch_game_timeline(game_pk):
         'plays':                 timeline,
         'hit_events':            hit_events,
         'header_events':         header_events,
+        'pitcher_k_events':      pitcher_k_events,
         'pitch_events':          pitch_events,
         'wp_events':             wp_events,
         'challenge_events':      challenge_events,
@@ -975,6 +995,17 @@ def _game_state_at_time(base_game, tl, target_utc):
             if _header_event_count >= 7:
                 break
     state['half_inning_plays'] = list(reversed(_kept_tokens))
+
+    # Cell-2 footer K tally: cumulative strikeouts by each side's pitching
+    # as of target_utc.
+    state['home_pitcher_ks'] = [
+        kt for (t, side, kt) in tl.get('pitcher_k_events', [])
+        if t <= target_utc and side == 'home'
+    ]
+    state['away_pitcher_ks'] = [
+        kt for (t, side, kt) in tl.get('pitcher_k_events', [])
+        if t <= target_utc and side == 'away'
+    ]
 
     # ABS challenges: replay cumulative state up to target_utc.
     # Default to full allotment when no challenges have been used yet.

--- a/tests/test_timelapse.py
+++ b/tests/test_timelapse.py
@@ -298,6 +298,174 @@ def test_fetch_game_timeline_first_actual_pitch_fallback_to_first_completed_play
 
 
 # ---------------------------------------------------------------------------
+# _fetch_game_timeline — header_events / pitcher_k_events (cell-2 header strip
+# and K-footer reconstruction for the timelapse video)
+# ---------------------------------------------------------------------------
+
+def _action_event(event_type, time='2026-06-20T23:04:30Z'):
+    """A mid-play 'action' playEvent (steal, pickoff, wild pitch, ...)."""
+    return {'type': 'action', 'startTime': time, 'details': {'eventType': event_type}}
+
+
+def _review_event(overturned, in_progress=False, time='2026-06-20T23:04:45Z'):
+    """A playEvent carrying a completed challenge/replay review."""
+    return {
+        'type': 'no_pitch', 'startTime': time,
+        'reviewDetails': {'inProgress': in_progress, 'isOverturned': overturned},
+    }
+
+
+def test_fetch_game_timeline_header_events_action_code_inserts_break_marker():
+    """A stolen base in the bottom half after a top-half event gets an SB token
+    plus a 'v' inning-break marker, since the two events span different halves."""
+    top_play = _play(inning=1, half='top', outs_after=1,
+                      start='2026-06-20T23:00:00Z', end='2026-06-20T23:02:00Z')
+    bottom_play = _play(inning=1, half='bottom', outs_after=1,
+                         start='2026-06-20T23:03:00Z', end='2026-06-20T23:05:00Z',
+                         events=[_action_event('stolen_base_2b')])
+    feed = _live_feed(all_plays=[top_play, bottom_play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    tokens = [tok for _, tok in tl['header_events']]
+    assert 'SB' in tokens
+    assert 'v' in tokens
+    assert tokens.index('v') < tokens.index('SB')
+
+
+def test_fetch_game_timeline_header_events_action_code_malformed_time_ignored():
+    """An action event with an unparsable startTime contributes no token."""
+    play = _play(events=[_action_event('wild_pitch', time='not-a-timestamp')])
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert 'WP' not in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_header_events_challenge_review_overturned():
+    """A completed, overturned review produces a 'CHAL W' token."""
+    play = _play(events=[_review_event(overturned=True)])
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert 'CHAL W' in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_header_events_challenge_review_upheld():
+    """A completed, upheld review produces a 'CHAL L' token, added only once per play."""
+    play = _play(events=[_review_event(overturned=False), _review_event(overturned=False)])
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    tokens = [tok for _, tok in tl['header_events']]
+    assert tokens.count('CHAL L') == 1
+
+
+def test_fetch_game_timeline_header_events_review_in_progress_ignored():
+    """A review still in progress contributes no token."""
+    play = _play(events=[_review_event(overturned=False, in_progress=True)])
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert not [tok for _, tok in tl['header_events'] if tok.startswith('CHAL')]
+
+
+def test_fetch_game_timeline_header_events_review_malformed_time_ignored():
+    """A review with an unparsable startTime contributes no token."""
+    play = _play(events=[_review_event(overturned=True, time='not-a-timestamp')])
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert 'CHAL W' not in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_header_events_pitching_substitution_deduped():
+    """Consecutive pitching-substitution plays collapse to a single 'PC' token."""
+    p1 = _play(event='', event_type='Pitching Substitution', outs_after=0,
+               start='2026-06-20T23:00:00Z', end='2026-06-20T23:01:00Z')
+    p2 = _play(event='', event_type='Pitching Substitution', outs_after=0,
+               start='2026-06-20T23:01:00Z', end='2026-06-20T23:02:00Z')
+    feed = _live_feed(all_plays=[p1, p2])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    tokens = [tok for _, tok in tl['header_events']]
+    assert tokens.count('PC') == 1
+
+
+def test_fetch_game_timeline_header_events_grand_slam_notation():
+    """A 4-RBI home run is relabeled 'Grand Slam' in the header strip."""
+    play = _play(event='Home Run', event_type='home_run')
+    play['result']['rbi'] = 4
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert 'Grand Slam' in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_header_events_multi_run_hr_notation():
+    """A 2- or 3-RBI home run is prefixed 'NR HR' in the header strip."""
+    play = _play(event='Home Run', event_type='home_run')
+    play['result']['rbi'] = 3
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert '3R HR' in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_header_events_solo_hr_no_prefix():
+    """A solo (1-RBI) home run keeps the plain 'HR' notation."""
+    play = _play(event='Home Run', event_type='home_run')
+    play['result']['rbi'] = 1
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert 'HR' in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_header_events_single_rbi_prefix():
+    """A 1-RBI non-HR play is prefixed 'RBI '."""
+    play = _play(event='Single', event_type='single')
+    play['result']['rbi'] = 1
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert 'RBI 1B' in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_header_events_multi_rbi_prefix():
+    """A multi-RBI non-HR play is prefixed 'NRBI '."""
+    play = _play(event='Double', event_type='double')
+    play['result']['rbi'] = 2
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert '2RBI 2B' in [tok for _, tok in tl['header_events']]
+
+
+def test_fetch_game_timeline_pitcher_k_events_swinging_by_side():
+    """A strikeout in the top half is credited to the home pitcher as a swinging K."""
+    pitch = {'type': 'pitch', 'isPitch': True, 'startTime': '2026-06-20T23:00:30Z',
+              'details': {'code': 'S'}, 'count': {}}
+    play = _play(inning=1, half='top', event='Strikeout', event_type='strikeout',
+                 events=[pitch])
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert [(side, kt) for _, side, kt in tl['pitcher_k_events']] == [('home', 'K')]
+
+
+def test_fetch_game_timeline_pitcher_k_events_looking_by_side():
+    """A called-strikeout in the bottom half is credited to the away pitcher as a looking K."""
+    pitch = {'type': 'pitch', 'isPitch': True, 'startTime': '2026-06-20T23:00:30Z',
+              'details': {'code': 'C'}, 'count': {}}
+    play = _play(inning=1, half='bottom', event='Strikeout', event_type='strikeout',
+                 events=[pitch])
+    feed = _live_feed(all_plays=[play])
+    with patch('timelapse.requests.get', side_effect=_mock_requests_get(feed)):
+        tl = _fetch_game_timeline(12345)
+    assert [(side, kt) for _, side, kt in tl['pitcher_k_events']] == [('away', 'L')]
+
+
+# ---------------------------------------------------------------------------
 # _inning_runs_at_time
 # ---------------------------------------------------------------------------
 
@@ -629,6 +797,44 @@ def test_game_state_next_batters_shown_during_break():
     state = _game_state_at_time(_base_game(), tl, _dt(23, 12))
     assert state['next_batter_1'] == 'A'
     assert state['next_pitcher'] == 'D'
+
+
+def test_game_state_half_inning_plays_filtered_by_target_time():
+    """half_inning_plays only includes header tokens at or before target_utc."""
+    plays = [_completed_play(1, 'top', 0, 0, _dt(23, 10))]
+    header_events = [(_dt(23, 8), 'K'), (_dt(23, 12), '1B')]
+    tl = _tl(plays=plays, header_events=header_events, last_play_utc=_dt(23, 10))
+    state = _game_state_at_time(_base_game(), tl, _dt(23, 10))
+    assert state['half_inning_plays'] == ['K']
+
+
+def test_game_state_half_inning_plays_trims_to_last_seven_events_with_markers():
+    """Only the last 7 non-marker tokens survive, plus any markers between them."""
+    plays = [_completed_play(1, 'top', 0, 0, _dt(23, 10))]
+    header_events = [
+        (_dt(23, 0), 'K'), (_dt(23, 1), '1B'), (_dt(23, 2), 'v'), (_dt(23, 3), 'F9'),
+        (_dt(23, 4), 'K'), (_dt(23, 5), '6-3'), (_dt(23, 6), '^'), (_dt(23, 7), 'BB'),
+        (_dt(23, 8), 'K'), (_dt(23, 9), 'HR'),
+    ]
+    tl = _tl(plays=plays, header_events=header_events, last_play_utc=_dt(23, 10))
+    state = _game_state_at_time(_base_game(), tl, _dt(23, 10))
+    # 10 events total, oldest ('K' at 23:00) dropped to keep the last 7.
+    assert state['half_inning_plays'] == [
+        '1B', 'v', 'F9', 'K', '6-3', '^', 'BB', 'K', 'HR',
+    ]
+
+
+def test_game_state_pitcher_ks_accumulate_by_side_and_time():
+    """home_pitcher_ks/away_pitcher_ks accumulate cumulatively as of target_utc."""
+    plays = [_completed_play(1, 'top', 0, 0, _dt(23, 10))]
+    pitcher_k_events = [
+        (_dt(23, 1), 'home', 'K'), (_dt(23, 2), 'away', 'K'),
+        (_dt(23, 3), 'home', 'L'), (_dt(23, 20), 'home', 'K'),  # after target
+    ]
+    tl = _tl(plays=plays, pitcher_k_events=pitcher_k_events, last_play_utc=_dt(23, 10))
+    state = _game_state_at_time(_base_game(), tl, _dt(23, 10))
+    assert state['home_pitcher_ks'] == ['K', 'L']
+    assert state['away_pitcher_ks'] == ['K']
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The live 2-cell/3-cell header shows the last 7 game events (K, 6-3, F9, HR, ...) via `game_data['half_inning_plays']`, populated by `game_detail_fetch.fetch_scoreboard_live_extras` for live games.
- `timelapse.py` never reconstructed this field for historical frames, so the generated video's 3-cell tile header was blank while the live 2-cell display showed plays correctly.
- Added a timestamped `header_events` stream (finalized play notation, in-play actions, challenge reviews) built alongside the existing hit/runner reconstruction, then filtered to the last 7 events as of each frame's `target_utc` — same trimming logic the live path uses.

## Test plan
- [x] Full test suite passes (1800 passed, 15 skipped)
- [x] Manually verified against real completed game data (gamePk 777505): reconstructed header shows `3▲F9 | 1B | P5 | BB | F9▼HR` matching the live path's format, in the same header spot as the 2-cell display
- [ ] Visual check of a generated timelapse video on actual hardware or a rendered frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMvJe7Wg2TzE3fvW4x5Mkh