### PR TITLE
Fix dead poll throttle, teams.json wipe, idle-screen flashing, missing timeouts

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,7 +61,7 @@ sport_id_priority:
 
 # Night mode: skip refreshes between night_start and night_end (24-hour format)
 night_mode: true
-night_start: 2   # midnight (hour in 24h, local timezone)
+night_start: 2   # 2am (hour in 24h, local timezone)
 night_end: 7     # 7am
 
 # Morning alternating mode: between night_end and morning_end, alternate between yesterday's

--- a/main.py
+++ b/main.py
@@ -357,7 +357,11 @@ def _should_skip_poll(date_str, config, sched):
     last_fetch = sched.get('last_game_fetch')
     if last_fetch:
         try:
-            elapsed = datetime.now() - datetime.fromisoformat(last_fetch)
+            last_dt = datetime.fromisoformat(last_fetch)
+            if last_dt.tzinfo is None:
+                # State written before the UTC-aware format (pre-#202 files)
+                last_dt = last_dt.replace(tzinfo=timezone.utc)
+            elapsed = datetime.now(timezone.utc) - last_dt
             if elapsed < timedelta(minutes=interval_min):
                 mins = int(elapsed.total_seconds() // 60)
                 state_label = (
@@ -467,6 +471,26 @@ def _show_idle_screen(config, sched, auto_open=False):
     image = draw_idle_screen(transactions, team_data, {}, idle_config)
 
     output_path = os.path.join(_REPO_ROOT, 'resulting_image.bmp')
+
+    # Skip the push when the idle screen is pixel-identical to what's already
+    # on disk — off-days hit this path on every cron tick, and an unconditional
+    # force_full would flash the e-ink panel all day. Still let the hourly
+    # full-refresh timer through for the anti-ghosting flash.
+    from refresh_tracker import needs_full_refresh
+    if not needs_full_refresh() and os.path.isfile(output_path):
+        try:
+            from PIL import Image as _PILImage, ImageChops as _ImageChops
+            _prev = _PILImage.open(output_path)
+            _unchanged = (
+                _prev.size == image.size and
+                _ImageChops.difference(_prev.convert('L'), image.convert('L')).getbbox() is None
+            )
+            if _unchanged:
+                print("Idle screen unchanged — skipping display update")
+                return
+        except Exception:
+            pass
+
     image.save(output_path)
     print(f"Idle screen saved → {output_path}")
 
@@ -569,8 +593,8 @@ Examples:
 
     config = load_config(args.config)
 
-    # 3. Night mode gate
-    if config.get('night_mode', False) and not _no_throttle:
+    # 3. Night mode gate (default True to match the dark-mode checks below)
+    if config.get('night_mode', True) and not _no_throttle:
         if _in_night_window(config):
             tz = config.get('timezone', 'America/Chicago')
             now_str = datetime.now(pytz.timezone(tz)).strftime('%H:%M')

--- a/src/display.py
+++ b/src/display.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from PIL import Image
 from display_eink import display_image, display_partial_regions
 from refresh_tracker import needs_full_refresh
-from config_loader import load_config, add_config_arg
+from config_loader import add_config_arg
 
 
 def send_to_display(image_path, changed_regions=None, force_full=False):

--- a/src/display_eink.py
+++ b/src/display_eink.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python3
 # -*- coding:utf-8 -*-
 
-import os
 import platform
-import json
 import logging
 from PIL import Image
 

--- a/src/download_mascots.py
+++ b/src/download_mascots.py
@@ -8,7 +8,6 @@ Teams with no official mascot are skipped silently.
 """
 import argparse
 import os
-import sys
 import urllib.request
 
 from PIL import Image, ImageOps, ImageEnhance

--- a/src/epd_7in5_V2_test.py
+++ b/src/epd_7in5_V2_test.py
@@ -11,7 +11,6 @@ import logging
 from waveshare_epd import epd7in5_V2
 import time
 from PIL import Image,ImageDraw,ImageFont
-import traceback
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/src/fetch_games.py
+++ b/src/fetch_games.py
@@ -15,7 +15,7 @@ import pytz
 # Allow running as a standalone script from any directory
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from util import load_json_file, load_yaml_file, save_off_results
+from util import load_json_file, save_off_results
 from config_loader import load_config, add_config_arg
 
 SPORT_NAMES = {
@@ -32,6 +32,8 @@ _WBC_ABBR_OVERRIDES = {
 
 def convert_time_z_to(utc_time_str, time_zone='America/Chicago'):
     """Convert time z to."""
+    if not utc_time_str:
+        return ''
     utc_time = datetime.strptime(utc_time_str, "%Y-%m-%dT%H:%M:%SZ")
     utc_time = pytz.utc.localize(utc_time)
     local_tz = pytz.timezone(time_zone)
@@ -381,7 +383,7 @@ def fetch_all_team_abbreviations(sport_id=1):
     team_abbreviations = {}
     try:
         print(f"Fetching all teams for sport_id {sport_id}...")
-        response = requests.get(f'https://statsapi.mlb.com/api/v1/teams?sportId={sport_id}')
+        response = requests.get(f'https://statsapi.mlb.com/api/v1/teams?sportId={sport_id}', timeout=10)
         if response.status_code == 200:
             data = response.json()
             teams = data.get('teams', [])
@@ -405,7 +407,7 @@ def fetch_all_team_abbreviations(sport_id=1):
 def get_team_abbreviation(team_id):
     """Fetch a single team abbreviation from MLB API."""
     try:
-        response = requests.get(f'https://statsapi.mlb.com/api/v1/teams/{team_id}')
+        response = requests.get(f'https://statsapi.mlb.com/api/v1/teams/{team_id}', timeout=10)
         if response.status_code == 200:
             data = response.json()
             abbreviation = data.get('teams', [{}])[0].get('abbreviation')
@@ -424,7 +426,7 @@ def check_games_for_sport(date, sport_id):
         f'startDate={date}&endDate={date}&sportId={sport_id}'
     )
     try:
-        response = requests.get(endpoint_url)
+        response = requests.get(endpoint_url, timeout=10)
         if response.status_code == 200:
             data = response.json()
             game_dates = data.get('dates', [])
@@ -469,24 +471,36 @@ def find_next_game_date(sport_id_priority, from_date_str):
     return None
 
 
+def _season_for_games(game_array):
+    """Season year for pitcher stat lookups — from the games' own dates so
+    historical --date replays query the right season, not today's."""
+    for gd in game_array:
+        gdate = gd.get('game_date') or ''
+        if len(gdate) >= 4 and gdate[:4].isdigit():
+            return gdate[:4]
+    from datetime import date as _date
+    return str(_date.today().year)
+
+
 def parse_games(data, sport_id=None, config=None):
     """Parse schedule API response and write data/games.json + data/teams.json."""
     if config is None:
         config = load_config()
     tz = config.get('timezone', 'America/Chicago')
 
+    # On empty days only clear games.json — leave the accumulated teams.json
+    # abbreviation cache intact (the idle screen and later fallback lookups
+    # depend on it).
     game_dates = data.get('dates', [])
     if not game_dates:
         print("No games found for this date")
         save_off_results({'games': []}, 'games')
-        save_off_results({'team_abbreviation': {}}, 'teams')
         return
 
     games = game_dates[0].get('games', [])
     if not games:
         print("No games found for this date")
         save_off_results({'games': []}, 'games')
-        save_off_results({'team_abbreviation': {}}, 'teams')
         return
 
     game_array = []
@@ -718,8 +732,7 @@ def parse_games(data, sport_id=None, config=None):
         if gd.get('_home_probable_id'):
             pitcher_ids.add(gd['_home_probable_id'])
     if pitcher_ids:
-        from datetime import date as _date
-        season = str(_date.today().year)
+        season = _season_for_games(game_array)
         eras = _fetch_pitcher_eras(pitcher_ids, season)
         for gd in game_array:
             away_id = gd.pop('_away_probable_id', None)
@@ -741,8 +754,7 @@ def parse_games(data, sport_id=None, config=None):
         decision_ids.add(gd.get('_saver_id'))
     decision_ids.discard(None)
     if decision_ids:
-        from datetime import date as _date
-        season = str(_date.today().year)
+        season = _season_for_games(game_array)
         decision_stats = _fetch_decision_pitcher_stats(decision_ids, season)
         for gd in game_array:
             winner_id = gd.pop('_winner_id', None)
@@ -907,7 +919,7 @@ def fetch_scoreboard_for_date(date, sport_id=None, config=None):
         f'startDate={date}&endDate={date}&sportId={sport_id}'
         '&hydrate=decisions,probablePitcher(note),linescore,flags,team,broadcasts(all),seriesStatus,gameInfo'
     )
-    response = requests.get(endpoint_url)
+    response = requests.get(endpoint_url, timeout=15)
     data = response.json()
     parse_games(data, sport_id, config)
 

--- a/src/field_view.py
+++ b/src/field_view.py
@@ -2,9 +2,7 @@ import os
 import math
 from PIL import Image, ImageDraw, ImageFont, ImageOps
 
-from generate_image import (
-    picdir, _logo_small, _load_logo_gray, draw_diamond, draw_circle,
-)
+from generate_image import picdir, _logo_small
 from stadium_polygons import get_polygon
 
 EPD_WIDTH = 800

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -1,12 +1,15 @@
 import os
 import json
-import random
 import time as _time_mod
 from datetime import datetime, timezone
 import pytz
 from util import load_json_file, load_yaml_file, save_off_results
 from collections import OrderedDict
 
+# NOTE: several names imported below are unused here but re-exported for
+# backward compatibility — field_view, scorecard_view, pitch_view, and the
+# test suite all import them via this module. Don't "clean up" without
+# checking consumers.
 from image_assets import (
     picdir, _get_font, _logo_small, _load_logo_gray, _logo_ghost, _paste_logo,
     Image, ImageDraw, ImageFont, ImageOps,

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -563,11 +563,8 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
         away_game.get('home_team_id') == today_home_id
     )
 
-    # Use full "H:MMp" time when only one matchup fills the whole strip (room to breathe).
-    # When two different games must share the strip, fall back to abbreviated "Hp".
-    _two_games = (not same_series) and away_game and home_game
-    _use_full_time = not _two_games
-
+    # _fit_time prefers the full "H:MMp" form and falls back to abbreviated "Hp"
+    # when space is tight, so shared-strip layouts degrade automatically.
     strip_right = BAR_X + BAR_W - 1 * s   # rightmost pixel the strip may use
 
     def _fit_time(t_full, t_abbr, cx, right_limit):
@@ -577,7 +574,7 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
                 return t
         return ''
 
-    def _draw_single(g, full=True):
+    def _draw_single(g):
         """Left-to-right: away logo  @  home logo  TIME (immediately after, if it fits)."""
         a_abbr = abbr_map.get(str(g['away_team_id']), '')
         h_abbr = abbr_map.get(str(g['home_team_id']), '')
@@ -594,7 +591,7 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
             draw.text((_tx + 1 * s, _time_y), t_str, font=font14, fill=0)
 
     if same_series:
-        _draw_single(away_game, full=True)
+        _draw_single(away_game)
         return
 
     # New series — only draw the entry for each team that actually has a game.
@@ -602,11 +599,11 @@ def _draw_next_game_preview(draw, Himage, start_x, start_y, tmrw_games, today_ho
     # Two different games share the strip → abbreviated preferred; each half checked independently.
 
     if away_game and not home_game:
-        _draw_single(away_game, full=True)
+        _draw_single(away_game)
         return
 
     if home_game and not away_game:
-        _draw_single(home_game, full=True)
+        _draw_single(home_game)
         return
 
     # Both teams have different games.

--- a/src/image_featured.py
+++ b/src/image_featured.py
@@ -285,7 +285,7 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     def _draw_team_row(abbr, tid, row_y, runs, hits, errs, bold_score=False,
                        batting=False, abs_remaining=None, replay_remaining=None):
         """Draw team row."""
-        nonlocal draw, canvas
+        nonlocal draw
         if use_logos:
             _lg = _logo_small(abbr, tid, size=LOGO_SZ)
             if _lg:

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -5,7 +5,7 @@ from collections import deque
 # import qrcode  # disabled — not supported on this Pi build
 
 from util import load_json_file, load_yaml_file
-from image_assets import _get_font, ImageDraw, Image
+from image_assets import _get_font, ImageDraw
 from image_standings import _WC_STRIP_H
 from image_box import draw_box, draw_wide_box, draw_triple_box
 from image_leaders import draw_leaders_cell, rotating_categories, _CATEGORIES as _LEADER_CATEGORIES

--- a/src/image_leaders.py
+++ b/src/image_leaders.py
@@ -8,7 +8,7 @@ for the duration of that window instead of changing on every render).
 import random as _random
 from datetime import datetime
 
-from image_assets import _get_font, ImageDraw, _logo_small, Image
+from image_assets import _get_font, ImageDraw, _logo_small
 
 _CATEGORIES = [
     'homeRuns', 'battingAverage', 'earnedRunAverage', 'saves', 'hits',

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageDraw
+from PIL import ImageDraw
 
 from image_assets import _get_font, _logo_small
 import time as _time

--- a/src/standings.py
+++ b/src/standings.py
@@ -1,5 +1,4 @@
 import requests
-import json
 import argparse
 from datetime import datetime, timedelta
 
@@ -31,7 +30,7 @@ def get_teams(team_id):
     if tid in team_abbreviation_list:
         return
     try:
-        response = requests.get(f'https://statsapi.mlb.com/api/v1/teams/{team_id}')
+        response = requests.get(f'https://statsapi.mlb.com/api/v1/teams/{team_id}', timeout=10)
         if response.status_code == 200:
             data = response.json()
             fetched_team_id = data.get('teams', [{}])[0].get('id')
@@ -65,7 +64,7 @@ def get_standings(league_id_list, season=2025, date=None, save_as='standings'):
         if date:
             url += f'&date={date}'
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
 
         data = response.json()
 


### PR DESCRIPTION
## Summary
Fixes for issues found in a full-codebase review.

### Bugs fixed
- **Smart-poll throttle was completely dead** (regression from #202): `_should_skip_poll` compared the timezone-aware stored `last_game_fetch` against naive `datetime.now()`; the `TypeError` was swallowed by a bare except, so every cron tick fetched the API regardless of the 2/5/15/60-minute interval logic. Now compares in UTC, with a naive-timestamp fallback for pre-#202 state files. Verified by direct exercise of the throttle path (aware → throttles, stale → fetches).
- **`teams.json` wiped on no-game days**: `parse_games` overwrote the accumulated team-abbreviation cache with `{}` when the schedule was empty, breaking the idle screen and later fallback lookups. Empty days now only clear `games.json`.
- **Idle screen full-flashed the e-ink panel every cron tick** on off days (All-Star break, offseason): `_show_idle_screen` now skips the push when the rendered image is pixel-identical to what's already on disk, while still allowing the hourly anti-ghosting full refresh through.
- **Missing HTTP timeouts** on the main schedule fetch and five other `requests.get` calls (fetch_games, standings) — a hung connection could block the cron pipeline indefinitely.

### Smaller fixes
- Pitcher ERA/decision lookups derive the season from the games' own dates, so `--date` historical replays query the correct season.
- `convert_time_z_to` returns `''` instead of crashing if the API ever omits `gameDate`.
- Night-mode gate default aligned to `True` to match the dark-mode checks.
- Dead code removed: `_use_full_time` / unused `full=` param in `image_box`, unused `nonlocal`, unused imports in leaf modules; `generate_image`'s intentional re-export surface is now documented so it doesn't get "cleaned up" by mistake.
- `config.yaml`: `night_start: 2` comment said "midnight", now says "2am".

## Test plan
- Full suite: 1829 passed, 15 skipped.
- Throttle path exercised directly with aware, legacy-naive, and stale timestamps.
- pyflakes clean except the documented re-export imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMvJe7Wg2TzE3fvW4x5Mkh