### PR TITLE
Enable hide_non_live_games and fix fullscreen dark-mode polarity

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -155,7 +155,7 @@ triple_cell_live: false
 # favorite_team_first) is never hidden, regardless of its state.
 # Can also be set via the HIDE_NON_LIVE_GAMES environment variable
 # (true/1/yes), which overrides this value.
-hide_non_live_games: false
+hide_non_live_games: true
 
 # Season leaders panel: show HR / AVG / ERA leaders in an empty grid cell when
 # fewer than 15 games are on the slate. Rotates categories every 5 minutes.

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -319,7 +319,15 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
             Himage = Image.new('1', (800, 480), 255)
             Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob)
 
-        Himage = ImageOps.invert(Himage.convert('L')).convert('1')
+        # Only invert to white-on-black during the configured dark window — matching
+        # the normal grid view — so a real light<->dark polarity flip occurs and the
+        # existing day/night transition logic in main.py can force a true full
+        # e-ink refresh at the boundary. Previously this always inverted regardless
+        # of dark_mode, so the display never actually changed polarity and the
+        # black background only ever got small partial refreshes, which accumulate
+        # visible ghosting on e-ink far more than the same content in light mode.
+        if config.get('dark_mode', False):
+            Himage = ImageOps.invert(Himage.convert('L')).convert('1')
 
         # Partial refresh for live fullscreen: map changed fields to display zones and
         # refresh only the affected zones.  Three zones:


### PR DESCRIPTION
## Summary
- Turn on `hide_non_live_games` in config.yaml so Final/not-yet-started games drop off the grid whenever another game is still live, freeing slots for live games to expand into wide (2-cell) / triple (3-cell) tiles.
- Fix the featured-team fullscreen ("one game") display: it was hardcoded to always invert to white-on-black regardless of `config['dark_mode']`, so it never actually changed polarity and the day/night transition logic in `main.py` never detected a flip to force a true full e-ink refresh. It now only inverts during the real dark window, matching the grid view, so genuine transitions get a proper full refresh instead of accumulating partial-refresh ghosting on the black background.

## Test plan
- [x] `pytest tests/` — 1806 passed, 38 skipped
- [ ] Visually confirm the fullscreen display now stays light during the day and only goes black in the configured dark window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqjFP1CZ4VoEnpY3CngVGn