### PR TITLE
Move triple-cell venue label into footer gap

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -3180,18 +3180,19 @@ def draw_triple_box(Himage, start_x, start_y, game_data, team_data,
     draw = ImageDraw.Draw(Himage)
     _draw_field_cell(draw, Himage, fp_x, start_y, 150, 150, game_data, scale=scale, vis_h=150)
 
-    # Venue name: right-aligned in the bottom-right corner of cell 3.
+    # Venue name: right-aligned at the very bottom of cell 3.
     # Drawn after the field diagram so it sits on top of any clipped elements.
     _venue_name = game_data.get('venue', '') or ''
     if _venue_name:
         _vfont = _get_font(9)
-        _max_vw = int(FIELD_W * s) - 4
+        _max_vw = int(FIELD_W) - 4
         _vname = _venue_name
         while _vname and int(_vfont.getlength(_vname)) > _max_vw:
             _vname = _vname[:-1]
         _vw = int(_vfont.getlength(_vname))
-        _vx = int(fp_x + FIELD_W * s) - _vw - 2
-        _vy = int(start_y + TOTAL_H * s) - 11
+        _vx = int(fp_x + FIELD_W) - _vw - 1
+        _vfont_h = _vfont.getbbox('Ay')[3]
+        _vy = start_y + int(TOTAL_H) + 14
         draw.text((_vx, _vy), _vname, font=_vfont, fill=0)
 
     # Invert spanning header when a run scored or score changed


### PR DESCRIPTION
## Summary
- Venue name in triple-cell tile was positioned 11 px from the 130 px cell border, floating mid-field diagram
- Now anchored `TOTAL_H + 14` px from cell top, placing it in the 20 px inter-row footer gap below the field drawing
- Right-aligned to the cell's right edge with 1 px margin
- Removes spurious double-scale (`FIELD_W * s`, `TOTAL_H * s`) — those constants already incorporate scale

## Test plan
- [ ] Golden scoreboard tests pass (triple-cell is not exercised by the existing goldens)
- [ ] All tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqjFP1CZ4VoEnpY3CngVGn