### PR TITLE
Fix stale leaders cache during no-games gaps and venue-specific infield polygon in field view

### DIFF
--- a/main.py
+++ b/main.py
@@ -787,6 +787,17 @@ Examples:
             game_state_data = load_json_file('games.json').get('games', [])
             no_games = _update_schedule_state(game_state_data, date_str, config, sched)
             if no_games:
+                # Leaders only otherwise refresh once games go Final, so a
+                # multi-day gap (All-Star break, rainouts) leaves the cache
+                # frozen.  Run the staleness check here too.
+                if config.get('show_leaders_panel', False) and league_mode != 'aaa' \
+                        and _should_refresh_leaders(sched, force=args.full_refresh):
+                    print("Refreshing leaders during no-games gap (stale cache)...")
+                    try:
+                        _leaders_sport = sport_id if sport_id else (config.get('sport_id_priority', [1])[0])
+                        fetch_leaders(sport_id=_leaders_sport)
+                    except Exception as _e:
+                        print(f"Warning: leaders fetch failed: {_e}")
                 if not _maybe_show_derby_bracket(config, no_throttle=_no_throttle,
                                                  auto_open=args.local and system_platform == 'Darwin'):
                     _show_idle_screen(config, sched,

--- a/src/field_view.py
+++ b/src/field_view.py
@@ -3,7 +3,7 @@ import math
 from PIL import Image, ImageDraw, ImageFont, ImageOps
 
 from generate_image import picdir, _logo_small
-from stadium_polygons import get_polygon
+from stadium_polygons import get_polygon, get_infield_polygon
 
 EPD_WIDTH = 800
 EPD_HEIGHT = 480
@@ -85,12 +85,17 @@ def _draw_field(draw, data, fonts=None):
     draw.line([HOME_PLATE, lf_pole], fill=0, width=1)
     draw.line([HOME_PLATE, rf_pole], fill=0, width=1)
 
-    # Infield arc: edge of infield grass, arcing from 3B side to 1B side through CF
-    # PIL arc angles: 0=east, 90=south, 180=west, 270=north (up on screen = toward CF)
-    # Second base is ~95 px from home plate (127.3 ft × 0.75), so radius > 95 clears it.
-    r_arc = 110  # ~15 px past second base (95 px from home)
-    bb_arc = [hx - r_arc, hy - r_arc, hx + r_arc, hy + r_arc]
-    draw.arc(bb_arc, start=225, end=315, fill=0, width=1)
+    # Infield dirt boundary — venue-specific polygon when available, generic arc fallback.
+    infield_poly = get_infield_polygon(venue, venue_id)
+    if infield_poly:
+        for i in range(len(infield_poly) - 1):
+            x0, y0 = infield_poly[i]
+            x1, y1 = infield_poly[i + 1]
+            draw.line([_poly_pt(x0, y0), _poly_pt(x1, y1)], fill=0, width=1)
+    else:
+        r_arc = 110
+        bb_arc = [hx - r_arc, hy - r_arc, hx + r_arc, hy + r_arc]
+        draw.arc(bb_arc, start=225, end=315, fill=0, width=1)
 
     # Base paths (infield diamond) — slightly bolder
     draw.line([HOME_PLATE, FIRST_BASE],  fill=0, width=2)


### PR DESCRIPTION
## Summary

- **`main.py`** — Leaders panel cache was never refreshed during multi-day no-games gaps (All-Star break, rainouts, off-days). The staleness check only ran when games went Final, so the panel showed frozen data for the entire gap. The fix runs `_should_refresh_leaders` in the `no_games` early-return path and triggers a fetch when the cache is stale.

- **`src/field_view.py`** — The `--mode field` full-screen view drew a hardcoded `r=110` infield arc regardless of which MLB park was being played at, making every field diagram look identical. The fix replaces the arc with the venue-specific infield dirt boundary polygon from `mlbam_infield.json` (via `get_infield_polygon`), so each park renders its distinct infield shape. Falls back to the generic arc for the two parks without polygon data.

## Test plan

- [ ] Run `poetry run pytest -q` — 1884 passed, 38 skipped
- [ ] Spot-check `--mode field` on Pi for a few different venues (e.g. Fenway vs Dodger Stadium vs Wrigley) and verify distinct infield shapes
- [ ] Confirm leaders panel data updates correctly after a full off-day cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBcWWJTKkQ5iPNmSVe5TwC