### PR TITLE
Always attempt e-ink display in triple-cell example

### DIFF
--- a/src/example_triple_cell_view.py
+++ b/src/example_triple_cell_view.py
@@ -130,9 +130,6 @@ def main():
     parser.add_argument('--output', default=_DEFAULT_OUTPUT)
     parser.add_argument('--dark', action='store_true')
     parser.add_argument('--open', action='store_true')
-    parser.add_argument('--display', action='store_true',
-                        help='Push the rendered image to the physical e-ink display '
-                             '(no-op outside Linux / without the waveshare driver)')
     args = parser.parse_args()
 
     # Fixed config, independent of config/config.yaml on disk — draw_out_of_town_score_board
@@ -169,12 +166,7 @@ def main():
     image, _regions = result
 
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
-
-    if args.display:
-        display_image(image, output_filename=args.output)
-    else:
-        image.save(args.output)
-        print(f"Image saved to {args.output}")
+    display_image(image, output_filename=args.output)
 
     if args.open:
         image.show()


### PR DESCRIPTION
## Summary
- Removes the `--display` flag from `src/example_triple_cell_view.py` — it now always calls `display_image`, which already saves the file and safely no-ops the hardware push on macOS or when the waveshare driver isn't available. So it just displays automatically whenever it can, no flag needed.

## Test plan
- [x] `poetry run python src/example_triple_cell_view.py --output /tmp/auto_test.bmp` — saves image, prints "skipping e-ink display update (hardware not available)" on macOS
- [ ] Run on the Raspberry Pi to confirm it lights up the panel without any flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)