### PR TITLE
Add overflow ticker to header strip; show games back in magic-number panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ Both outer edges of the scoreboard display division standings. AL divisions run 
 
 ### Top Header Strip
 
-The strip across the top of the scoreboard shows one of two things:
+The strip across the top of the scoreboard shows one of three things, in priority order:
 
-- **Wildcard standings** (`show_wildcard_standings`) — AL top-10 left-to-right on the left half, NL right-to-left on the right half; rank 1 at the outer edge, converging toward center, with abbreviation and games back per slot.
-- **Postseason bracket** (`show_playoff_bracket`) — during the postseason window (mid-September to mid-November), once real bracket data exists, the strip auto-switches to a series-win bracket fetched from the MLB schedule API. It falls back to wildcard standings the rest of the year.
+- **Overflow ticker** — whenever a live game's wide/triple tile (or a >15-game slate) bumps other games off the 5×3 grid, the bumped games are shown as a compact "Away v Home &lt;status&gt;" strip instead of just disappearing: start time if the game hasn't started, inning (e.g. `Top 4`) if live, `Final`, or `Postponed`. Games still worth watching are kept on the grid — already-finished games are bumped first. Rotates through a batch of them every `overflow_ticker_rotation_minutes` (default 2) if more are bumped than fit at once. Takes over the strip outright whenever any games are bumped.
+- **Postseason bracket** (`show_playoff_bracket`) — during the postseason window (mid-September to mid-November), once real bracket data exists, the strip switches to a series-win bracket fetched from the MLB schedule API.
+- **Wildcard standings** (`show_wildcard_standings`) — the fallback the rest of the year: AL top-10 left-to-right on the left half, NL right-to-left on the right half; rank 1 at the outer edge, converging toward center, with abbreviation and games back per slot.
 
 ---
 
@@ -85,7 +86,12 @@ The strip across the top of the scoreboard shows one of two things:
 
 When the slate has fewer than 15 games, the spare grid cells are filled with informational panels instead of being left blank. In priority order:
 
-- **Transactions ticker** (`show_transactions_ticker`) — recent MLB transactions (IL moves, call-ups/demotions, signings), claims the first free slot.
+- **Trade deadline countdown** (`show_deadline_panel`) — countdown to `trade_deadline` plus recent transactions; only appears in the two weeks before the deadline.
+- **Transactions ticker** (`show_transactions_ticker`) — recent MLB transactions (IL moves, call-ups/demotions, signings).
+- **Batting lineup panel** (`show_lineup_panel`) — both teams' batting orders, shown within 45 minutes of the primary team's first pitch.
+- **News headlines** (`show_news_panel`) — recent MLB news, optionally scoped to the primary team (`news_team_only`).
+- **Magic / elimination numbers** (`show_magic_numbers`) — the primary team's division standings. The leader's row always shows its magic number (`M12`); trailing teams show games back until their elimination number drops below 20, at which point that row switches to the elimination number (`E7`) instead. A miniature version of the same M12/E7 badge (`sidebar_magic_badges`) can also be shown next to each team's logo in the standings sidebar.
+- **Hot Hitters / Hot Arms** (`show_streaks_panel` / `show_scoreless_panel`) — 14-day rolling batting average and ERA leaders.
 - **Season leaders panel** (`show_leaders_panel`) — cycles through HR / AVG / ERA / Saves / Hits / RBI / SB, rotating category every `leaders_rotation_minutes` (default 5) and refreshed once a day.
 - **Config QR code** (`show_config_qr`) — a QR code linking straight to the [config web server](#config-web-server).
 
@@ -170,6 +176,7 @@ Shows R/H/E, **winning/losing pitcher** with record, and save. The winning team'
 
 | Feature | Detail |
 |---|---|
+| **Overflow ticker** | Header strip shows games bumped off the grid — already-finished games are bumped first |
 | **Wildcard strip** | Top row of team logos, AL left → NL right, ordered by games back |
 | **Playoff bracket** | Header strip auto-switches to a series-win bracket during the postseason |
 | **Standings sidebar** | AL East/Central/West on left edge, NL on right — 1st through 5th |
@@ -182,6 +189,7 @@ Shows R/H/E, **winning/losing pitcher** with record, and save. The winning team'
 | **Live details** | Pitcher, current batter, fastball %, pitch count, last pitch speed |
 | **Leaders panel** | HR / AVG / ERA / Saves / Hits / RBI / SB leaders in a spare cell, rotating |
 | **Transactions ticker** | Recent IL moves, call-ups, and signings in a spare cell |
+| **Magic / elimination numbers** | Leader shows magic number; trailing teams show games back, switching to elimination number under 20 |
 | **Idle screen** | "Recent Moves" + bouncing mascot when there are no games today |
 | **Derby bracket** | Auto Home Run Derby single-elimination bracket on Derby day |
 | **Team logos** | Auto-fetched from ESPN CDN; per-team invert/darken config |

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -107,6 +107,14 @@ show_wildcard_standings: true
 # the bracket entirely (always shows wildcard standings instead, if enabled).
 show_playoff_bracket: true
 
+# Overflow ticker: when a live game's triple/wide tile crowds another game off
+# the 5x3 grid (or there are simply >15 games), the bumped games are shown as
+# a compact "Away v Home <status>" strip in the top header instead of just
+# vanishing — taking over the header strip ahead of the playoff bracket and
+# wildcard standings above whenever any games are bumped. Rotates through a
+# batch of them every N minutes if more are bumped than fit on screen at once.
+overflow_ticker_rotation_minutes: 2
+
 # Small logo X offset: pixels from the left edge of each score box where the small logo is placed.
 # Set to 2 to align with the box edge. Increase to shift the logo right.
 small_logo_x_offset: 2
@@ -195,9 +203,12 @@ trade_deadline: "2026-08-03 18:00"
 show_news_panel: false
 news_team_only: true
 
-# Magic / elimination numbers: show the primary team's division standings with
-# each team's magic number (leader) or elimination number (trailer) in an empty
-# grid cell. Reuses the standings already cached in data/standings.json — no
+# Magic / elimination numbers: show the primary team's division standings in an
+# empty grid cell — the leader's row always shows its magic number; trailing
+# teams show games back until their elimination number drops below 20, at
+# which point that row switches to the elimination number instead (games back
+# isn't very interesting once a team is genuinely on the verge of being
+# eliminated). Reuses the standings already cached in data/standings.json — no
 # extra API call. Only meaningful during the regular season.
 show_magic_numbers: false
 

--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -24,6 +24,7 @@ from image_standings import (
     _WC_STRIP_H,
     derive_wildcard_from_standings, draw_wildcard_header, draw_standings_sidebar,
     draw_standings_sidebar_fullscreen, draw_playoff_bracket_header,
+    draw_overflow_ticker, _ticker_window,
 )
 from image_box import draw_box, _abbr_play, _draw_linescore_grid, _draw_backwards_k
 
@@ -31,6 +32,7 @@ from image_box import draw_box, _abbr_play, _draw_linescore_grid, _draw_backward
 from image_grid import (
     draw_out_of_town_score_board,
     compute_grid_layout,
+    _overflow_priority,
 )
 
 # Re-export featured/fullscreen functions for backward compatibility
@@ -400,6 +402,15 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
     _ordered, _slots = compute_grid_layout(game_state_data, team_data, config)
     Himage = draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str, changed_game_ids=changed_game_ids, use_logos=use_logos, logo_x_offset=logo_x_offset, show_win_prob=show_win_prob, layout=(_ordered, _slots))
 
+    # Games compute_grid_layout couldn't place on the grid (bumped by live-game
+    # tile expansion, hide_non_live_games, or >15-game overflow) — surfaced in
+    # the header strip via the overflow ticker below instead of just vanishing.
+    _placed_pks = {g.get('game_pk') for g in _ordered[:len(_slots)]}
+    _dropped_games = sorted(
+        (g for g in game_state_data if g.get('game_pk') not in _placed_pks),
+        key=_overflow_priority,
+    )
+
     standings_data = None
     if config.get('show_wildcard_standings', False) or config.get('show_standings_sidebar', False):
         standings_data = load_json_file('standings.json')
@@ -415,7 +426,15 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         if _candidate and _candidate.get('series') and _candidate.get('season') == datetime.now().year:
             _bracket = _candidate
 
-    if _bracket:
+    # The overflow ticker wins the header strip outright over both the
+    # playoff bracket and wildcard standings whenever games got dropped —
+    # a game missing from the grid is more time-sensitive than either.
+    if _dropped_games:
+        Himage = draw_overflow_ticker(
+            Himage, _dropped_games, team_data,
+            rotation_minutes=config.get('overflow_ticker_rotation_minutes', 2),
+        )
+    elif _bracket:
         Himage = draw_playoff_bracket_header(Himage, _bracket)
     elif config.get('show_wildcard_standings', False) and league_mode != 'aaa':
         if standings_data and 'standings' in standings_data:
@@ -483,5 +502,27 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         layout_changed = new_positions != old_positions
         save_off_results(new_positions, 'old_grid_positions')
         save_off_results({'needed': layout_changed}, 'force_full_refresh')
+
+        # The header strip (overflow ticker / bracket / wildcard standings)
+        # isn't covered by the grid-cell diffing above — a pure ticker
+        # rotation change, for instance, wouldn't otherwise be included in
+        # changed_regions and so wouldn't reach the e-ink panel on a partial
+        # refresh. Fingerprint whatever's currently showing there and add the
+        # strip to changed_regions when it differs from the last poll.
+        if _dropped_games:
+            _header_key = [str(g.get('game_pk', '')) for g in _ticker_window(
+                _dropped_games, rotation_minutes=config.get('overflow_ticker_rotation_minutes', 2))]
+            _header_state = {'mode': 'ticker', 'key': _header_key}
+        elif _bracket:
+            _header_state = {'mode': 'bracket', 'key': []}
+        elif config.get('show_wildcard_standings', False) and league_mode != 'aaa':
+            _header_state = {'mode': 'wildcard', 'key': []}
+        else:
+            _header_state = {'mode': 'none', 'key': []}
+
+        old_header_state = load_json_file('old_header_state.json') or {}
+        if _header_state != old_header_state and changed_regions != [(0, 0, 800, 480)]:
+            changed_regions.append((0, 0, 800, _WC_STRIP_H))
+        save_off_results(_header_state, 'old_header_state')
 
     return (Himage, changed_regions)

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -587,6 +587,37 @@ def _move_non_live_to_fillers(game_list, positions):
     return game_list
 
 
+def _prioritize_live_over_final(full_game_list, placed_list, positions):
+    """If tile-packing dropped a live/scheduled/postponed game while a Final
+    game still occupies a normal (single-cell) slot, swap them in place — a
+    game that's still worth watching should never lose its slot to one that's
+    already over, and this is a game the overflow header ticker can pick up.
+
+    Only swaps within 'normal' slots, so slot geometry never changes and no
+    repacking is needed. positions is parallel to placed_list.
+    """
+    placed_pks = {g.get('game_pk') for g in placed_list}
+    dropped_worth_showing = [
+        g for g in full_game_list
+        if g.get('game_pk') not in placed_pks and _overflow_priority(g) < 2
+    ]
+    if not dropped_worth_showing:
+        return placed_list
+
+    # Index 0 is protected — same as _move_non_live_to_fillers — since it may
+    # hold the favorite team's game when favorite_team_first is enabled, and
+    # that should never be displaced regardless of its state.
+    final_normal_idxs = [
+        i for i, (g, pos) in enumerate(zip(placed_list, positions))
+        if i != 0 and pos[0] == 'normal' and _overflow_priority(g) == 2
+    ]
+    for dg in dropped_worth_showing:
+        if not final_normal_idxs:
+            break
+        placed_list[final_normal_idxs.pop(0)] = dg
+    return placed_list
+
+
 def compute_grid_layout(game_state_data, team_data, config):
     """Return (ordered_game_list, slots) for the 5×3 scoreboard grid.
 
@@ -661,10 +692,12 @@ def compute_grid_layout(game_state_data, team_data, config):
     # non-live games into filler single-cell slots within expanded rows so a
     # live game never sits in a filler slot when a finished or not-yet-started
     # game can take it instead.
+    _pre_pack_list = list(game_list)
     _tile_map = _find_tile_types(game_list, config, team_data)
     if _tile_map:
         game_list, _slots = _pack_grid(game_list, _tile_map)
         game_list = _move_non_live_to_fillers(game_list, _slots)
+        game_list = _prioritize_live_over_final(_pre_pack_list, game_list, _slots)
     else:
         # No expansion — try clustering live games into the bottom row instead.
         # When 1-5 live games exist and everyone fits on the grid, group all of
@@ -772,15 +805,6 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
         game_list, _slots = layout
     else:
         game_list, _slots = compute_grid_layout(game_state_data, team_data, config)
-
-    # Finished games dropped from the grid (e.g. by hide_non_live_games) are
-    # shown in spare cells ahead of the leaders panel so scores aren't lost.
-    _placed_pks = {g.get('game_pk') for g in game_list[:len(_slots)]}
-    _dropped_finals = [
-        g for g in game_state_data
-        if g.get('game_pk') not in _placed_pks
-        and g.get('detailed_state') in _FINAL_STATES
-    ]
 
     # Build per-team stats lookup {str(team_id): {'streak', 'l10_wins', 'l10_losses', 'wins', 'losses'}}
     _standings = load_json_file('standings.json')
@@ -905,19 +929,6 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
         _sc_lx = _sc_col * 150 + x_start
         _sc_ly = _sc_row * 150 + y_start
         Himage = draw_scoreless_cell(Himage, _sc_lx, _sc_ly, _sc_data, team_data, use_logos=use_logos)
-
-    # Dropped Final games — show scores for games hidden by hide_non_live_games.
-    for _fg in _dropped_finals:
-        if not _free_slots:
-            break
-        _fg_col, _fg_row = _free_slots.pop(0)
-        _fg_lx = _fg_col * 150 + x_start
-        _fg_ly = _fg_row * 150 + y_start
-        Himage = draw_box(
-            Himage, _fg_lx, _fg_ly, _fg, team_data,
-            use_logos=use_logos, logo_x_offset=logo_x_offset,
-            streak_map=streak_map,
-        )
 
     if config.get('show_leaders_panel', False) and _free_slots:
         _leaders_data = load_json_file('leaders.json').get('leaders', {})

--- a/src/image_magic.py
+++ b/src/image_magic.py
@@ -6,8 +6,10 @@ call. For each team in the division:
 
   * Division leader → magic number ``M`` (games to clinch over the closest
     rival, i.e. the rival with the fewest losses).
-  * Trailing team  → elimination number ``E`` (games until it can no longer
-    catch the leader).
+  * Trailing team  → games back from the leader, until its elimination
+    number drops below ``_ELIM_THRESHOLD`` (elimination numbers are too
+    large to be meaningful for most of the season); once the race is
+    actually close, the elimination number ``E`` takes over that same slot.
 
 When the MLB Stats API's ``clinch_indicator`` already settles it, that wins
 over the arithmetic: ``z``/``y`` → ``CL`` (clinched), ``e`` → ``OUT``.
@@ -26,6 +28,11 @@ _PAD = 2
 # A full MLB season is 162 games; a team clinches over a rival the moment the
 # rival can no longer tie it, i.e. when (162 + 1) - wins - rival_losses hits 0.
 _MAGIC_BASE = 163
+
+# Below this, a trailing team's elimination number is dramatic enough to show
+# instead of games back — early/mid-season elimination numbers (60+) aren't
+# meaningful, so games back is the more useful stat until the race tightens.
+_ELIM_THRESHOLD = 20
 
 # Collapse a division's full name into a compact header, e.g.
 # "American League East" → "AL EAST".
@@ -62,8 +69,10 @@ def _find_primary_division(standings, abbr_map, primary_abbr):
 
 
 def _magic_or_elim(team, leader, is_leader, rival_losses):
-    """Value string for one team's row: 'M4', 'E7', 'CL', 'OUT', or '' when
-    the underlying win/loss data isn't available yet."""
+    """Value string for one team's row: 'M4' (leader), 'E7' (trailing team
+    within _ELIM_THRESHOLD of elimination), games back (trailing team
+    otherwise), 'CL', 'OUT', or '' when the underlying win/loss data isn't
+    available yet."""
     clinch = (team.get('clinch_indicator') or '').strip().lower()
     if clinch in ('z', 'y'):
         return 'CL'
@@ -84,7 +93,11 @@ def _magic_or_elim(team, leader, is_leader, rival_losses):
     if team_l is None:
         return ''
     elim = _MAGIC_BASE - lead_w - team_l
-    return 'OUT' if elim <= 0 else f'E{elim}'
+    if elim <= 0:
+        return 'OUT'
+    if elim < _ELIM_THRESHOLD:
+        return f'E{elim}'
+    return str(team.get('games_back') or '-')
 
 
 def draw_magic_cell(Himage, sx, sy, standings_data, team_data, primary_abbr, use_logos=False):

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -1,3 +1,4 @@
+import re
 from PIL import ImageDraw
 
 from image_assets import _get_font, _logo_small
@@ -236,6 +237,178 @@ def draw_playoff_bracket_header(Himage, bracket_data):
     return Himage
 
 
+# Local state-set duplication of image_grid.py's equivalents — image_grid
+# already imports from this module, so importing back would be circular.
+_TICKER_FINAL_STATES = {'Final', 'Game Over', 'Final: Tied'}
+_TICKER_POSTPONED_STATES = {'Postponed', 'Cancelled', 'Cancelled: Rain'}
+_TICKER_LIVE_STATES = {'In Progress', 'Player challenge', 'Manager challenge'}
+
+_TICKER_MAX_ENTRIES = 5   # entries shown per render before rotation kicks in
+_TICKER_SCORE_FONT_SIZE = 16   # bigger than the surrounding 9pt status text
+# Font.ttc's glyphs have enough negative left-bearing at these odd pixel sizes
+# that the dash visually overlaps whatever getlength() alone measured as
+# "before" it — a small fixed gap on each side compensates (same technique as
+# draw_playoff_bracket_header's leader-digit spacing).
+_TICKER_SCORE_GAP = 2
+
+
+def _ticker_status(game):
+    """Short status label for one overflow-ticker entry, based on game state:
+    start time (not started), 'Top 4'/'Bot 7' (live), 'Final', or 'Postponed'."""
+    state = game.get('detailed_state', '')
+    if state in _TICKER_FINAL_STATES:
+        return 'Final'
+    if state in _TICKER_POSTPONED_STATES:
+        return 'Postponed'
+    if state in _TICKER_LIVE_STATES:
+        _inn_state = game.get('inningState') or ''
+        _inn_label = {'Top': 'Top', 'Bottom': 'Bot', 'Middle': 'Mid', 'End': 'End'}.get(
+            _inn_state, _inn_state[:3].capitalize() if _inn_state else '')
+        _inn_ord_raw = game.get('currentInningOrdinal') or str(game.get('current_inning') or 1)
+        _inn_ord = re.sub(r'(?:st|nd|rd|th)$', '', _inn_ord_raw, flags=re.IGNORECASE)
+        return f'{_inn_label} {_inn_ord}'.strip()
+    # Scheduled / Pre-Game / Warmup / Delayed Start / anything else not-yet-started —
+    # fetch_games.py pre-formats game_start as local time (e.g. "7:05 PM").
+    return game.get('game_start') or state
+
+
+def _ticker_score(game):
+    """'5-3' scoreline for a Final or live game with runs recorded, '' for a
+    Scheduled/Postponed game (nothing to score yet)."""
+    state = game.get('detailed_state', '')
+    if state not in _TICKER_FINAL_STATES and state not in _TICKER_LIVE_STATES:
+        return ''
+    away = game.get('away_runs')
+    home = game.get('home_runs')
+    if away is None or home is None:
+        return ''
+    return f'{away}-{home}'
+
+
+def _ticker_window(dropped_games, max_entries=_TICKER_MAX_ENTRIES, rotation_minutes=2):
+    """Return up to ``max_entries`` games to show this render.
+
+    When there are more dropped games than fit at once, cycles through
+    consecutive windows over time (stable within a rotation_minutes block,
+    same time-block-seeded approach as image_leaders.py's rotating_categories)
+    so every dropped game eventually gets shown instead of a fixed subset
+    winning forever.
+    """
+    if len(dropped_games) <= max_entries:
+        return dropped_games
+    rotation_minutes = max(rotation_minutes, 1)
+    n_chunks = -(-len(dropped_games) // max_entries)  # ceil division
+    block_idx = int(_time.time() // (rotation_minutes * 60))
+    i = (block_idx % n_chunks) * max_entries
+    return dropped_games[i:i + max_entries]
+
+
+def draw_overflow_ticker(Himage, dropped_games, team_data, rotation_minutes=2):
+    """Draw games that couldn't fit on the grid as a compact 'Away v Home
+    <score> <status>' ticker across the top header strip (y=0..30). The score
+    is included for Final and live games (e.g. '5-3 Final', '5-3 Bot 7');
+    Scheduled/Postponed games have no score yet, so it's omitted for those.
+
+    ``dropped_games`` are games compute_grid_layout couldn't place — bumped by
+    live-game tile expansion, hide_non_live_games, or plain >15-game overflow.
+    compute_grid_layout's _prioritize_live_over_final biases what gets dropped
+    toward already-finished games, so in practice this is mostly Finals, but
+    formats every state (see _ticker_status) since a live/scheduled/postponed
+    game can still end up here (e.g. hide_non_live_games, doubleheader
+    postponed eviction). Takes over the header strip outright — callers should
+    only invoke this instead of draw_wildcard_header/draw_playoff_bracket_header,
+    not alongside them. Rotates through a subset each render via _ticker_window
+    when more games are dropped than fit on screen at once.
+    """
+    if not dropped_games:
+        return Himage
+
+    chunk = _ticker_window(dropped_games, rotation_minutes=rotation_minutes)
+
+    draw = ImageDraw.Draw(Himage)
+    font = _get_font(9)
+    score_font = _get_font(_TICKER_SCORE_FONT_SIZE)
+    abbr_map = team_data.get('team_abbreviation', {})
+    text_y = (_WC_STRIP_H - 9) // 2
+    score_y = (_WC_STRIP_H - _TICKER_SCORE_FONT_SIZE) // 2
+
+    n = len(chunk)
+    entry_w = 800 // n
+
+    for i, game in enumerate(chunk):
+        x0 = i * entry_w
+
+        away_id = str(game.get('away_team_id', ''))
+        home_id = str(game.get('home_team_id', ''))
+        away_abbr = abbr_map.get(away_id, '???')
+        home_abbr = abbr_map.get(home_id, '???')
+        score = _ticker_score(game)
+        status = _ticker_status(game)
+
+        away_logo = _logo_small(away_abbr, away_id, size=_WC_LOGO_SZ)
+        home_logo = _logo_small(home_abbr, home_id, size=_WC_LOGO_SZ)
+
+        away_w = away_logo.size[0] if away_logo else int(font.getlength(away_abbr))
+        home_w = home_logo.size[0] if home_logo else int(font.getlength(home_abbr))
+        sep = ' v '
+        sep_w = int(font.getlength(sep))
+        status_w = int(font.getlength(status)) if status else 0
+
+        # Score digits/dash measured individually (at the bigger font) so the
+        # gap around the dash can be added explicitly rather than trusting
+        # getlength() on the combined string, which is what causes the
+        # overlap in the first place.
+        if score:
+            away_r, home_r = score.split('-')
+            away_r_w = int(score_font.getlength(away_r))
+            dash_w = int(score_font.getlength('-'))
+            home_r_w = int(score_font.getlength(home_r))
+            score_w = away_r_w + _TICKER_SCORE_GAP + dash_w + _TICKER_SCORE_GAP + home_r_w
+        else:
+            score_w = 0
+
+        total_w = away_w + sep_w + home_w
+        if score:
+            total_w += 4 + score_w
+        if status:
+            total_w += 4 + status_w
+
+        cur_x = x0 + max(0, (entry_w - total_w) // 2)
+
+        if away_logo:
+            Himage.paste(away_logo, (cur_x, (_WC_STRIP_H - away_logo.size[1]) // 2))
+        else:
+            draw.text((cur_x, text_y), away_abbr, font=font, fill=0)
+        cur_x += away_w
+
+        draw.text((cur_x, text_y), sep, font=font, fill=0)
+        cur_x += sep_w
+
+        if home_logo:
+            Himage.paste(home_logo, (cur_x, (_WC_STRIP_H - home_logo.size[1]) // 2))
+        else:
+            draw.text((cur_x, text_y), home_abbr, font=font, fill=0)
+        cur_x += home_w
+
+        if score:
+            cur_x += 4
+            draw.text((cur_x, score_y), away_r, font=score_font, fill=0)
+            cur_x += away_r_w + _TICKER_SCORE_GAP
+            draw.text((cur_x, score_y), '-', font=score_font, fill=0)
+            cur_x += dash_w + _TICKER_SCORE_GAP
+            draw.text((cur_x, score_y), home_r, font=score_font, fill=0)
+            cur_x += home_r_w
+
+        if status:
+            cur_x += 4
+            draw.text((cur_x, text_y), status, font=font, fill=0)
+
+    draw.line((0, 0, 799, 0), fill=0, width=1)
+    draw.line((0, _WC_STRIP_H - 1, 799, _WC_STRIP_H - 1), fill=0, width=1)
+
+    return Himage
+
+
 def _aaa_divisions(standings_data, side):
     """Return division names for each sidebar side in AAA mode.
 
@@ -250,12 +423,16 @@ def _aaa_divisions(standings_data, side):
     return [d for d in candidates if d in all_divs]
 
 
-_ME_BADGE_THRESHOLD = 50   # only show M/E badge when ≤ this many games remain
+_ME_BADGE_THRESHOLD = 50   # below this, the elimination number is dramatic
+                           # enough to badge instead of games back
 _ME_MAGIC_BASE = 163       # 162 games + 1
 
 
 def _me_badge_value(team, leader, is_leader, rival_losses):
-    """Return badge text ('M5', 'E12', 'CL', 'OUT', or '') for a standings row."""
+    """Return badge text for a standings row: 'M5'/'CL' for the leader
+    (always shown), or games back for a trailing team until its elimination
+    number drops below _ME_BADGE_THRESHOLD, at which point 'E12'/'OUT' takes
+    over — mirrors image_magic._magic_or_elim's leader/trailer split."""
     clinch = (team.get('clinch_indicator') or '').strip().lower()
     if clinch in ('z', 'y'):
         return 'CL'
@@ -270,9 +447,7 @@ def _me_badge_value(team, leader, is_leader, rival_losses):
         if rival_losses is None:
             return 'CL'
         magic = _ME_MAGIC_BASE - lead_w - rival_losses
-        if magic <= 0:
-            return 'CL'
-        return f'M{magic}' if magic <= _ME_BADGE_THRESHOLD else ''
+        return 'CL' if magic <= 0 else f'M{magic}'
     else:
         team_l = team.get('league_record_losses')
         if team_l is None:
@@ -280,7 +455,9 @@ def _me_badge_value(team, leader, is_leader, rival_losses):
         elim = _ME_MAGIC_BASE - lead_w - team_l
         if elim <= 0:
             return 'OUT'
-        return f'E{elim}' if elim <= _ME_BADGE_THRESHOLD else ''
+        if elim < _ME_BADGE_THRESHOLD:
+            return f'E{elim}'
+        return str(team.get('games_back') or '-')
 
 
 def draw_standings_sidebar(Himage, standings_data, team_data, side='left', league_mode='mlb',

--- a/tests/test_generate_image_orchestrate.py
+++ b/tests/test_generate_image_orchestrate.py
@@ -135,10 +135,15 @@ def _fake_loader(overrides):
     """Build a side_effect for generate_image.load_json_file keyed by filename.
 
     Any filename not present in `overrides` returns {} (matching util's
-    default-empty-dict behavior for a missing file).
+    default-empty-dict behavior for a missing file) — except
+    old_header_state.json, which defaults to the steady-state "nothing in the
+    header strip" fingerprint so tests unrelated to the header/overflow
+    ticker don't pick up a spurious extra changed_regions entry for it.
     """
     def _load(file_name, *args, **kwargs):
         """Load."""
+        if file_name == 'old_header_state.json' and file_name not in overrides:
+            return {'mode': 'none', 'key': []}
         return overrides.get(file_name, {})
     return _load
 
@@ -641,7 +646,7 @@ def test_games_without_game_pk_are_skipped_in_refresh_and_score_tracking():
     stub_img = Image.new('1', (800, 480), 255)
     games = [{'detailed_state': 'Scheduled'}]  # no game_pk at all
 
-    with patch('generate_image.load_json_file', return_value={}), \
+    with patch('generate_image.load_json_file', side_effect=_fake_loader({})), \
          patch('generate_image.save_off_results'), \
          patch('generate_image.draw_out_of_town_score_board', return_value=stub_img):
         result = generate_image.orchestrate_score_board(
@@ -978,6 +983,175 @@ def test_playoff_bracket_header_drawn_when_bracket_data_present():
 
     mock_bracket.assert_called_once()
     assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Overflow ticker header wiring
+# ---------------------------------------------------------------------------
+
+@needs_pil
+def test_overflow_ticker_wins_over_playoff_bracket_when_games_dropped():
+    """When compute_grid_layout can't place every game (here: wide_cell_featured
+    forcing 2 of 15 games off the grid), draw_overflow_ticker takes the header
+    strip instead of draw_playoff_bracket_header, even with valid bracket data
+    present and otherwise eligible to show."""
+    import generate_image
+    from datetime import datetime
+
+    cfg = dict(FIXED_CONFIG, show_playoff_bracket=True, wide_cell_featured=True,
+               league_mode='mlb')
+    stub_img = Image.new('1', (800, 480), 255)
+    bracket_data = {'season': datetime.now().year,
+                     'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'LAD',
+                                 'away_wins': 2, 'home_wins': 3, 'complete': False}]}
+
+    games = (
+        [_live_game(game_pk=1)]
+        + [_base_game(game_pk=100 + i, detailed_state='Final') for i in range(3)]
+        + [_base_game(game_pk=200 + i, detailed_state='Scheduled') for i in range(11)]
+    )
+
+    def fake_load(filename, *a, **kw):
+        """Fake load."""
+        return {'playoff_bracket.json': bracket_data}.get(filename, {})
+
+    with patch('generate_image.load_json_file', side_effect=fake_load), \
+         patch('generate_image.save_off_results'), \
+         patch('generate_image.draw_out_of_town_score_board', return_value=stub_img), \
+         patch('generate_image.draw_playoff_bracket_header', return_value=stub_img) as mock_bracket, \
+         patch('generate_image.draw_overflow_ticker', return_value=stub_img) as mock_ticker:
+        result = generate_image.orchestrate_score_board(
+            games, TEAM_DATA, date_str='2026-06-20',
+            bypass_cache=True, config=cfg,
+        )
+
+    mock_ticker.assert_called_once()
+    mock_bracket.assert_not_called()
+    assert result is not None
+
+
+@needs_pil
+def test_no_dropped_games_falls_back_to_playoff_bracket():
+    """With no overflow (every game fits), the ticker is never invoked and the
+    playoff bracket still wins the header strip as before."""
+    import generate_image
+    from datetime import datetime
+
+    cfg = dict(FIXED_CONFIG, show_playoff_bracket=True, league_mode='mlb')
+    stub_img = Image.new('1', (800, 480), 255)
+    bracket_data = {'season': datetime.now().year,
+                     'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'LAD',
+                                 'away_wins': 2, 'home_wins': 3, 'complete': False}]}
+    games = [_base_game(game_pk=1)]
+
+    def fake_load(filename, *a, **kw):
+        """Fake load."""
+        return {'playoff_bracket.json': bracket_data}.get(filename, {})
+
+    with patch('generate_image.load_json_file', side_effect=fake_load), \
+         patch('generate_image.save_off_results'), \
+         patch('generate_image.draw_out_of_town_score_board', return_value=stub_img), \
+         patch('generate_image.draw_playoff_bracket_header', return_value=stub_img) as mock_bracket, \
+         patch('generate_image.draw_overflow_ticker', return_value=stub_img) as mock_ticker:
+        result = generate_image.orchestrate_score_board(
+            games, TEAM_DATA, date_str='2026-06-20',
+            bypass_cache=True, config=cfg,
+        )
+
+    mock_bracket.assert_called_once()
+    mock_ticker.assert_not_called()
+    assert result is not None
+
+
+@needs_pil
+def test_header_fingerprint_covers_bracket_and_wildcard_modes():
+    """With bypass_cache=False (so the header-fingerprint persistence path
+    actually runs) and no dropped games, the fingerprint's 'bracket' and
+    'wildcard' branches are exercised instead of only 'ticker'/'none'."""
+    import generate_image
+    from datetime import datetime
+
+    bracket_data = {'season': datetime.now().year,
+                     'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'LAD',
+                                 'away_wins': 2, 'home_wins': 3, 'complete': False}]}
+    games = [_base_game(game_pk=1, detailed_state='Scheduled', away_runs=0, home_runs=0)]
+
+    bracket_cfg = dict(FIXED_CONFIG, show_playoff_bracket=True, league_mode='mlb')
+    with patch('generate_image.load_json_file',
+               side_effect=_fake_loader({'playoff_bracket.json': bracket_data})), \
+         patch('generate_image.save_off_results') as mock_save, \
+         patch('image_grid.load_yaml_file', return_value=bracket_cfg), \
+         patch('image_box.load_yaml_file', return_value=bracket_cfg), \
+         patch('generate_image.draw_playoff_bracket_header', side_effect=lambda img, b: img):
+        result = generate_image.orchestrate_score_board(
+            games, TEAM_DATA, date_str='2026-06-20', bypass_cache=False, config=bracket_cfg,
+        )
+    assert result is not None
+    saved_states = [c.args[0] for c in mock_save.call_args_list if c.args[1] == 'old_header_state']
+    assert saved_states[-1] == {'mode': 'bracket', 'key': []}
+
+    wc_cfg = dict(FIXED_CONFIG, show_wildcard_standings=True, league_mode='mlb')
+    standings_data = {'standings': {'1': [{'team_id': 119, 'streak': 'W2'}]}}
+    with patch('generate_image.load_json_file',
+               side_effect=_fake_loader({'standings.json': standings_data})), \
+         patch('generate_image.save_off_results') as mock_save, \
+         patch('image_grid.load_yaml_file', return_value=wc_cfg), \
+         patch('image_box.load_yaml_file', return_value=wc_cfg), \
+         patch('generate_image.draw_wildcard_header', side_effect=lambda img, wc: img):
+        result = generate_image.orchestrate_score_board(
+            games, TEAM_DATA, date_str='2026-06-20', bypass_cache=False, config=wc_cfg,
+        )
+    assert result is not None
+    saved_states = [c.args[0] for c in mock_save.call_args_list if c.args[1] == 'old_header_state']
+    assert saved_states[-1] == {'mode': 'wildcard', 'key': []}
+
+
+@needs_pil
+def test_header_region_included_when_ticker_activates():
+    """The overflow ticker turning on between polls (dropped-games set going
+    from empty to non-empty) is a header-strip content change that isn't
+    captured by the per-cell grid diffing alone — changed_regions must still
+    include the header strip so it reaches the e-ink panel.
+
+    Games 1-13 (Scheduled) and 14 (Final) are byte-identical old vs new, so
+    none of them register in refreshed_game_ids even though 13 and 14 get
+    bumped off the grid into the ticker this poll (wide_cell_featured gives
+    the one new live game, 99, a triple tile). Only game 99 is "changed" —
+    a single small region from grid-cell diffing alone, well under the
+    10-cells collapse threshold — so the header region can only be present
+    because the header-fingerprint check added it.
+    """
+    import generate_image
+    import image_box
+
+    old_games = (
+        [_base_game(game_pk=i, detailed_state='Scheduled') for i in range(1, 14)]
+        + [_base_game(game_pk=14, detailed_state='Final')]
+    )
+    new_games = (
+        [_live_game(game_pk=99)]
+        + [_base_game(game_pk=i, detailed_state='Scheduled') for i in range(1, 14)]
+        + [_base_game(game_pk=14, detailed_state='Final')]
+    )
+    cfg = dict(FIXED_CONFIG, wide_cell_featured=True)
+
+    with patch('generate_image.load_json_file',
+               side_effect=_fake_loader({'old_scoreboard_state.json': old_games})), \
+         patch('generate_image.save_off_results'), \
+         patch('image_grid.load_yaml_file', return_value=cfg), \
+         patch('image_box.load_yaml_file', return_value=cfg):
+        image_box.set_historical_mode(True)
+        try:
+            result = generate_image.orchestrate_score_board(
+                new_games, TEAM_DATA, date_str='2026-06-20', bypass_cache=False, config=cfg,
+            )
+        finally:
+            image_box.set_historical_mode(False)
+
+    assert result is not None
+    _, regions = result
+    assert (0, 0, 800, 30) in regions
+    assert regions != [(0, 0, 800, 480)]   # sanity: didn't just collapse to full-screen
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image_grid.py
+++ b/tests/test_image_grid.py
@@ -786,3 +786,53 @@ class TestPackGridOverflowSkipAndBreak:
         wide_pos = [p for p in positions if p[0] == 'wide']
         assert len(wide_pos) == 1
         assert wide_pos[0][1] == 0   # wide starts at col 0 (new row)
+
+
+# ---------------------------------------------------------------------------
+# _prioritize_live_over_final — dropped games favor keeping live/scheduled
+# ---------------------------------------------------------------------------
+
+class TestPrioritizeLiveOverFinal:
+    def test_final_games_dropped_before_scheduled_ones(self):
+        """15 games (1 live + 3 Final + 11 Scheduled) with wide_cell_featured
+        forces 2 games off the grid via the >=15 row-major path. Without
+        state-aware prioritization, whichever games land at the tail of the
+        packed order get dropped regardless of state; with it, the already-
+        finished games must be the ones bumped, not the scheduled ones still
+        worth watching."""
+        cfg = dict(BASE_CONFIG, wide_cell_featured=True, primary='NYY')
+        games = (
+            [_game(0, state='In Progress', inning=5)]
+            + [_game(100 + i, state='Final') for i in range(3)]
+            + [_game(200 + i, state='Scheduled') for i in range(11)]
+        )
+        ordered, slots = compute_grid_layout(games, TEAM_DATA, cfg)
+        placed_pks = {g['game_pk'] for g in ordered}
+        dropped = [g for g in games if g['game_pk'] not in placed_pks]
+
+        assert len(ordered) < len(games)   # sanity: this scenario does drop games
+        assert all(g['detailed_state'] == 'Final' for g in dropped)
+        assert all(g['game_pk'] in placed_pks for g in games if g['detailed_state'] == 'Scheduled')
+
+    def test_no_drop_means_no_swap(self):
+        """When everything fits, the swap is a no-op — order/content untouched
+        beyond what packing already does."""
+        games = [_game(0, state='In Progress')] + [_game(i + 1, state='Final') for i in range(4)]
+        ordered, slots = compute_grid_layout(games, TEAM_DATA, BASE_CONFIG)
+        assert len(ordered) == len(games)
+        assert {g['game_pk'] for g in ordered} == {g['game_pk'] for g in games}
+
+    def test_pinned_favorite_final_game_never_swapped_out(self):
+        """The pinned favorite-team game stays in slot 0 even when it's Final
+        and a live/scheduled game elsewhere got dropped — index 0 is exempt
+        from the priority swap, same as _move_non_live_to_fillers."""
+        cfg = dict(BASE_CONFIG, wide_cell_featured=True, favorite_team_first=True, primary='NYY')
+        pinned = _game(999, state='Final')
+        games = (
+            [pinned]
+            + [_game(0, state='In Progress', inning=5)]
+            + [_game(100 + i, state='Final') for i in range(3)]
+            + [_game(200 + i, state='Scheduled') for i in range(11)]
+        )
+        ordered, slots = compute_grid_layout(games, TEAM_DATA, cfg)
+        assert ordered[0]['game_pk'] == 999

--- a/tests/test_image_magic.py
+++ b/tests/test_image_magic.py
@@ -124,9 +124,9 @@ class TestMagicOrElim:
         return {'league_record_wins': wins, 'league_record_losses': losses,
                 'clinch_indicator': ''}
 
-    def _team(self, wins=50, losses=40, clinch=''):
+    def _team(self, wins=50, losses=40, clinch='', games_back=None):
         return {'league_record_wins': wins, 'league_record_losses': losses,
-                'clinch_indicator': clinch}
+                'clinch_indicator': clinch, 'games_back': games_back}
 
     def test_leader_magic_number(self):
         leader = self._leader(wins=60)
@@ -152,12 +152,31 @@ class TestMagicOrElim:
         result = _magic_or_elim(leader, leader, is_leader=True, rival_losses=None)
         assert result == 'CL'
 
-    def test_trailer_elimination_number(self):
+    def test_trailer_shows_games_back_when_elim_number_is_large(self):
+        """Above _ELIM_THRESHOLD, games back is shown instead of the (not yet
+        meaningful) elimination number."""
         leader = self._leader(wins=60)
-        team = self._team(losses=40)
-        # E = 163-60-40 = 63
+        team = self._team(losses=40, games_back='6.5')
+        # E = 163-60-40 = 63, well above the threshold
         result = _magic_or_elim(team, leader, is_leader=False, rival_losses=35)
-        assert result == 'E63'
+        assert result == '6.5'
+
+    def test_trailer_games_back_falls_back_to_dash_when_missing(self):
+        """No games_back on the team dict falls back to '-', mirroring the
+        wildcard header's convention for a missing value."""
+        leader = self._leader(wins=60)
+        team = self._team(losses=40, games_back=None)
+        result = _magic_or_elim(team, leader, is_leader=False, rival_losses=35)
+        assert result == '-'
+
+    def test_trailer_shows_elimination_number_once_race_is_close(self):
+        """Below _ELIM_THRESHOLD, the elimination number takes over from
+        games back — the race is tight enough to be worth highlighting."""
+        leader = self._leader(wins=100)
+        team = self._team(losses=44, games_back='18.0')
+        # E = 163-100-44 = 19 < 20 → elimination number, not games back
+        result = _magic_or_elim(team, leader, is_leader=False, rival_losses=35)
+        assert result == 'E19'
 
     def test_trailer_eliminated(self):
         leader = self._leader(wins=120)

--- a/tests/test_image_standings_more.py
+++ b/tests/test_image_standings_more.py
@@ -27,6 +27,10 @@ from image_standings import (
     draw_wildcard_header,
     draw_standings_sidebar,
     draw_standings_sidebar_fullscreen,
+    draw_overflow_ticker,
+    _ticker_status,
+    _ticker_score,
+    _ticker_window,
 )
 
 try:
@@ -695,6 +699,192 @@ class TestDrawPlayoffBracketHeader:
 
 
 # ===========================================================================
+# draw_overflow_ticker() / _ticker_status() / _ticker_window()
+# ===========================================================================
+
+def _ov_game(pk, away_id=1, home_id=2, state='Scheduled', **overrides):
+    """Minimal game dict covering the fields _ticker_status/draw_overflow_ticker read."""
+    g = {
+        'game_pk': pk, 'away_team_id': away_id, 'home_team_id': home_id,
+        'detailed_state': state, 'game_start': '7:05 PM',
+    }
+    g.update(overrides)
+    return g
+
+
+class TestTickerStatus:
+    def test_final_family_normalizes_to_final(self):
+        """Final family normalizes to Final."""
+        for state in ('Final', 'Game Over', 'Final: Tied'):
+            assert _ticker_status(_ov_game(1, state=state)) == 'Final'
+
+    def test_postponed_family_normalizes_to_postponed(self):
+        """Postponed family normalizes to Postponed."""
+        for state in ('Postponed', 'Cancelled', 'Cancelled: Rain'):
+            assert _ticker_status(_ov_game(1, state=state)) == 'Postponed'
+
+    def test_live_game_formats_inning_half_and_number(self):
+        """Live game formats inning half and number."""
+        g = _ov_game(1, state='In Progress', inningState='Bottom', currentInningOrdinal='7th')
+        assert _ticker_status(g) == 'Bot 7'
+
+    def test_live_game_falls_back_to_current_inning_without_ordinal(self):
+        """Live game falls back to current_inning without ordinal."""
+        g = _ov_game(1, state='In Progress', inningState='Top', current_inning=4)
+        assert _ticker_status(g) == 'Top 4'
+
+    def test_not_started_uses_pre_formatted_game_start(self):
+        """Not started uses pre-formatted game_start (already local time)."""
+        g = _ov_game(1, state='Scheduled', game_start='7:05 PM')
+        assert _ticker_status(g) == '7:05 PM'
+
+
+class TestTickerScore:
+    def test_final_game_shows_score(self):
+        """Final game shows score."""
+        g = _ov_game(1, state='Final', away_runs=5, home_runs=3)
+        assert _ticker_score(g) == '5-3'
+
+    def test_live_game_shows_score(self):
+        """Live game shows score."""
+        g = _ov_game(1, state='In Progress', away_runs=2, home_runs=1)
+        assert _ticker_score(g) == '2-1'
+
+    def test_scheduled_game_has_no_score(self):
+        """Scheduled game has no score."""
+        g = _ov_game(1, state='Scheduled', away_runs=None, home_runs=None)
+        assert _ticker_score(g) == ''
+
+    def test_postponed_game_has_no_score(self):
+        """Postponed game has no score."""
+        g = _ov_game(1, state='Postponed', away_runs=0, home_runs=0)
+        assert _ticker_score(g) == ''
+
+    def test_missing_runs_data_falls_back_to_empty(self):
+        """Missing runs data falls back to empty, not 'None-None'."""
+        g = _ov_game(1, state='Final', away_runs=None, home_runs=3)
+        assert _ticker_score(g) == ''
+
+
+class TestTickerWindow:
+    def test_fewer_than_max_returns_all(self):
+        """Fewer than max returns all."""
+        games = [_ov_game(i) for i in range(3)]
+        assert _ticker_window(games, max_entries=5) == games
+
+    def test_more_than_max_returns_a_capped_subset(self):
+        """More than max returns a capped subset (10 games / 5 per window —
+        an exact multiple, so every rotation window is full-sized, not just
+        whichever wall-clock block this test happens to run in)."""
+        games = [_ov_game(i) for i in range(10)]
+        window = _ticker_window(games, max_entries=5)
+        assert len(window) == 5
+        assert all(g in games for g in window)
+
+    def test_stable_within_same_rotation_block(self):
+        """Two calls within the same rotation window return the same subset."""
+        games = [_ov_game(i) for i in range(12)]
+        first = _ticker_window(games, max_entries=5, rotation_minutes=5)
+        second = _ticker_window(games, max_entries=5, rotation_minutes=5)
+        assert first == second
+
+    def test_empty_input_returns_empty(self):
+        """Empty input returns empty."""
+        assert _ticker_window([], max_entries=5) == []
+
+
+@needs_pil
+class TestDrawOverflowTicker:
+    def _white(self):
+        """White."""
+        return Image.new('1', (800, 30), 255)
+
+    def test_empty_dropped_games_returns_unchanged(self):
+        """Empty dropped games returns unchanged."""
+        canvas = self._white()
+        result = draw_overflow_ticker(canvas, [], {'team_abbreviation': {}})
+        assert result is canvas
+
+    def test_single_entry_renders_with_logo_fallback(self):
+        """Single entry renders with logo fallback (abbreviation text)."""
+        canvas = self._white()
+        team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS'}}
+        games = [_ov_game(1, away_id=1, home_id=2, state='Final', away_runs=5, home_runs=3)]
+        with patch('image_standings._logo_small', return_value=None):
+            result = draw_overflow_ticker(canvas, games, team_data)
+        assert isinstance(result, Image.Image)
+        assert any(px == 0 for px in result.getdata())
+
+    def test_final_entry_includes_score_and_status(self):
+        """A Final game draws both the score (digits + dash, each measured
+        and drawn separately at the bigger score font) and the status word —
+        verified via draw.text call args since font rendering itself isn't
+        pixel-inspectable at this granularity."""
+        canvas = self._white()
+        team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS'}}
+        games = [_ov_game(1, away_id=1, home_id=2, state='Final', away_runs=5, home_runs=3)]
+        with patch('image_standings._logo_small', return_value=None), \
+             patch('image_standings.ImageDraw.ImageDraw.text') as mock_text:
+            draw_overflow_ticker(canvas, games, team_data)
+        drawn_strings = [call.args[1] for call in mock_text.call_args_list]
+        assert '5' in drawn_strings
+        assert '-' in drawn_strings
+        assert '3' in drawn_strings
+        assert 'Final' in drawn_strings
+
+    def test_no_separator_lines_between_entries(self):
+        """The vertical '|' separators between entries have been removed —
+        only the top/bottom strip border lines remain."""
+        canvas = self._white()
+        team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS', '3': 'LAD', '4': 'SF'}}
+        games = [
+            _ov_game(1, away_id=1, home_id=2, state='Final', away_runs=5, home_runs=3),
+            _ov_game(2, away_id=3, home_id=4, state='Scheduled'),
+        ]
+        with patch('image_standings._logo_small', return_value=None), \
+             patch('image_standings.ImageDraw.ImageDraw.line') as mock_line:
+            draw_overflow_ticker(canvas, games, team_data)
+        # Only the two horizontal border lines (top + bottom of the strip) —
+        # no vertical separator between the two entries.
+        assert mock_line.call_count == 2
+
+    def test_multiple_entries_render_with_separators(self):
+        """Multiple entries render with separators."""
+        canvas = self._white()
+        team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS', '3': 'LAD', '4': 'SF'}}
+        games = [
+            _ov_game(1, away_id=1, home_id=2, state='Final'),
+            _ov_game(2, away_id=3, home_id=4, state='Scheduled'),
+        ]
+        with patch('image_standings._logo_small', return_value=None):
+            result = draw_overflow_ticker(canvas, games, team_data)
+        assert isinstance(result, Image.Image)
+        assert any(px == 0 for px in result.getdata())
+
+    def test_more_than_max_entries_consults_ticker_window(self):
+        """With more dropped games than fit, draw_overflow_ticker delegates the
+        windowing decision to _ticker_window rather than drawing everything."""
+        canvas = self._white()
+        team_data = {'team_abbreviation': {}}
+        games = [_ov_game(i) for i in range(12)]
+        with patch('image_standings._logo_small', return_value=None), \
+             patch('image_standings._ticker_window', wraps=_ticker_window) as mock_window:
+            draw_overflow_ticker(canvas, games, team_data)
+        mock_window.assert_called_once()
+
+    def test_logo_available_pastes_instead_of_text(self):
+        """When a logo is available, it's pasted rather than falling back to text."""
+        canvas = self._white()
+        team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS'}}
+        games = [_ov_game(1, away_id=1, home_id=2, state='Final')]
+        fake_logo = Image.new('1', (20, 20), 0)  # solid black square
+        with patch('image_standings._logo_small', return_value=fake_logo):
+            result = draw_overflow_ticker(canvas, games, team_data)
+        assert isinstance(result, Image.Image)
+        assert any(px == 0 for px in result.getdata())
+
+
+# ===========================================================================
 # draw_standings_sidebar() — mover detection paths (lines 341-357, 389-393,
 # 397-398, 408, 447, 481)
 # ===========================================================================
@@ -905,10 +1095,11 @@ class TestMeBadgeValue:
         result = _me_badge_value({}, self._leader(wins=90), True, 40)
         assert result == 'M33'
 
-    def test_leader_magic_above_threshold(self):
-        # 163 - 60 - 10 = 93 > 50
+    def test_leader_magic_above_threshold_still_shows_magic_number(self):
+        # 163 - 60 - 10 = 93 > threshold — the leader always shows its magic
+        # number, unlike a trailing team's badge.
         result = _me_badge_value({}, self._leader(wins=60), True, 10)
-        assert result == ''
+        assert result == 'M93'
 
     def test_trailer_losses_none_returns_empty(self):
         team = {}  # missing league_record_losses
@@ -920,14 +1111,18 @@ class TestMeBadgeValue:
         assert _me_badge_value(team, self._leader(wins=100), False, 50) == 'OUT'
 
     def test_trailer_elim_within_threshold(self):
-        # 163 - 90 - 40 = 33 ≤ 50
+        # 163 - 90 - 40 = 33 < 50
         team = {'league_record_losses': 40}
         assert _me_badge_value(team, self._leader(wins=90), False, 50) == 'E33'
 
-    def test_trailer_elim_above_threshold(self):
-        # 163 - 60 - 10 = 93 > 50
+    def test_trailer_elim_at_or_above_threshold_shows_games_back(self):
+        # 163 - 60 - 10 = 93 >= 50 → games back, not the elimination number
+        team = {'league_record_losses': 10, 'games_back': '15.5'}
+        assert _me_badge_value(team, self._leader(wins=60), False, 50) == '15.5'
+
+    def test_trailer_games_back_falls_back_to_dash_when_missing(self):
         team = {'league_record_losses': 10}
-        assert _me_badge_value(team, self._leader(wins=60), False, 50) == ''
+        assert _me_badge_value(team, self._leader(wins=60), False, 50) == '-'
 
     def test_clinch_indicator_case_insensitive(self):
         assert _me_badge_value({'clinch_indicator': 'Z'}, self._leader(), True, 50) == 'CL'
@@ -969,8 +1164,8 @@ class TestDrawStandingsSidebarMagicBadges:
         result = self._render(standings, side='right')
         assert result is not None
 
-    def test_no_badge_above_threshold(self):
-        # 163 - 50 - 10 = 103 > 50 → no badge
+    def test_games_back_badge_above_threshold(self):
+        # 163 - 50 - 10 = 103 > 50 → games back badge instead of E-number
         standings = self._make_standings(wins_leader=50, losses_rival=10)
         result = self._render(standings, side='left')
         assert result is not None


### PR DESCRIPTION
## Summary
- Games bumped off the 5x3 grid (live-game tile expansion, `hide_non_live_games`, or >15-game overflow) now surface as a compact "Away v Home <score> <status>" ticker in the top header instead of vanishing, rotating through a batch every `overflow_ticker_rotation_minutes` when more are bumped than fit at once. Takes priority over the playoff bracket / wildcard standings header.
- `compute_grid_layout` now biases which games get dropped toward already-finished ones, so live/scheduled/postponed games keep their grid slot over a Final whenever something has to give.
- Magic-number panel (and its sidebar M/E badge) now show games back from the division leader for trailing teams instead of an elimination number, until that number drops below the "race is close" threshold. The leader's row always shows its magic number.
- README updated with the header-strip priority order and previously-undocumented empty-cell panels.

## Test plan
- [x] `pytest -q --cov` — 2059 passed, 98.13% coverage (gate is 98%)
- [x] `ruff check src/ tests/` — clean
- [x] Manually rendered the ticker/magic panel/sidebar badges with real cached team/standings data to confirm visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6kSVUQLmPqyCrXHWs3Lg3