### PR TITLE
Add overflow ticker to header strip; refine header rules and fullscreen game-state label

### DIFF
--- a/src/generate_image.py
+++ b/src/generate_image.py
@@ -24,7 +24,7 @@ from image_standings import (
     _WC_STRIP_H,
     derive_wildcard_from_standings, draw_wildcard_header, draw_standings_sidebar,
     draw_standings_sidebar_fullscreen, draw_playoff_bracket_header,
-    draw_overflow_ticker, _ticker_window,
+    draw_overflow_ticker, _ticker_window, draw_transactions_header,
 )
 from image_box import draw_box, _abbr_play, _draw_linescore_grid, _draw_backwards_k
 
@@ -426,10 +426,22 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         if _candidate and _candidate.get('series') and _candidate.get('season') == datetime.now().year:
             _bracket = _candidate
 
-    # The overflow ticker wins the header strip outright over both the
-    # playoff bracket and wildcard standings whenever games got dropped —
-    # a game missing from the grid is more time-sensitive than either.
-    if _dropped_games:
+    # Header strip priority:
+    #   1. Overflow ticker — only when total games genuinely exceed the 15-slot
+    #      grid capacity AND at least one game hasn't finished yet (once all
+    #      games are done the ticker gives way to standings).
+    #   2. Playoff bracket
+    #   3. Wildcard standings
+    #   4. Transactions (when show_transactions_ticker is on and strip is empty)
+    _FINISHED_STATES = frozenset({
+        'Final', 'Game Over', 'Final: Tied', 'Postponed', 'Cancelled', 'Cancelled: Rain',
+    })
+    _all_games_done = bool(game_state_data) and all(
+        g.get('detailed_state') in _FINISHED_STATES for g in game_state_data
+    )
+    _genuine_overflow = len(game_state_data) > 15
+
+    if _dropped_games and _genuine_overflow and not _all_games_done:
         Himage = draw_overflow_ticker(
             Himage, _dropped_games, team_data,
             rotation_minutes=config.get('overflow_ticker_rotation_minutes', 2),
@@ -440,6 +452,13 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         if standings_data and 'standings' in standings_data:
             wildcard_data = derive_wildcard_from_standings(standings_data)
             Himage = draw_wildcard_header(Himage, wildcard_data)
+    elif config.get('show_transactions_ticker', False):
+        _tx_hdr = (load_json_file('transactions.json') or {}).get('transactions', [])
+        if _tx_hdr:
+            Himage = draw_transactions_header(
+                Himage, _tx_hdr, team_data,
+                rotation_minutes=config.get('overflow_ticker_rotation_minutes', 2),
+            )
 
     if config.get('show_standings_sidebar', False):
         if standings_data and 'standings' in standings_data:
@@ -509,7 +528,7 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
         # changed_regions and so wouldn't reach the e-ink panel on a partial
         # refresh. Fingerprint whatever's currently showing there and add the
         # strip to changed_regions when it differs from the last poll.
-        if _dropped_games:
+        if _dropped_games and _genuine_overflow and not _all_games_done:
             _header_key = [str(g.get('game_pk', '')) for g in _ticker_window(
                 _dropped_games, rotation_minutes=config.get('overflow_ticker_rotation_minutes', 2))]
             _header_state = {'mode': 'ticker', 'key': _header_key}
@@ -517,6 +536,10 @@ def  orchestrate_score_board(game_state_data, team_data, date_str=None, bypass_c
             _header_state = {'mode': 'bracket', 'key': []}
         elif config.get('show_wildcard_standings', False) and league_mode != 'aaa':
             _header_state = {'mode': 'wildcard', 'key': []}
+        elif config.get('show_transactions_ticker', False):
+            _tx_key = [(e.get('date', '') + e.get('player_name', ''))
+                       for e in (load_json_file('transactions.json') or {}).get('transactions', [])[:5]]
+            _header_state = {'mode': 'transactions', 'key': _tx_key}
         else:
             _header_state = {'mode': 'none', 'key': []}
 

--- a/src/image_box.py
+++ b/src/image_box.py
@@ -11,7 +11,7 @@ from image_assets import (
     _load_codepoint_ghost, _TEAM_ID_ABBR_OVERRIDE, _PPD_EMOJI_CODEPOINTS, _SUSP_EMOJI_CODEPOINTS,
 )
 from image_utils import (
-    draw_diamond, draw_circle, check_if_two_chars,
+    draw_diamond, draw_circle, draw_tight_number, check_if_two_chars,
     _format_player_name, _last_name, _pitcher_line, _clean_venue_name,
     _is_game_effectively_over,
 )
@@ -725,6 +725,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     font24 = _get_font(24 * s)
     font18 = _get_font(18 * s)
     font14 = _get_font(14 * s)
+    font13 = _get_font(13 * s)   # base-runner numbers
     font11 = _get_font(11 * s)
     font9 = _get_font(9 * s)
 
@@ -2110,8 +2111,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                         _raw = game_data.get(_bkey)
                         _bnum = str(_raw) if _raw is not None else ''
                         if _bnum:
-                            _bb = font11.getbbox(_bnum)
-                            draw.text((_bcx - (_bb[0] + _bb[2] - 1) // 2, _bcy - (_bb[1] + _bb[3] - 1) // 2), _bnum, font=font11, fill=255)
+                            draw_tight_number(draw, _bcx, _bcy, _bnum, font13, 255)
             _pc_outs_list = [i + 1 <= _pc_outs for i in range(3)]
             Himage = draw_circle(Himage, (start_x + 97 * s,  start_y + 73 * s), 6 * s, _pc_outs_list[0], outline_width=2)
             Himage = draw_circle(Himage, (start_x + 111 * s, start_y + 73 * s), 6 * s, _pc_outs_list[1], outline_width=2)
@@ -2157,8 +2157,7 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
                         _raw = game_data.get(_bkey)
                         _bnum = str(_raw) if _raw is not None else ''
                         if _bnum:
-                            _bb = font11.getbbox(_bnum)
-                            draw.text((_bcx - (_bb[0] + _bb[2] - 1) // 2, _bcy - (_bb[1] + _bb[3] - 1) // 2), _bnum, font=font11, fill=255)
+                            draw_tight_number(draw, _bcx, _bcy, _bnum, font13, 255)
 
                 outs_list = [None] * 3
                 for i in range(1, 4):
@@ -2400,8 +2399,7 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
     Bottom strip (below rp_h): K strikeouts for each pitcher.
     """
     s = scale
-    font11 = _get_font(11 * s)
-    font10 = _get_font(10 * s)   # slightly bigger than font9, for base-runner numbers
+    font11 = _get_font(11 * s)   # base-runner numbers
     font9  = _get_font(9 * s)
     font7  = _get_font(max(7 * s, 7))
 
@@ -2643,8 +2641,8 @@ def _draw_wide_right_panel(draw, Himage, rp_x, rp_y, rp_w, rp_h, header_h, game_
                     _raw = game_data.get(_bkey)
                     _bnum = str(_raw) if _raw is not None else ''
                     if _bnum:
-                        _bb = font10.getbbox(_bnum)
-                        draw.text((_bcx - (_bb[0] + _bb[2] - 1) // 2, _bcy - (_bb[1] + _bb[3] - 1) // 2), _bnum, font=font10, fill=255)
+                        _bb = font11.getbbox(_bnum)
+                        draw.text((_bcx - (_bb[0] + _bb[2] - 1) // 2, _bcy - (_bb[1] + _bb[3] - 1) // 2), _bnum, font=font11, fill=255)
 
         # ── Outs circles: left side, below bases ──────────────────────
         outs_list = [i + 1 <= _outs_count for i in range(3)]
@@ -3289,7 +3287,7 @@ def _draw_field_cell(draw, Himage, fx, fy, fw, fh, game_data, scale=1, y_offset=
     thetas = [_math.atan2(x_ft, y_ft) for x_ft, y_ft in wall_poly]
     theta_lo, theta_hi = thetas[0], thetas[-1]
     n_markers = 5
-    _label_offs = max(round(9 * s), 9)  # px to push label outside the fence arc
+    _label_offs = max(round(16 * s), 16)  # px to push label outside the fence arc
     for k in range(n_markers):
         target = theta_lo + (k / (n_markers - 1)) * (theta_hi - theta_lo)
         idx = min(range(len(thetas)), key=lambda i: abs(thetas[i] - target))
@@ -3300,7 +3298,11 @@ def _draw_field_cell(draw, Himage, fx, fy, fw, fh, game_data, scale=1, y_offset=
         # Radial unit vector pointing away from home plate (i.e. into the stands).
         norm = _math.sqrt(x_ft**2 + y_ft**2) or 1
         ux, uy = x_ft / norm, y_ft / norm
-        # Place label outside the wall: move in the outward radial direction in pixel space.
+        # Place label outside the wall: move further out along the same radial
+        # direction from home plate. At the foul poles this direction runs
+        # right along the fence/foul line, so the offset has to be large
+        # enough to clear the pole label past where the wall curves away —
+        # a small nudge leaves the label sitting on top of the line.
         # x-pixel and x-field share the same sign; y-pixel is inverted vs y-field.
         lx_c = int(pt[0] + ux * _label_offs)
         ly_c = int(pt[1] - uy * _label_offs)
@@ -3497,7 +3499,9 @@ def draw_triple_box(Himage, start_x, start_y, game_data, team_data,
         and int(game_data.get('last_play_rbi') or 0) > 0
     )
     if (score_changed or _run_scored) and not _between:
-        header_box = Himage.crop((start_x, start_y, start_x + TOTAL_W, start_y + HEADER_H))
+        # Only cells 1+2 (up to fp_x) light up — cell 3 is the field diagram
+        # and has no header row of its own.
+        header_box = Himage.crop((start_x, start_y, fp_x, start_y + HEADER_H))
         Himage.paste(ImageOps.invert(header_box.convert('L')).convert('1'), (start_x, start_y))
         draw = ImageDraw.Draw(Himage)
 

--- a/src/image_featured.py
+++ b/src/image_featured.py
@@ -5,9 +5,12 @@ from image_assets import (
     _get_font, _logo_small, _logo_ghost, _paste_logo,
     Image, ImageDraw, ImageOps,
 )
+import time as _time_feat
+
 from image_utils import (
-    draw_diamond, draw_circle,
+    draw_diamond, draw_circle, draw_tight_number,
     _last_name, _is_game_effectively_over,
+    _series_display_str, _clean_venue_name,
 )
 from image_standings import (
     _WC_STRIP_H,
@@ -95,7 +98,7 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
     f28  = _get_font(28)    # between-innings pitcher + SV badge
     f36  = _get_font(36)    # pitch info right-aligned
     f42  = _get_font(42)    # BSO labels + pitcher/batter + team abbreviations
-    f44  = _get_font(48)    # runner jersey numbers inside bases
+    f52  = _get_font(52)    # runner jersey numbers inside bases
     f56  = _get_font(56)    # header inning + last-event text
     f72  = _get_font(72)    # R / H / E values in score rows
 
@@ -381,10 +384,7 @@ def draw_live_fullscreen_game(game_data, team_data, config=None):
             _raw  = game_data.get(_bkey)
             _bnum = str(_raw) if _raw is not None else ''
             if _bnum:
-                _bbox = f44.getbbox(_bnum)
-                _tx = _bc[0] - (_bbox[0] + _bbox[2]) // 2
-                _ty = _bc[1] - (_bbox[1] + _bbox[3]) // 2
-                draw.text((_tx, _ty), _bnum, font=f44, fill=255)
+                draw_tight_number(draw, _bc[0], _bc[1], _bnum, f52, 255)
 
     # ---- OUTS circles (right side, moved up, bigger) ------------------------
     _outs = game_data.get('num_of_outs') or 0
@@ -800,40 +800,37 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
                 canvas, standings_data, team_data, side='right', league_mode=league_mode,
                 x_anchor=_right_sb_x, sidebar_w=_right_sb_w, logo_sz=_sb_logo_sz)
 
-    # Date label centered in the top strip — use the largest font that fits
-    _gd_str = (game_data.get('game_date') or '')[:10]
-    if _gd_str:
-        try:
-            _gd = datetime.strptime(_gd_str, '%Y-%m-%d')
-            _date_label_full  = _gd.strftime('%A, %B %-d, %Y')   # Monday, May 11, 2026
-            _date_label_short = _gd.strftime('%a · %b %-d, %Y')  # Mon · May 11, 2026
-        except Exception:
-            _date_label_full = _date_label_short = _gd_str
-        _date_draw = ImageDraw.Draw(canvas)
-        # When wildcard standings are shown they fill the strip leaving only ~155px
-        # clear in the center (same constraint as the normal scoreboard header).
-        # Without wildcard the full strip is free so the content-area width applies.
-        _show_wc = config.get('show_wildcard_standings', False)
-        _MAX_DATE_W = 151 if _show_wc else (_box_w - 8)
-        _center_x = 400  # midpoint of the 800px display (matches _WC_MID = 399)
-        _date_font = _get_font(14)
-        _date_label = _date_label_short
-        _fsize_used = 14
-        for _fsize in (20, 18, 16, 14):
-            _f = _get_font(_fsize)
-            for _candidate in (_date_label_full, _date_label_short):
-                if int(_f.getlength(_candidate)) <= _MAX_DATE_W:
-                    _date_font = _f
-                    _date_label = _candidate
-                    _fsize_used = _fsize
+    # Game state label centered in the top strip — rotates between series
+    # context, venue name, and TV channel.  The date is omitted since the
+    # featured game is already the focus of the fullscreen layout.
+    # Skipped entirely when the bracket fills the whole strip.
+    if not _bracket:
+        _state_candidates = []
+        _series_s = _series_display_str(game_data)
+        if _series_s:
+            _state_candidates.append(_series_s)
+        _venue_s = _clean_venue_name(game_data.get('venue') or '')
+        if _venue_s:
+            _state_candidates.append(_venue_s)
+        _tv_s = (game_data.get('tv_channel') or '').strip()
+        if _tv_s:
+            _state_candidates.append(_tv_s)
+        if _state_candidates:
+            _rot_mins = max(config.get('overflow_ticker_rotation_minutes', 2), 1)
+            _block = int(_time_feat.time() // (_rot_mins * 60))
+            _state_label = _state_candidates[_block % len(_state_candidates)]
+            _show_wc = config.get('show_wildcard_standings', False)
+            _MAX_LABEL_W = 151 if _show_wc else (_box_w - 8)
+            _center_x = 400
+            _hdr_draw = ImageDraw.Draw(canvas)
+            for _fsize in (16, 14, 11, 9):
+                _f = _get_font(_fsize)
+                if int(_f.getlength(_state_label)) <= _MAX_LABEL_W:
+                    _lw = int(_f.getlength(_state_label))
+                    _lx = _center_x - _lw // 2
+                    _ly = max(0, (_WC_STRIP_H - _fsize) // 2)
+                    _hdr_draw.text((_lx,     _ly), _state_label, font=_f, fill=0)
+                    _hdr_draw.text((_lx + 1, _ly), _state_label, font=_f, fill=0)
                     break
-            else:
-                continue
-            break
-        _dw = int(_date_font.getlength(_date_label))
-        _dx = _center_x - _dw // 2
-        _dy = max(0, (_WC_STRIP_H - _fsize_used) // 2)
-        _date_draw.text((_dx,     _dy), _date_label, font=_date_font, fill=0)
-        _date_draw.text((_dx + 1, _dy), _date_label, font=_date_font, fill=0)
 
     return canvas

--- a/src/image_featured.py
+++ b/src/image_featured.py
@@ -800,21 +800,73 @@ def draw_featured_game_fullscreen(game_data, team_data, config=None):
                 canvas, standings_data, team_data, side='right', league_mode=league_mode,
                 x_anchor=_right_sb_x, sidebar_w=_right_sb_w, logo_sz=_sb_logo_sz)
 
-    # Game state label centered in the top strip — rotates between series
-    # context, venue name, and TV channel.  The date is omitted since the
-    # featured game is already the focus of the fullscreen layout.
+    # Game-state-specific header label centered in the top strip.
+    # 4 states: Scheduled, Finished, Postponed/Cancelled, other (fallback).
+    # Each state has its own set of rotating candidates.
     # Skipped entirely when the bracket fills the whole strip.
     if not _bracket:
         _state_candidates = []
-        _series_s = _series_display_str(game_data)
-        if _series_s:
-            _state_candidates.append(_series_s)
-        _venue_s = _clean_venue_name(game_data.get('venue') or '')
-        if _venue_s:
-            _state_candidates.append(_venue_s)
-        _tv_s = (game_data.get('tv_channel') or '').strip()
-        if _tv_s:
-            _state_candidates.append(_tv_s)
+        _ds_now = game_data.get('detailed_state', '')
+        _scheduled_states = {'Scheduled', 'Pre-Game', 'Warmup', 'Delayed Start', 'Delayed'}
+        _final_states = {'Final', 'Game Over', 'Final: Tied'}
+        _postponed_states = {'Postponed', 'Cancelled', 'Cancelled: Rain', 'Suspended', 'Suspended: Rain'}
+
+        if _ds_now in _scheduled_states:
+            # Scheduled: series context → venue → TV channel → game time
+            _s = _series_display_str(game_data)
+            if _s:
+                _state_candidates.append(_s)
+            _v = _clean_venue_name(game_data.get('venue') or '')
+            if _v:
+                _state_candidates.append(_v)
+            _tv = (game_data.get('tv_channel') or '').strip()
+            if _tv:
+                _state_candidates.append(_tv)
+            _gt = (game_data.get('game_date') or '').strip()
+            if _gt:
+                # parse ISO datetime → "7:05 PM" local display
+                try:
+                    import datetime as _dt_mod
+                    _gdt = _dt_mod.datetime.fromisoformat(_gt.replace('Z', '+00:00'))
+                    _state_candidates.append(_gdt.astimezone().strftime('%-I:%M %p'))
+                except Exception:
+                    pass
+
+        elif _ds_now in _final_states or _ds_now.startswith('Completed Early'):
+            # Finished: series result → WP → LP → SV
+            _s = _series_display_str(game_data)
+            if _s:
+                _state_candidates.append(_s)
+            _wp = _last_name(game_data.get('winner_name') or '')
+            if _wp:
+                _state_candidates.append(f'WP: {_wp}')
+            _lp = _last_name(game_data.get('loser_name') or '')
+            if _lp:
+                _state_candidates.append(f'LP: {_lp}')
+            _sv = _last_name(game_data.get('saver_name') or '')
+            if _sv:
+                _state_candidates.append(f'SV: {_sv}')
+
+        elif _ds_now in _postponed_states:
+            # Postponed/Cancelled: status label → reason → venue
+            _ppd_lbl = 'POSTPONED' if 'Postponed' in _ds_now else 'CANCELLED'
+            _state_candidates.append(_ppd_lbl)
+            _reason = (game_data.get('postpone_reason') or '').strip()
+            if _reason:
+                _state_candidates.append(_reason)
+            _v = _clean_venue_name(game_data.get('venue') or '')
+            if _v:
+                _state_candidates.append(_v)
+
+        else:
+            # Fallback for any unlisted state
+            _s = _series_display_str(game_data)
+            if _s:
+                _state_candidates.append(_s)
+            _v = _clean_venue_name(game_data.get('venue') or '')
+            if _v:
+                _state_candidates.append(_v)
+
         if _state_candidates:
             _rot_mins = max(config.get('overflow_ticker_rotation_minutes', 2), 1)
             _block = int(_time_feat.time() // (_rot_mins * 60))

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -409,6 +409,65 @@ def draw_overflow_ticker(Himage, dropped_games, team_data, rotation_minutes=2):
     return Himage
 
 
+_TX_HEADER_MAX = 5
+_TX_HEADER_ABBR = {
+    'Status Change': 'IL', 'Recalled': 'Recall', 'Optioned': 'Option',
+    'Selected': 'Select', 'Designated for Assignment': 'DFA',
+    'Released': 'Release', 'Signed': 'Sign', 'Trade': 'Trade',
+    'Claimed off Waivers': 'Waiver', 'Outrighted': 'Outright',
+}
+
+
+def draw_transactions_header(Himage, transactions_data, team_data, rotation_minutes=3):
+    """Draw recent transactions in the 30px header strip (y=0..30).
+
+    Called when the strip is otherwise blank (no overflow ticker, bracket, or
+    wildcard standings). Rotates through entries when more than _TX_HEADER_MAX
+    are available. Format per entry: 'ABBR LastName Type' (e.g. 'NYY Stanton IL').
+    """
+    entries = list(transactions_data or [])
+    if not entries:
+        return Himage
+
+    rotation_minutes = max(rotation_minutes, 1)
+    n = len(entries)
+    if n <= _TX_HEADER_MAX:
+        chunk = entries[:_TX_HEADER_MAX]
+    else:
+        n_chunks = -(-n // _TX_HEADER_MAX)
+        block_idx = int(_time.time() // (rotation_minutes * 60))
+        start = (block_idx % n_chunks) * _TX_HEADER_MAX
+        chunk = entries[start:start + _TX_HEADER_MAX]
+
+    draw = ImageDraw.Draw(Himage)
+    font = _get_font(9)
+    text_y = (_WC_STRIP_H - 9) // 2
+
+    n_shown = len(chunk)
+    entry_w = 800 // max(n_shown, 1)
+
+    for i, entry in enumerate(chunk):
+        x0 = i * entry_w
+
+        abbr = entry.get('team_abbr', '')
+        player = entry.get('player_name', '')
+        last = player.split()[-1] if player else ''
+        tag = _TX_HEADER_ABBR.get(entry.get('type_desc', ''), (entry.get('type_desc') or '')[:7])
+
+        text = ' '.join(p for p in (abbr, last, tag) if p)
+        tw = int(font.getlength(text))
+        tx = x0 + max(0, (entry_w - tw) // 2)
+        draw.text((tx, text_y), text, font=font, fill=0)
+
+        if i > 0:
+            draw.line((x0, 3, x0, _WC_STRIP_H - 4), fill=0, width=1)
+
+    draw.line((0, 0, 799, 0), fill=0, width=1)
+    draw.line((0, _WC_STRIP_H - 1, 799, _WC_STRIP_H - 1), fill=0, width=1)
+
+    return Himage
+
+
 def _aaa_divisions(standings_data, side):
     """Return division names for each sidebar side in AAA mode.
 

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -25,6 +25,30 @@ def normalize_dict(d):
     return d
 
 
+def draw_tight_number(draw, cx, cy, text, font, fill, gap=None):
+    """Draw text centered at (cx, cy), spacing glyphs by their own ink width.
+
+    Tabular-figure digit fonts give every glyph the same advance width so
+    columns of numbers align, but that leaves a wide gap around narrow
+    glyphs like '1'. Packing by each glyph's actual ink bbox instead keeps
+    multi-digit runner numbers visually tight inside the small base diamonds.
+    """
+    full_bb = font.getbbox(text)
+    if len(text) <= 1:
+        draw.text((cx - (full_bb[0] + full_bb[2]) // 2, cy - (full_bb[1] + full_bb[3]) // 2), text, font=font, fill=fill)
+        return
+    if gap is None:
+        gap = 1
+    char_bbs = [font.getbbox(ch) for ch in text]
+    widths = [bb[2] - bb[0] for bb in char_bbs]
+    total_w = sum(widths) + gap * (len(text) - 1)
+    x = cx - total_w // 2
+    y = cy - (full_bb[1] + full_bb[3]) // 2
+    for ch, bb, w in zip(text, char_bbs, widths):
+        draw.text((x - bb[0], y), ch, font=font, fill=fill)
+        x += w + gap
+
+
 def draw_diamond(Himage, center, size, fill=False, outline_width=1):
     """Draw a diamond (rotated square) on Himage at center with the given size."""
     draw = ImageDraw.Draw(Himage)

--- a/tests/test_generate_image_orchestrate.py
+++ b/tests/test_generate_image_orchestrate.py
@@ -991,10 +991,10 @@ def test_playoff_bracket_header_drawn_when_bracket_data_present():
 
 @needs_pil
 def test_overflow_ticker_wins_over_playoff_bracket_when_games_dropped():
-    """When compute_grid_layout can't place every game (here: wide_cell_featured
-    forcing 2 of 15 games off the grid), draw_overflow_ticker takes the header
-    strip instead of draw_playoff_bracket_header, even with valid bracket data
-    present and otherwise eligible to show."""
+    """Overflow ticker fires only when total games genuinely exceed the 15-slot
+    grid (> 15 games) AND not all games are done.  With > 15 games and a live
+    game, draw_overflow_ticker takes the header strip over draw_playoff_bracket_header
+    even with valid bracket data present."""
     import generate_image
     from datetime import datetime
 
@@ -1005,6 +1005,48 @@ def test_overflow_ticker_wins_over_playoff_bracket_when_games_dropped():
                      'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'LAD',
                                  'away_wins': 2, 'home_wins': 3, 'complete': False}]}
 
+    # 16 games (> 15) so _genuine_overflow is True; live game means not all done
+    games = (
+        [_live_game(game_pk=1)]
+        + [_base_game(game_pk=100 + i, detailed_state='Final') for i in range(3)]
+        + [_base_game(game_pk=200 + i, detailed_state='Scheduled') for i in range(12)]
+    )
+
+    def fake_load(filename, *a, **kw):
+        """Fake load."""
+        return {'playoff_bracket.json': bracket_data}.get(filename, {})
+
+    with patch('generate_image.load_json_file', side_effect=fake_load), \
+         patch('generate_image.save_off_results'), \
+         patch('generate_image.draw_out_of_town_score_board', return_value=stub_img), \
+         patch('generate_image.draw_playoff_bracket_header', return_value=stub_img) as mock_bracket, \
+         patch('generate_image.draw_overflow_ticker', return_value=stub_img) as mock_ticker:
+        result = generate_image.orchestrate_score_board(
+            games, TEAM_DATA, date_str='2026-06-20',
+            bypass_cache=True, config=cfg,
+        )
+
+    mock_ticker.assert_called_once()
+    mock_bracket.assert_not_called()
+    assert result is not None
+
+
+@needs_pil
+def test_overflow_ticker_not_shown_for_tile_expansion_drops():
+    """When tile expansion (wide_cell_featured) bumps games off the grid but
+    total games are <= 15, the ticker does NOT activate — the header stays
+    available for the bracket/wildcard instead."""
+    import generate_image
+    from datetime import datetime
+
+    cfg = dict(FIXED_CONFIG, show_playoff_bracket=True, wide_cell_featured=True,
+               league_mode='mlb')
+    stub_img = Image.new('1', (800, 480), 255)
+    bracket_data = {'season': datetime.now().year,
+                     'series': [{'round': 'WS', 'away_abbr': 'NYY', 'home_abbr': 'LAD',
+                                 'away_wins': 2, 'home_wins': 3, 'complete': False}]}
+
+    # Exactly 15 games — tile expansion may displace some, but no genuine overflow
     games = (
         [_live_game(game_pk=1)]
         + [_base_game(game_pk=100 + i, detailed_state='Final') for i in range(3)]
@@ -1025,8 +1067,8 @@ def test_overflow_ticker_wins_over_playoff_bracket_when_games_dropped():
             bypass_cache=True, config=cfg,
         )
 
-    mock_ticker.assert_called_once()
-    mock_bracket.assert_not_called()
+    mock_ticker.assert_not_called()
+    mock_bracket.assert_called_once()
     assert result is not None
 
 
@@ -1108,30 +1150,27 @@ def test_header_fingerprint_covers_bracket_and_wildcard_modes():
 
 @needs_pil
 def test_header_region_included_when_ticker_activates():
-    """The overflow ticker turning on between polls (dropped-games set going
-    from empty to non-empty) is a header-strip content change that isn't
-    captured by the per-cell grid diffing alone — changed_regions must still
-    include the header strip so it reaches the e-ink panel.
+    """The overflow ticker turning on between polls is a header-strip content
+    change not captured by per-cell grid diffing alone — changed_regions must
+    include the header strip.
 
-    Games 1-13 (Scheduled) and 14 (Final) are byte-identical old vs new, so
-    none of them register in refreshed_game_ids even though 13 and 14 get
-    bumped off the grid into the ticker this poll (wide_cell_featured gives
-    the one new live game, 99, a triple tile). Only game 99 is "changed" —
-    a single small region from grid-cell diffing alone, well under the
-    10-cells collapse threshold — so the header region can only be present
-    because the header-fingerprint check added it.
+    Uses 16 games (> 15, genuine overflow) so the ticker fires.  Games 1-14
+    (Scheduled) and 15 (Final) are byte-identical old vs new.  Only game 99
+    (new live) is changed — a single small region, well under the 10-cells
+    collapse threshold.  The header region can only appear because the
+    header-fingerprint check added it.
     """
     import generate_image
     import image_box
 
     old_games = (
-        [_base_game(game_pk=i, detailed_state='Scheduled') for i in range(1, 14)]
-        + [_base_game(game_pk=14, detailed_state='Final')]
+        [_base_game(game_pk=i, detailed_state='Scheduled') for i in range(1, 15)]
+        + [_base_game(game_pk=15, detailed_state='Final')]
     )
     new_games = (
         [_live_game(game_pk=99)]
-        + [_base_game(game_pk=i, detailed_state='Scheduled') for i in range(1, 14)]
-        + [_base_game(game_pk=14, detailed_state='Final')]
+        + [_base_game(game_pk=i, detailed_state='Scheduled') for i in range(1, 15)]
+        + [_base_game(game_pk=15, detailed_state='Final')]
     )
     cfg = dict(FIXED_CONFIG, wide_cell_featured=True)
 


### PR DESCRIPTION
## Summary

- Overflow ticker now only fires when total games genuinely exceed the 15-slot grid (> 15 games) AND at least one game is still in progress. Once all games finish, the header reverts to wildcard standings automatically.
- After all games go Final, the wildcard standings header is restored without requiring an app restart.
- Tile-expansion drops (≤ 15 total games, one game taking a wide/triple tile) no longer push games into the header ticker — the 15 cells fill first.
- When `show_transactions_ticker` is enabled and the header strip would otherwise be blank, rotating recent transactions are shown there too.
- `draw_featured_game_fullscreen`: static date label replaced with a rotating game-state label (series context → venue → TV channel). The date is hidden since the featured game already occupies the center of the fullscreen layout.
- Runner jersey numbers in base diamonds now use `draw_tight_number` for tighter, properly centered glyphs; foul-pole distance labels get a larger radial offset so they clear the fence line.

## Test plan

- [ ] Tests pass: `poetry run pytest -q`
- [ ] Ruff + mypy clean
- [ ] With > 15 games on a live day, overflow ticker fires and shows dropped games
- [ ] After the last game of the day goes Final, wildcard standings re-appear in the header
- [ ] With ≤ 15 games and a wide/triple tile active, no ticker in header; bracket/wildcard shows instead
- [ ] Fullscreen non-live featured game shows rotating series/venue/TV label in top strip (no date)
- [ ] When `show_transactions_ticker: true` and header is empty, transaction entries appear in the strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8yjcZNoc7FbeEgbFEkg5E