### PR TITLE
Fix triple-cell tiles capped at 1 on 15+ game slates

### DIFF
--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -324,12 +324,14 @@ def _find_tile_types(game_list, config, team_data):
                 remaining -= 1
         return tile_map
 
-    # 15+ games: expanding forces a game off the grid — only do it if the
-    # config explicitly opts in (wide_cell_always or wide_cell_featured).
+    # 15+ games: expanding forces games off the grid — only do it if the
+    # config explicitly opts in (wide_cell_always or wide_cell_featured). Up
+    # to _MAX_TRIPLE_TILES live games still get a triple, same as the <15
+    # path — the packer (_pack_multi_triple_rows) drops lower-priority games
+    # to make room rather than us capping it to a single tile here.
     if not (config.get('wide_cell_always', False) or config.get('wide_cell_featured', False)):
         return {}
-    best = max(in_progress, key=_rank)
-    return {best: 'triple'}
+    return {idx: 'triple' for idx in sorted_live[:_MAX_TRIPLE_TILES]}
 
 
 def _pack_multi_triple_rows(game_list, tile_type_map):


### PR DESCRIPTION
## Summary
- On days with 15+ total games, `_find_tile_types` only ever expanded the single best-ranked live game into a triple (3-cell) tile, instead of up to `_MAX_TRIPLE_TILES` (3) like the <15-game path does.
- Verified with the packer: `_pack_multi_triple_rows` already handles dropping lower-priority games to make room for multiple triples, so the single-triple cap in the 15+ branch was unnecessary.

## Test plan
- [x] `pytest tests/test_image_grid.py tests/test_scoreboard_rules.py tests/test_wide_cell.py` — 473 passed
- [x] Verified against today's real `data/games.json` (16 games, 6 live) — now produces 3 triple tiles instead of 1