### PR TITLE
Show lineup panel 1 hour before first pitch (was 2)

### DIFF
--- a/src/image_box.py
+++ b/src/image_box.py
@@ -736,11 +736,11 @@ def draw_box(Himage, start_x, start_y, game_data, team_data, score_changed=False
     font11 = _get_font(11 * s)   # also used for base-runner numbers
     font9 = _get_font(9 * s)
 
-    # Lineup mode: within 2 hours of first pitch with lineup data posted.
+    # Lineup mode: within 1 hour of first pitch with lineup data posted.
     # Replaces pitcher-probables body and team-records section with batting orders.
     _is_lineup_mode = (
         game_data.get('detailed_state') in ('Scheduled', 'Pre-Game', 'Warmup')
-        and _game_within_minutes_check(game_data, 120)
+        and _game_within_minutes_check(game_data, 60)
         and bool(game_data.get('away_lineup') or game_data.get('home_lineup'))
     )
 

--- a/src/image_grid.py
+++ b/src/image_grid.py
@@ -908,7 +908,7 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
             Himage, _tx_lx, _tx_ly, _tx_data, team_data, use_logos=use_logos,
         )
 
-    # Batting lineup panel — both teams' orders, shown within 30 min of first pitch.
+    # Batting lineup panel — both teams' orders, shown within 1 hour of first pitch.
     if config.get('show_lineup_panel', False) and _free_slots:
         _primary_abbr = config.get('primary', '')
         from image_lineup import _find_primary_game, game_within_minutes
@@ -916,7 +916,7 @@ def draw_out_of_town_score_board(Himage, game_state_data, team_data, date_str=No
         if (
             _lu_game
             and _lu_game.get('detailed_state') in ('Scheduled', 'Pre-Game', 'Warmup')
-            and game_within_minutes(_lu_game, minutes=120)
+            and game_within_minutes(_lu_game, minutes=60)
         ):
             _lu_col, _lu_row = _free_slots.pop(0)
             _lu_lx = _lu_col * 150 + x_start

--- a/src/image_lineup.py
+++ b/src/image_lineup.py
@@ -4,7 +4,7 @@ Shows both teams' batting orders side-by-side (Away left, Home right) with
 the starting pitchers in a strip at the bottom.  The header replicates the
 standard scheduled-game tile style: game time on the left, venue on the right.
 
-Only shown by image_grid when the game is within 2 hours of first pitch.
+Only shown by image_grid when the game is within 1 hour of first pitch.
 """
 from image_assets import _get_font, ImageDraw, _logo_ghost, _paste_logo
 from image_utils import _clean_venue_name, _pitcher_line
@@ -45,7 +45,7 @@ def _find_primary_game(games_data, primary_abbr):
     return None
 
 
-def game_within_minutes(game, minutes=120):
+def game_within_minutes(game, minutes=60):
     """Return True once the game is within `minutes` of its scheduled start.
 
     No lower bound: stays True past the scheduled start time too, so a game


### PR DESCRIPTION
## Summary
- Both lineup-mode gates — `draw_box`'s pre-game body (image_box.py) and the grid's dedicated lineup cell (image_grid.py) — switch from a 2-hour to a 1-hour pre-game window.
- `game_within_minutes`'s default in image_lineup.py updated from 120 to 60 for consistency (no caller relies on the default; all pass `minutes=` explicitly).

## Test plan
- [x] `pytest tests/test_lineup_deadline_panels.py tests/test_image_box_more.py tests/test_scoreboard_rules.py` — 528 passed