### PR TITLE
Hide magic number until 20 or less; align elimination threshold

### DIFF
--- a/src/image_magic.py
+++ b/src/image_magic.py
@@ -29,9 +29,11 @@ _PAD = 2
 # rival can no longer tie it, i.e. when (162 + 1) - wins - rival_losses hits 0.
 _MAGIC_BASE = 163
 
-# Below this, a trailing team's elimination number is dramatic enough to show
-# instead of games back — early/mid-season elimination numbers (60+) aren't
-# meaningful, so games back is the more useful stat until the race tightens.
+# At or below this, a trailing team's elimination number is dramatic enough
+# to show instead of games back — early/mid-season elimination numbers (60+)
+# aren't meaningful, so games back is the more useful stat until the race
+# tightens. Also gates the leader's magic number (see _magic_or_elim): a
+# leader whose magic number is still above this shows nothing at all.
 _ELIM_THRESHOLD = 20
 
 # Collapse a division's full name into a compact header, e.g.
@@ -69,10 +71,12 @@ def _find_primary_division(standings, abbr_map, primary_abbr):
 
 
 def _magic_or_elim(team, leader, is_leader, rival_losses):
-    """Value string for one team's row: 'M4' (leader), 'E7' (trailing team
-    within _ELIM_THRESHOLD of elimination), games back (trailing team
-    otherwise), 'CL', 'OUT', or '' when the underlying win/loss data isn't
-    available yet."""
+    """Value string for one team's row: 'M4' (leader, only while the magic
+    number is _ELIM_THRESHOLD or less — a triple-digit magic number early in
+    the season isn't meaningful, so the leader shows nothing until then),
+    'E7' (trailing team within _ELIM_THRESHOLD of elimination), games back
+    (trailing team otherwise), 'CL', 'OUT', or '' when the underlying
+    win/loss data isn't available yet."""
     clinch = (team.get('clinch_indicator') or '').strip().lower()
     if clinch in ('z', 'y'):
         return 'CL'
@@ -87,7 +91,9 @@ def _magic_or_elim(team, leader, is_leader, rival_losses):
         if rival_losses is None:
             return 'CL'          # no rivals left to hold off
         magic = _MAGIC_BASE - lead_w - rival_losses
-        return 'CL' if magic <= 0 else f'M{magic}'
+        if magic <= 0:
+            return 'CL'
+        return f'M{magic}' if magic <= _ELIM_THRESHOLD else ''
 
     team_l = team.get('league_record_losses')
     if team_l is None:
@@ -95,7 +101,7 @@ def _magic_or_elim(team, leader, is_leader, rival_losses):
     elim = _MAGIC_BASE - lead_w - team_l
     if elim <= 0:
         return 'OUT'
-    if elim < _ELIM_THRESHOLD:
+    if elim <= _ELIM_THRESHOLD:
         return f'E{elim}'
     return str(team.get('games_back') or '-')
 

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -546,16 +546,20 @@ def _aaa_divisions(standings_data, side):
     return [d for d in candidates if d in all_divs]
 
 
-_ME_BADGE_THRESHOLD = 50   # below this, the elimination number is dramatic
-                           # enough to badge instead of games back
+_ME_BADGE_THRESHOLD = 20   # at or below this, a trailing team's elimination
+                           # number is dramatic enough to badge instead of
+                           # games back; also gates the leader's magic number
+                           # (magic still above this shows nothing at all)
 _ME_MAGIC_BASE = 163       # 162 games + 1
 
 
 def _me_badge_value(team, leader, is_leader, rival_losses):
-    """Return badge text for a standings row: 'M5'/'CL' for the leader
-    (always shown), or games back for a trailing team until its elimination
-    number drops below _ME_BADGE_THRESHOLD, at which point 'E12'/'OUT' takes
-    over — mirrors image_magic._magic_or_elim's leader/trailer split."""
+    """Return badge text for a standings row: 'M5'/'CL' for the leader (only
+    once the magic number drops to _ME_BADGE_THRESHOLD or less — otherwise
+    the leader shows nothing), or games back for a trailing team until its
+    elimination number drops to _ME_BADGE_THRESHOLD or less, at which point
+    'E12'/'OUT' takes over — mirrors image_magic._magic_or_elim's
+    leader/trailer split."""
     clinch = (team.get('clinch_indicator') or '').strip().lower()
     if clinch in ('z', 'y'):
         return 'CL'
@@ -570,7 +574,9 @@ def _me_badge_value(team, leader, is_leader, rival_losses):
         if rival_losses is None:
             return 'CL'
         magic = _ME_MAGIC_BASE - lead_w - rival_losses
-        return 'CL' if magic <= 0 else f'M{magic}'
+        if magic <= 0:
+            return 'CL'
+        return f'M{magic}' if magic <= _ME_BADGE_THRESHOLD else ''
     else:
         team_l = team.get('league_record_losses')
         if team_l is None:
@@ -578,7 +584,7 @@ def _me_badge_value(team, leader, is_leader, rival_losses):
         elim = _ME_MAGIC_BASE - lead_w - team_l
         if elim <= 0:
             return 'OUT'
-        if elim < _ME_BADGE_THRESHOLD:
+        if elim <= _ME_BADGE_THRESHOLD:
             return f'E{elim}'
         return str(team.get('games_back') or '-')
 

--- a/tests/test_image_magic.py
+++ b/tests/test_image_magic.py
@@ -129,10 +129,18 @@ class TestMagicOrElim:
                 'clinch_indicator': clinch, 'games_back': games_back}
 
     def test_leader_magic_number(self):
+        leader = self._leader(wins=100)
+        # rival_losses=48 → M = 163-100-48 = 15, within _ELIM_THRESHOLD (20)
+        result = _magic_or_elim(leader, leader, is_leader=True, rival_losses=48)
+        assert result == 'M15'
+
+    def test_leader_magic_number_hidden_when_above_threshold(self):
+        """A magic number above _ELIM_THRESHOLD isn't meaningful yet, so the
+        leader shows nothing instead of a large 'M68'."""
         leader = self._leader(wins=60)
-        # rival_losses=35 → M = 163-60-35 = 68
+        # rival_losses=35 → M = 163-60-35 = 68, well above the threshold
         result = _magic_or_elim(leader, leader, is_leader=True, rival_losses=35)
-        assert result == 'M68'
+        assert result == ''
 
     def test_leader_clinched_when_magic_zero(self):
         # M = 163 - wins - rival_losses; CL when M <= 0

--- a/tests/test_image_standings_more.py
+++ b/tests/test_image_standings_more.py
@@ -1126,15 +1126,15 @@ class TestMeBadgeValue:
         assert _me_badge_value({}, self._leader(wins=100), True, 63) == 'CL'
 
     def test_leader_magic_within_threshold(self):
-        # 163 - 90 - 40 = 33 ≤ 50
-        result = _me_badge_value({}, self._leader(wins=90), True, 40)
-        assert result == 'M33'
+        # 163 - 100 - 48 = 15 ≤ _ME_BADGE_THRESHOLD (20)
+        result = _me_badge_value({}, self._leader(wins=100), True, 48)
+        assert result == 'M15'
 
-    def test_leader_magic_above_threshold_still_shows_magic_number(self):
-        # 163 - 60 - 10 = 93 > threshold — the leader always shows its magic
-        # number, unlike a trailing team's badge.
+    def test_leader_magic_above_threshold_shows_nothing(self):
+        # 163 - 60 - 10 = 93, well above _ME_BADGE_THRESHOLD (20) —
+        # not meaningful yet, so the leader shows nothing.
         result = _me_badge_value({}, self._leader(wins=60), True, 10)
-        assert result == 'M93'
+        assert result == ''
 
     def test_trailer_losses_none_returns_empty(self):
         team = {}  # missing league_record_losses
@@ -1146,12 +1146,12 @@ class TestMeBadgeValue:
         assert _me_badge_value(team, self._leader(wins=100), False, 50) == 'OUT'
 
     def test_trailer_elim_within_threshold(self):
-        # 163 - 90 - 40 = 33 < 50
-        team = {'league_record_losses': 40}
-        assert _me_badge_value(team, self._leader(wins=90), False, 50) == 'E33'
+        # 163 - 100 - 44 = 19 ≤ 20
+        team = {'league_record_losses': 44}
+        assert _me_badge_value(team, self._leader(wins=100), False, 50) == 'E19'
 
     def test_trailer_elim_at_or_above_threshold_shows_games_back(self):
-        # 163 - 60 - 10 = 93 >= 50 → games back, not the elimination number
+        # 163 - 60 - 10 = 93 > 20 → games back, not the elimination number
         team = {'league_record_losses': 10, 'games_back': '15.5'}
         assert _me_badge_value(team, self._leader(wins=60), False, 50) == '15.5'
 


### PR DESCRIPTION
## Summary
- Division leader's magic number (`image_magic.draw_magic_cell` and the standings sidebar's `_me_badge_value`) now only shows once it drops to 20 or less — previously it was always shown, even at triple digits early in the season. Above that threshold, the leader's row shows nothing (rank/logo/record still render).
- Aligned the elimination-number threshold: `image_magic.py` already used 20, changed its comparison to inclusive (`<=`); the standings sidebar previously used a separate threshold of 50 — changed to 20 to match.

## Test plan
- [x] `poetry run pytest -q` — 2064 passed
- [x] `poetry run ruff check` / `poetry run mypy` — clean

https://claude.ai/code/session_019wNSRBb3Hy5BTe88UoLpHe