### PR TITLE
Overflow ticker: compact logo-dash-logo row for not-yet-started games

### DIFF
--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -363,6 +363,14 @@ def draw_overflow_ticker(Himage, dropped_games, team_data, rotation_minutes=2):
         score = _ticker_score(game)
         status = _ticker_status(game)
 
+        def _draw_bold_status(xy, text, bold_font=font):
+            """Bold via the same double-draw-offset-by-1px technique used
+            for the live/final status below (and draw_wildcard_header's
+            prefix) — keeps the not-yet-started start time visually
+            consistent with 'Bot 7' / 'F'."""
+            draw.text(xy, text, font=bold_font, fill=0)
+            draw.text((xy[0] + 1, xy[1]), text, font=bold_font, fill=0)
+
         state = game.get('detailed_state', '')
         not_started = (
             state not in _TICKER_FINAL_STATES
@@ -396,7 +404,7 @@ def draw_overflow_ticker(Himage, dropped_games, team_data, rotation_minutes=2):
             _cx += _h_w
             if status:
                 _cx += 4
-                draw.text((_cx, text_y), status, font=font, fill=0)
+                _draw_bold_status((_cx, text_y), status)
             continue
 
         away_logo = _logo_small(away_abbr, away_id, size=_TICKER_LOGO_SZ)

--- a/src/image_standings.py
+++ b/src/image_standings.py
@@ -363,6 +363,42 @@ def draw_overflow_ticker(Himage, dropped_games, team_data, rotation_minutes=2):
         score = _ticker_score(game)
         status = _ticker_status(game)
 
+        state = game.get('detailed_state', '')
+        not_started = (
+            state not in _TICKER_FINAL_STATES
+            and state not in _TICKER_POSTPONED_STATES
+            and state not in _TICKER_LIVE_STATES
+        )
+        if not_started:
+            # Nothing to score yet — a single row is enough: away logo, a
+            # dash, home logo, then the start time trailing (no stacked
+            # rows/dividers, unlike the live/final layout below).
+            _sched_logo_sz = _WC_STRIP_H - 2
+            _a_logo = _logo_small(away_abbr, away_id, size=_sched_logo_sz)
+            _h_logo = _logo_small(home_abbr, home_id, size=_sched_logo_sz)
+            _a_w = _a_logo.size[0] if _a_logo else int(font.getlength(away_abbr))
+            _h_w = _h_logo.size[0] if _h_logo else int(font.getlength(home_abbr))
+            _dash_w = int(font.getlength(' - '))
+            _time_w = int(font.getlength(status)) if status else 0
+            _total_w = _a_w + _dash_w + _h_w + (4 + _time_w if status else 0)
+            _cx = x0 + max(0, (entry_w - _total_w) // 2)
+            if _a_logo:
+                Himage.paste(_a_logo, (_cx, (_WC_STRIP_H - _a_logo.size[1]) // 2))
+            else:
+                draw.text((_cx, text_y), away_abbr, font=font, fill=0)
+            _cx += _a_w
+            draw.text((_cx, text_y), ' - ', font=font, fill=0)
+            _cx += _dash_w
+            if _h_logo:
+                Himage.paste(_h_logo, (_cx, (_WC_STRIP_H - _h_logo.size[1]) // 2))
+            else:
+                draw.text((_cx, text_y), home_abbr, font=font, fill=0)
+            _cx += _h_w
+            if status:
+                _cx += 4
+                draw.text((_cx, text_y), status, font=font, fill=0)
+            continue
+
         away_logo = _logo_small(away_abbr, away_id, size=_TICKER_LOGO_SZ)
         home_logo = _logo_small(home_abbr, home_id, size=_TICKER_LOGO_SZ)
 

--- a/tests/test_image_standings_more.py
+++ b/tests/test_image_standings_more.py
@@ -851,12 +851,14 @@ class TestDrawOverflowTicker:
         """No top/bottom strip border and no vertical separator between
         entries — only the horizontal away/home divider (always drawn) and
         the in-entry R/H/E column dividers (added when a game has a score)
-        may appear."""
+        may appear. Uses live (not Scheduled) games since not-yet-started
+        games use the single-row logo-dash-logo layout, which draws no
+        divider at all."""
         canvas = self._white()
         team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS', '3': 'LAD', '4': 'SF'}}
         games = [
-            _ov_game(1, away_id=1, home_id=2, state='Scheduled'),
-            _ov_game(2, away_id=3, home_id=4, state='Scheduled'),
+            _ov_game(1, away_id=1, home_id=2, state='In Progress'),
+            _ov_game(2, away_id=3, home_id=4, state='In Progress'),
         ]
         with patch('image_standings._logo_small', return_value=None), \
              patch('image_standings.ImageDraw.ImageDraw.line') as mock_line:
@@ -917,6 +919,37 @@ class TestDrawOverflowTicker:
             result = draw_overflow_ticker(canvas, games, team_data)
         assert isinstance(result, Image.Image)
         assert any(px == 0 for px in result.getdata())
+
+    def test_not_started_game_renders_single_row_logo_dash_logo_time(self):
+        """A game that hasn't started yet (Scheduled/Pre-Game/Warmup/Delayed
+        Start) skips the stacked two-row live/final layout entirely — no R,
+        H, E, or divider line — and instead draws one row: away logo, a
+        dash, home logo, then the start time."""
+        canvas = self._white()
+        team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS'}}
+        games = [_ov_game(1, away_id=1, home_id=2, state='Scheduled', game_start='7:05 PM')]
+        with patch('image_standings._logo_small', return_value=None), \
+             patch('image_standings.ImageDraw.ImageDraw.line') as mock_line, \
+             patch('image_standings.ImageDraw.ImageDraw.text') as mock_text:
+            draw_overflow_ticker(canvas, games, team_data)
+        mock_line.assert_not_called()
+        drawn_strings = [call.args[1] for call in mock_text.call_args_list]
+        assert 'NYY' in drawn_strings
+        assert 'BOS' in drawn_strings
+        assert ' - ' in drawn_strings
+        assert '7:05 PM' in drawn_strings
+
+    def test_not_started_game_pastes_logos_when_available(self):
+        """Pre-Game/Warmup/Delayed Start all share the not-yet-started single
+        row layout, not just Scheduled."""
+        team_data = {'team_abbreviation': {'1': 'NYY', '2': 'BOS'}}
+        fake_logo = Image.new('1', (28, 28), 0)
+        for state in ('Scheduled', 'Pre-Game', 'Warmup', 'Delayed Start'):
+            games = [_ov_game(1, away_id=1, home_id=2, state=state)]
+            with patch('image_standings._logo_small', return_value=fake_logo):
+                result = draw_overflow_ticker(self._white(), games, team_data)
+            assert isinstance(result, Image.Image)
+            assert any(px == 0 for px in result.getdata())
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Scheduled/Pre-Game/Warmup/Delayed Start games in the overflow ticker now render a single compact row (away logo, dash, home logo, start time) instead of the two-row stacked live/final layout, since there's no score/hits/errors to show yet.
- Live and Final games are unchanged.

## Test plan
- [x] `poetry run pytest tests/test_image_standings_more.py -k Ticker`
- [x] `poetry run ruff check` / `poetry run mypy`
- [x] Rendered a sample ticker locally to confirm the visual layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wNSRBb3Hy5BTe88UoLpHe